### PR TITLE
feat: create a minimal docker image and github workflow for building it when pushed to master branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+Dockerfile
+.env

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+name: Build & publish docker image
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=sha,format=long
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,9 @@
 name: Build & publish docker image
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - master
 
@@ -11,7 +13,7 @@ env:
 
 jobs:
   build:
-    if: startsWith(github.event.ref, 'refs/heads/release/')
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build:
+    if: startsWith(github.event.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 RUN cargo build --release --target x86_64-unknown-linux-musl
 RUN strip /app/target/x86_64-unknown-linux-musl/release/rindexer_cli
 
-FROM scratch
+FROM --platform=linux/amd64 scratch
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/rindexer_cli /app/rindexer
 
 ENTRYPOINT ["/app/rindexer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM --platform=linux/amd64 clux/muslrust:stable as builder
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-RUN mkdir /app
 WORKDIR /app
 COPY . .
 RUN rustup target add x86_64-unknown-linux-musl
 RUN cargo build --release --target x86_64-unknown-linux-musl
 RUN strip /app/target/x86_64-unknown-linux-musl/release/rindexer_cli
 
-FROM --platform=linux/amd64 node:16 as node-builder
-RUN mkdir /app
+FROM --platform=linux/amd64 node:lts as node-builder
 WORKDIR /app
 COPY . .
 RUN cd /app/graphql && npm i && npm run build-linuxstatic

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
-FROM --platform=linux/amd64 clux/muslrust:stable as builder
+FROM --platform=linux/amd64 rust:1.79-slim-bookworm as builder
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+RUN apt update && apt install -y libssl-dev binutils libc-dev libstdc++6 pkg-config
+
 WORKDIR /app
 COPY . .
-RUN rustup target add x86_64-unknown-linux-musl
-RUN cargo build --release --target x86_64-unknown-linux-musl
-RUN strip /app/target/x86_64-unknown-linux-musl/release/rindexer_cli
+RUN cargo build --release
+RUN strip /app/target/release/rindexer_cli
 
-FROM --platform=linux/amd64 node:lts as node-builder
+FROM --platform=linux/amd64 node:lts-bookworm as node-builder
+RUN apt update && apt install -y ca-certificates
 WORKDIR /app
 COPY . .
-RUN cd /app/graphql && npm i && npm run build-linuxstatic
+RUN cd /app/graphql && npm i && npm run build-linux
 
-FROM --platform=linux/amd64 alpine
-COPY --from=node-builder /app/core/resources/rindexer-graphql-linuxstatic /app/resources/rindexer-graphql-linux
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/rindexer_cli /app/rindexer
+FROM --platform=linux/amd64 debian:bookworm-slim
+RUN apt update \
+  && apt install -y libssl-dev libc-dev libstdc++6 ca-certificates lsof \
+  && apt-get autoremove --yes \
+  && apt-get clean --yes \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=node-builder /app/core/resources/rindexer-graphql-linux /app/resources/rindexer-graphql-linux
+COPY --from=builder /app/target/release/rindexer_cli /app/rindexer
 
 ENTRYPOINT ["/app/rindexer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:stable as builder
+FROM --platform=linux/amd64 clux/muslrust:stable as builder
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 RUN mkdir /app
 WORKDIR /app
@@ -7,7 +7,14 @@ RUN rustup target add x86_64-unknown-linux-musl
 RUN cargo build --release --target x86_64-unknown-linux-musl
 RUN strip /app/target/x86_64-unknown-linux-musl/release/rindexer_cli
 
-FROM --platform=linux/amd64 scratch
+FROM --platform=linux/amd64 node:16 as node-builder
+RUN mkdir /app
+WORKDIR /app
+COPY . .
+RUN cd /app/graphql && npm i && npm run build-linuxstatic
+
+FROM --platform=linux/amd64 alpine
+COPY --from=node-builder /app/core/resources/rindexer-graphql-linuxstatic /app/resources/rindexer-graphql-linux
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/rindexer_cli /app/rindexer
 
 ENTRYPOINT ["/app/rindexer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM clux/muslrust:stable as builder
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+RUN mkdir /app
+WORKDIR /app
+COPY . .
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN strip /app/target/x86_64-unknown-linux-musl/release/rindexer_cli
+
+FROM scratch
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/rindexer_cli /app/rindexer
+
+ENTRYPOINT ["/app/rindexer"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ There's a pre-built docker image which can be used to run `rindexer` inside your
 
 [`ghcr.io/joshstevens19/rindexer`](https://github.com/users/joshstevens19/packages/container/package/rindexer)
 
+### Create new project
+To create a new `no-code` project in your current directory, you can run the following:
+
+`docker run -it -v $PWD:/app/project_path ghcr.io/joshstevens19/rindexer new -p /app/project_path no-code`
+
+### Use with existing project
 To use it with an existing project and a running postgres instance you can simply invoke:
 
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ rindexer and all the commands available to you.
 
 There's a pre-built docker image which can be used to run `rindexer` inside your dockerized infra:
 
-`ghcr.io/joshstevens19/rindexer`
+[`ghcr.io/joshstevens19/rindexer`](https://github.com/users/joshstevens19/packages/container/package/rindexer)
 
 To use it with an existing project and a running postgres instance you can simply invoke:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ Options:
 We have full documentation https://rindexer.xyz/docs/introduction/installation which goes into more detail on how to use 
 rindexer and all the commands available to you.
 
+## Docker
+
+There's a pre-built docker image which can be used to run `rindexer` inside your dockerized infra:
+
+`ghcr.io/joshstevens19/rindexer`
+
+To use it with an existing project and a running postgres instance you can simply invoke:
+
+```
+export PROJECT_PATH=/path/to/your/project
+export DATABASE_URL="postgresql://user:pass@postgres/db"
+
+docker-compose up -d
+```
+
+This will start all local indexing and if you have enabled the graphql endpoint, it will become exposed under:
+
+http://localhost:3001
+
+
 ## What can I use rindexer for?
 
 - Hackathons: spin up a quick indexer to index events for your dApp with an API without any code needed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-volumes:
-  postgres_data: {}
-
 networks:
   default:
     name: rindexer_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+volumes:
+  postgres_data: {}
+
+networks:
+  default:
+    name: rindexer_default
+
+services:
+  rindexer:
+    image: ghcr.io/joshstevens19/rindexer
+    platform: linux/amd64
+    command: |
+      start -p /app/project_path all
+    environment:
+      - PROJECT_PATH
+      - DATABASE_URL
+    volumes:
+      - ${PROJECT_PATH}:/app/project_path
+    ports:
+      - 3001:3001
+    restart: always

--- a/documentation/docs/pages/docs/introduction/installation.mdx
+++ b/documentation/docs/pages/docs/introduction/installation.mdx
@@ -64,7 +64,25 @@ rindexerdown
 rindexer uses docker to spin up postgres databases for you when it runs locally so its recommended to install [docker](https://www.docker.com/products/docker-desktop/)
 if you don't have it installed already.
 
-**If you are using csv you do not need to install docker, it is only recommended with postgres.**
+There's a pre-built docker image which can be used to run `rindexer` inside your dockerized infra:
+
+[`ghcr.io/joshstevens19/rindexer`](https://github.com/users/joshstevens19/packages/container/package/rindexer)
+
+To use it with an existing project and a running postgres instance you can simply invoke:
+
+```
+export PROJECT_PATH=/path/to/your/project
+export DATABASE_URL="postgresql://user:pass@postgres/db"
+
+docker-compose up -d
+```
+
+This will start all local indexing and if you have enabled the graphql endpoint, it will become exposed under:
+
+http://localhost:3001
+
+
+**If you are using csv you do not need to install docker, it is only recommended with postgres or if you're deploying rindexer in cloud environments.**
 
 ## Rust - optional
 

--- a/documentation/docs/pages/docs/introduction/installation.mdx
+++ b/documentation/docs/pages/docs/introduction/installation.mdx
@@ -68,6 +68,12 @@ There's a pre-built docker image which can be used to run `rindexer` inside your
 
 [`ghcr.io/joshstevens19/rindexer`](https://github.com/users/joshstevens19/packages/container/package/rindexer)
 
+### Create new project
+To create a new `no-code` project in your current directory, you can run the following:
+
+`docker run -it -v $PWD:/app/project_path ghcr.io/joshstevens19/rindexer new -p /app/project_path no-code`
+
+### Use with existing project
 To use it with an existing project and a running postgres instance you can simply invoke:
 
 ```

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "pkg index.js --output ../core/resources/rindexer-graphql --targets node16-linux-x64,node16-macos-x64,node16-win-x64"
+    "build": "pkg index.js --output ../core/resources/rindexer-graphql --targets node16-linux-x64,node16-macos-x64,node16-win-x64",
+    "build-linuxstatic": "pkg index.js --output ../core/resources/rindexer-graphql-linuxstatic --targets node16-linuxstatic-x64"
   },
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "pkg index.js --output ../core/resources/rindexer-graphql --targets node16-linux-x64,node16-macos-x64,node16-win-x64",
-    "build-linuxstatic": "pkg index.js --output ../core/resources/rindexer-graphql-linuxstatic --targets node16-linuxstatic-x64"
+    "build-linux": "pkg --debug index.js --output ../core/resources/rindexer-graphql-linux --targets node18-linux-x64"
   },
   "dependencies": {
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",

--- a/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/erc_20_filter_abi_gen.rs
+++ b/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/erc_20_filter_abi_gen.rs
@@ -12,7 +12,7 @@ pub use rindexer_erc20_filter_gen::*;
 pub mod rindexer_erc20_filter_gen {
     const _: () = {
         ::core::include_bytes!(
-            "/Users/joshstevens/code/rindexer/rindexer_rust_playground/abis/erc20-abi.json",
+            "../../../../../abis/erc20-abi.json",
         );
     };
     #[allow(deprecated)]

--- a/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/rocket_pool_eth_abi_gen.rs
+++ b/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/rocket_pool_eth_abi_gen.rs
@@ -12,7 +12,7 @@ pub use rindexer_rocket_pool_eth_gen::*;
 pub mod rindexer_rocket_pool_eth_gen {
     const _: () = {
         ::core::include_bytes!(
-            "/Users/joshstevens/code/rindexer/rindexer_rust_playground/abis/erc20-abi.json",
+            "../../../../../abis/erc20-abi.json",
         );
     };
     #[allow(deprecated)]

--- a/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/world_abi_gen.rs
+++ b/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/world_abi_gen.rs
@@ -12,7 +12,7 @@ pub use rindexer_world_gen::*;
 pub mod rindexer_world_gen {
     const _: () = {
         ::core::include_bytes!(
-            "/Users/joshstevens/code/rindexer/rindexer_rust_playground/abis/world.abi.json",
+            "../../../../../abis/world.abi.json",
         );
     };
     #[allow(deprecated)]


### PR DESCRIPTION
# What I did

- Created a docker image which contains `rindexer` and the graphql server binary with docker
- Github workflow that builds and tags it on ghcr.io when a branch starting with `release/` is merged/pushed to `master`