### PR TITLE
Fix: add prefix when generating abi name properties

### DIFF
--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -87,10 +87,14 @@ impl ABIInput {
             .iter()
             .flat_map(|input| {
                 if let Some(components) = &input.components {
+                    let new_prefix = match prefix {
+                        Some(p) => format!("{}_{}", p, camel_to_snake(&input.name)),
+                        None => camel_to_snake(&input.name),
+                    };
                     ABIInput::generate_abi_name_properties(
                         components,
                         properties_type,
-                        Some(&camel_to_snake(&input.name)),
+                        Some(&new_prefix),
                     )
                 } else {
                     match properties_type {

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 -------------------------------------------------
+fix: Use the prefix when generating abi name properties.
 
 ### Breaking changes
 -------------------------------------------------


### PR DESCRIPTION
<img width="1470" alt="Capture d’écran 2024-08-23 à 00 02 35" src="https://github.com/user-attachments/assets/bc17a328-0820-4bbb-8751-4849cc1cd1c0">

The prefix when calling generate_abi_name_properties was not taken into account which leads to errors in table creations for some contracts, e.g. [https://arbiscan.io/address/0xb21b06d71c75973babde35b49ffdac3f82ad3775](Compound V3 Configurator) SetConfiguration event
