### PR TITLE
Cross-platform support (adding windows)

### DIFF
--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -345,7 +345,7 @@ impl EventInfo {
         csv_path: &str,
     ) -> Result<String, CreateCsvFileForEvent> {
         let csv_file_name = format!("{}-{}.csv", contract.name, self.name).to_lowercase();
-        let csv_folder = project_path.join(format!("{}/{}", csv_path, contract.name));
+        let csv_folder = project_path.join(csv_path).join(&contract.name);
 
         // Create directory if it does not exist.
         if let Err(e) = fs::create_dir_all(&csv_folder) {
@@ -357,7 +357,7 @@ impl EventInfo {
             return Err(CreateCsvFileForEvent::CreateDirFailed(e));
         }
 
-        Ok(format!("{}/{}", csv_folder.display(), csv_file_name))
+        Ok(csv_folder.join(csv_file_name).display().to_string())
     }
 }
 

--- a/core/src/generator/events_bindings.rs
+++ b/core/src/generator/events_bindings.rs
@@ -181,7 +181,7 @@ fn generate_csv_instance(
 
     if !contract.generate_csv.unwrap_or(true) {
         return Ok(Code::new(format!(
-            r#"let csv = AsyncCsvAppender::new("{csv_path}");"#,
+            r#"let csv = AsyncCsvAppender::new(r"{csv_path}");"#,
             csv_path = csv_path,
         )));
     }
@@ -192,8 +192,8 @@ fn generate_csv_instance(
 
     Ok(Code::new(format!(
         r#"
-        let csv = AsyncCsvAppender::new("{csv_path}");
-        if !Path::new("{csv_path}").exists() {{
+        let csv = AsyncCsvAppender::new(r"{csv_path}");
+        if !Path::new(r"{csv_path}").exists() {{
             csv.append_header(vec![{headers}.into()])
                 .await
                 .expect("Failed to write CSV header");

--- a/core/src/generator/events_bindings.rs
+++ b/core/src/generator/events_bindings.rs
@@ -177,7 +177,9 @@ fn generate_csv_instance(
     event_info: &EventInfo,
     csv: &Option<CsvDetails>,
 ) -> Result<Code, CreateCsvFileForEvent> {
-    let mut csv_path = csv.as_ref().map_or(PathBuf::from("generated_csv"), |c| PathBuf::from((&c.path).strip_prefix("./").unwrap()));
+    let mut csv_path = csv.as_ref().map_or(PathBuf::from("generated_csv"), |c| {
+        PathBuf::from((&c.path).strip_prefix("./").unwrap())
+    });
 
     csv_path = project_path.join(csv_path);
 

--- a/core/src/generator/events_bindings.rs
+++ b/core/src/generator/events_bindings.rs
@@ -193,6 +193,8 @@ fn generate_csv_instance(
     let headers: Vec<String> =
         event_info.csv_headers_for_event().iter().map(|h| format!("\"{}\"", h)).collect();
 
+    let headers_with_into: Vec<String> = headers.iter().map(|h| format!("{}.into()", h)).collect();
+
     Ok(Code::new(format!(
         r#"
         let csv = AsyncCsvAppender::new(r"{}");
@@ -204,7 +206,7 @@ fn generate_csv_instance(
     "#,
         csv_path,
         csv_path,
-        headers.join(".into(), ")
+        headers_with_into.join(", ")
     )))
 }
 

--- a/core/src/indexer/last_synced.rs
+++ b/core/src/indexer/last_synced.rs
@@ -55,17 +55,14 @@ fn build_last_synced_block_number_file(
     network: &str,
     event_name: &str,
 ) -> String {
-    let path = full_path
-    .join(contract_name)
-    .join("last-synced-blocks")
-    .join(format!(
+    let path = full_path.join(contract_name).join("last-synced-blocks").join(format!(
         "{}-{}-{}.txt",
         contract_name.to_lowercase(),
         network.to_lowercase(),
         event_name.to_lowercase()
     ));
 
-path.to_string_lossy().into_owned()
+    path.to_string_lossy().into_owned()
 }
 
 pub struct SyncConfig<'a> {

--- a/core/src/indexer/last_synced.rs
+++ b/core/src/indexer/last_synced.rs
@@ -55,14 +55,26 @@ fn build_last_synced_block_number_file(
     network: &str,
     event_name: &str,
 ) -> String {
-    format!(
+    #[cfg(unix)]
+    return format!(
         "{}/{}/last-synced-blocks/{}-{}-{}.txt",
         full_path.display(),
         contract_name,
         contract_name.to_lowercase(),
         network.to_lowercase(),
         event_name.to_lowercase()
-    )
+    );
+
+    #[cfg(windows)]
+    return format!(
+        "{}\\{}\\last-synced-blocks\\{}-{}-{}.txt",
+        full_path.display(),
+        contract_name,
+        contract_name.to_lowercase(),
+        network.to_lowercase(),
+        event_name.to_lowercase()
+    );
+
 }
 
 pub struct SyncConfig<'a> {

--- a/core/src/indexer/last_synced.rs
+++ b/core/src/indexer/last_synced.rs
@@ -55,26 +55,17 @@ fn build_last_synced_block_number_file(
     network: &str,
     event_name: &str,
 ) -> String {
-    #[cfg(unix)]
-    return format!(
-        "{}/{}/last-synced-blocks/{}-{}-{}.txt",
-        full_path.display(),
-        contract_name,
+    let path = full_path
+    .join(contract_name)
+    .join("last-synced-blocks")
+    .join(format!(
+        "{}-{}-{}.txt",
         contract_name.to_lowercase(),
         network.to_lowercase(),
         event_name.to_lowercase()
-    );
+    ));
 
-    #[cfg(windows)]
-    return format!(
-        "{}\\{}\\last-synced-blocks\\{}-{}-{}.txt",
-        full_path.display(),
-        contract_name,
-        contract_name.to_lowercase(),
-        network.to_lowercase(),
-        event_name.to_lowercase()
-    );
-
+path.to_string_lossy().into_owned()
 }
 
 pub struct SyncConfig<'a> {

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -1,4 +1,4 @@
-use std::{io, path::Path, sync::Arc};
+use std::{io, path::Path, path::PathBuf, sync::Arc};
 
 use colored::Colorize;
 use ethers::abi::{Abi, Contract as EthersContract, Event};
@@ -499,11 +499,12 @@ pub async fn process_events(
 
             let mut csv: Option<Arc<AsyncCsvAppender>> = None;
             if contract.generate_csv.unwrap_or(true) && manifest.storage.csv_enabled() {
-                let csv_path = manifest.storage.csv.as_ref().map_or("./generated_csv", |c| &c.path);
-                let headers: Vec<String> = event_info.csv_headers_for_event();
+                let csv_path = manifest.storage.csv.as_ref().map_or(PathBuf::from("generated_csv"), |c| PathBuf::from((&c.path).strip_prefix("./").unwrap()));
 
+                let headers: Vec<String> = event_info.csv_headers_for_event();
+                let csv_path_str = csv_path.to_str().expect("Failed to convert csv path to string");
                 let csv_path =
-                    event_info.create_csv_file_for_event(project_path, contract, csv_path)?;
+                    event_info.create_csv_file_for_event(project_path, contract, csv_path_str)?;
                 let csv_appender = AsyncCsvAppender::new(&csv_path);
                 if !Path::new(&csv_path).exists() {
                     csv_appender.append_header(headers).await?;

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -1,4 +1,8 @@
-use std::{io, path::Path, path::PathBuf, sync::Arc};
+use std::{
+    io,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use colored::Colorize;
 use ethers::abi::{Abi, Contract as EthersContract, Event};
@@ -499,7 +503,10 @@ pub async fn process_events(
 
             let mut csv: Option<Arc<AsyncCsvAppender>> = None;
             if contract.generate_csv.unwrap_or(true) && manifest.storage.csv_enabled() {
-                let csv_path = manifest.storage.csv.as_ref().map_or(PathBuf::from("generated_csv"), |c| PathBuf::from((&c.path).strip_prefix("./").unwrap()));
+                let csv_path =
+                    manifest.storage.csv.as_ref().map_or(PathBuf::from("generated_csv"), |c| {
+                        PathBuf::from((&c.path).strip_prefix("./").unwrap())
+                    });
 
                 let headers: Vec<String> = event_info.csv_headers_for_event();
                 let csv_path_str = csv_path.to_str().expect("Failed to convert csv path to string");

--- a/core/src/manifest/stream.rs
+++ b/core/src/manifest/stream.rs
@@ -181,11 +181,9 @@ impl StreamsConfig {
         let base_path = Path::new(&streams_last_synced_block_path);
         let path = base_path.join(contract_name).join("last-synced-blocks");
         let full_path = project_path.join(path);
-    
+
         if !full_path.exists() {
-            fs::create_dir_all(&full_path)
-                .await
-                .expect("Failed to create directory for stream");
+            fs::create_dir_all(&full_path).await.expect("Failed to create directory for stream");
         }
     }
 }

--- a/core/src/manifest/stream.rs
+++ b/core/src/manifest/stream.rs
@@ -177,16 +177,15 @@ impl StreamsConfig {
         project_path: &Path,
         contract_name: &str,
     ) {
-        #[cfg(unix)]
-        let path =
-            self.get_streams_last_synced_block_path() + "/" + contract_name + "/last-synced-blocks";
-        #[cfg(windows)]
-        let path =
-            self.get_streams_last_synced_block_path() + "\\" + contract_name + "\\last-synced-blocks";
+        let streams_last_synced_block_path = self.get_streams_last_synced_block_path();
+        let base_path = Path::new(&streams_last_synced_block_path);
+        let path = base_path.join(contract_name).join("last-synced-blocks");
         let full_path = project_path.join(path);
-
-        if !Path::new(&full_path).exists() {
-            fs::create_dir_all(&full_path).await.expect("Failed to create directory for stream");
+    
+        if !full_path.exists() {
+            fs::create_dir_all(&full_path)
+                .await
+                .expect("Failed to create directory for stream");
         }
     }
 }

--- a/core/src/manifest/stream.rs
+++ b/core/src/manifest/stream.rs
@@ -177,9 +177,12 @@ impl StreamsConfig {
         project_path: &Path,
         contract_name: &str,
     ) {
+        #[cfg(unix)]
         let path =
             self.get_streams_last_synced_block_path() + "/" + contract_name + "/last-synced-blocks";
-
+        #[cfg(windows)]
+        let path =
+            self.get_streams_last_synced_block_path() + "\\" + contract_name + "\\last-synced-blocks";
         let full_path = project_path.join(path);
 
         if !Path::new(&full_path).exists() {

--- a/core/src/start.rs
+++ b/core/src/start.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
+use tokio::signal;
 use tracing::{error, info};
 
 use crate::{
@@ -233,7 +234,7 @@ pub async fn start_rindexer(details: StartDetails<'_>) -> Result<(), StartRindex
             shutdown_handle.await.map_err(|e| {
                 error!("Shutdown handler failed: {:?}", e);
                 StartRindexerError::ShutdownHandlerFailed(e.to_string())
-            })??;
+            })?;
 
             Ok(())
         }


### PR DESCRIPTION
As stated on issue #120, rindexer has dependencies on unix::signals, here I add the option to use control c if you are in windows making the tool cross-platform. There is also some Path normalization to do to make it work :)
