### PR TITLE
Relative paths instead of absolute

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -63,10 +63,7 @@ fn resolve_path(override_path: &Option<String>) -> Result<PathBuf, String> {
             let path = PathBuf::from_str(path).map_err(|_| "Invalid path provided.".to_string())?;
             Ok(path)
         }
-        None => {
-            Ok(std::env::current_dir()
-                .map_err(|_| "Failed to get current directory.".to_string())?)
-        }
+        None => Ok(PathBuf::from(".")),
     }
 }
 

--- a/core/src/generator/build.rs
+++ b/core/src/generator/build.rs
@@ -346,7 +346,7 @@ pub enum GenerateRustProjectError {
 
 pub fn generate_rust_project(project_path: &Path) -> Result<(), GenerateRustProjectError> {
     let manifest_location = project_path.join(YAML_CONFIG_NAME);
-    let manifest = read_manifest(&project_path.join(&manifest_location))?;
+    let manifest = read_manifest(&manifest_location)?;
 
     let abi_path = project_path.join("abis");
 


### PR DESCRIPTION
Replaced the absolute path obtained from `std::env::current_dir()` with the relative path `.`. 

Partially fixes an issue where the generated typings file for events contained the absolute path (#94).

Includes #97.