### PR TITLE
fixes: fetching implementation ABI for proxy contracts | rate limits …

### DIFF
--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -8,7 +8,8 @@
 
 ### Bug fixes
 -------------------------------------------------
-
+- fix: fixing the query of implemntation ABI for proxy contracts
+- fix: add request timeouts to adapt to different verifier's rate limits
 ### Breaking changes
 -------------------------------------------------
 


### PR DESCRIPTION
Two fixes added related to adding a contract:

### Proxy contract ABI fix
handle_add_contract_command in rindexer/cli/src/commands/add.rs was not fetching the implementation ABI correctly -> it would repeatedly fetch the contract's ABI and not the implementation's once it knew it was a proxy.

As an example here's the error that you get when adding the Aave V3 Pool contract on Ethereum (0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2)  
printing metadata generated in rindexer/cli/src/commands/add.rs:85 see the below gist: 
https://gist.github.com/kakagri/419806f17d2f4634eebaec3d7ca95291

### Verifier rate limits fix
Second is adding some timeouts when querying the ABI, this is necessary because trying to verify a proxy contract even with the above fix will yield some errors related to rate limits on the verifier's end.
As an example basescan and arbiscan have different rate limits and can lead to rate limit exceed error, see below when adding Aave V3 Pool on base and arbitrum.
<img width="650" alt="Capture d’écran 2024-07-20 à 16 48 16" src="https://github.com/user-attachments/assets/dccb697c-4a55-4b57-a9bb-e57a5c1f30d8">




