### PR TITLE
Remove package specifier from codegen Cargo.toml

### DIFF
--- a/core/src/generator/build.rs
+++ b/core/src/generator/build.rs
@@ -360,7 +360,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rindexer = {{ git = "https://github.com/joshstevens19/rindexer", branch = "master", package = "core" }}
+rindexer = {{ git = "https://github.com/joshstevens19/rindexer", branch = "master" }}
 tokio = {{ version = "1", features = ["full"] }}
 ethers = {{ version = "2.0", features = ["rustls", "openssl"] }}
 serde = {{ version = "1.0.194", features = ["derive"] }}

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -9,6 +9,8 @@
 ### Bug fixes
 -------------------------------------------------
 
+fix: Remove package specifier from codegen Cargo.toml
+
 ### Breaking changes
 -------------------------------------------------
 


### PR DESCRIPTION
## tl;dr

I was running into issues trying to use the codegen'd package:

```
error: no matching package named `core` found
```

This is because the Cargo.toml inside the `core` folder actually has the name field set to `rindexer`. Cargo cares about the name, not the folder, so it can't import.  