### PR TITLE
Option error in railway link command

### DIFF
--- a/documentation/docs/pages/docs/deploying/railway.mdx
+++ b/documentation/docs/pages/docs/deploying/railway.mdx
@@ -32,7 +32,13 @@ https://github.com/joshstevens19/rindexer/tree/master/providers/railway
   
   ```bash
   railway up --detach
-  railway link --name rindexer-example --enviroment production
+  railway link
+  ? Select a project
+  > rindexer-example
+  ? Select an environment  
+  > production
+  ? Select a service
+  > rindexer-example
   ```
 
 4. Create a Postgres database


### PR DESCRIPTION
The following commands with options will result in an error.

```bash
railway link --name rindexer-example --enviroment production

error: unexpected argument '--name' found

Usage: railway link [OPTIONS]

For more information, try '--help'.
```

Only railway link can be successfully executed.

```bash
railway link
```