### PR TITLE
feat: Redis Streams

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -52,3 +52,5 @@ codegen_indexer_lens:
 	RUSTFLAGS='-C target-cpu=native' cargo run --release --features jemalloc -- codegen --path $(CURDIR)/../../lens-backend/crates/indexer indexer
 start_uniswap_base:
 	RUSTFLAGS='-C target-cpu=native' cargo run --release --features jemalloc -- start --path $(CURDIR)/../examples/uniswap_v3_base indexer
+start_indexer_redis_stream:
+    RUSTFLAGS='-C target-cpu=native' cargo run --release --features jemalloc -- start --path $(CURDIR)/../examples/redis-stream

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -53,4 +53,4 @@ codegen_indexer_lens:
 start_uniswap_base:
 	RUSTFLAGS='-C target-cpu=native' cargo run --release --features jemalloc -- start --path $(CURDIR)/../examples/uniswap_v3_base indexer
 start_indexer_redis_stream:
-    RUSTFLAGS='-C target-cpu=native' cargo run --release --features jemalloc -- start --path $(CURDIR)/../examples/redis-stream
+    RUSTFLAGS='-C target-cpu=native' cargo run --release --features jemalloc -- start --path $(CURDIR)/../examples/redis-stream indexer

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,6 +58,7 @@ deadpool-lapin = "0.12"
 teloxide = "0.12"
 serenity = { version = "0.12", features = ["client", "framework"] }
 once_cell = "1.19.0"
+redis = { version = "0.27.6", features = ["tokio-comp", "aio"] }
 
 # build
 jemallocator = { version = "0.5.0", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,7 +58,8 @@ deadpool-lapin = "0.12"
 teloxide = "0.12"
 serenity = { version = "0.12", features = ["client", "framework"] }
 once_cell = "1.19.0"
-redis = { version = "0.27.6", features = ["tokio-comp", "aio"] }
+redis = { version = "0.27.6", features = ["streams"] }
+bb8-redis = "0.18.0"
 
 # build
 jemallocator = { version = "0.5.0", optional = true }

--- a/core/src/manifest/stream.rs
+++ b/core/src/manifest/stream.rs
@@ -40,7 +40,13 @@ pub struct WebhookStreamConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RedisStreamConfig {
     pub connection_uri: String,
+    #[serde(default = "default_pool_size")]
+    pub max_pool_size: u32,
     pub streams: Vec<RedisStreamStreamConfig>
+}
+
+fn default_pool_size() -> u32 {
+    50
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/core/src/manifest/stream.rs
+++ b/core/src/manifest/stream.rs
@@ -37,6 +37,19 @@ pub struct WebhookStreamConfig {
     pub events: Vec<StreamEvent>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RedisStreamConfig {
+    pub connection_uri: String,
+    pub streams: Vec<RedisStreamStreamConfig>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RedisStreamStreamConfig {
+    pub stream_name: String,
+    pub networks: Vec<String>,
+    pub events: Vec<StreamEvent>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ExchangeKindWrapper(pub ExchangeKind);
 
@@ -146,6 +159,9 @@ pub struct StreamsConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kafka: Option<KafkaStreamConfig>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redis: Option<RedisStreamConfig>
 }
 
 impl StreamsConfig {
@@ -167,6 +183,8 @@ impl StreamsConfig {
             path.push_str("webhooks_");
         } else if self.kafka.is_some() {
             path.push_str("kafka_");
+        } else if self.redis.is_some() {
+            path.push_str("redis_");
         }
 
         path.trim_end_matches('_').to_string()

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -126,7 +126,9 @@ impl StreamsClients {
             Some(RedisStream {
                 config: config.clone(),
                 client: Arc::new(
-                    Redis::new(&config.connection_uri)
+                    Redis::new(config)
+                        .await
+                        .unwrap_or_else(|e| panic!("Failed to create Redis client: {:?}", e)),
                 )
             })
         } else {

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -14,11 +14,11 @@ use crate::{
     event::{filter_event_data_by_conditions, EventMessage},
     manifest::stream::{
         KafkaStreamConfig, KafkaStreamQueueConfig, RabbitMQStreamConfig, RabbitMQStreamQueueConfig,
-        SNSStreamTopicConfig, StreamEvent, StreamsConfig, WebhookStreamConfig,
+        SNSStreamTopicConfig, StreamEvent, StreamsConfig, WebhookStreamConfig, RedisStreamConfig, RedisStreamStreamConfig
     },
     streams::{
         kafka::{Kafka, KafkaError},
-        RabbitMQ, RabbitMQError, Webhook, WebhookError, SNS,
+        RabbitMQ, RabbitMQError, Webhook, WebhookError, SNS, Redis, RedisError
     },
 };
 
@@ -48,6 +48,9 @@ pub enum StreamError {
     #[error("Kafka could not publish: {0}")]
     KafkaCouldNotPublish(#[from] KafkaError),
 
+    #[error("Redis could not publish: {0}")]
+    RedisCouldNotPublish(#[from] RedisError),
+
     #[error("Task failed: {0}")]
     JoinError(JoinError),
 }
@@ -68,11 +71,17 @@ pub struct KafkaStream {
     client: Arc<Kafka>,
 }
 
+pub struct RedisStream {
+    config: RedisStreamConfig,
+    client: Arc<Redis>
+}
+
 pub struct StreamsClients {
     sns: Option<SNSStream>,
     webhook: Option<WebhookStream>,
     rabbitmq: Option<RabbitMQStream>,
     kafka: Option<KafkaStream>,
+    redis: Option<RedisStream>,
 }
 
 impl StreamsClients {
@@ -113,14 +122,26 @@ impl StreamsClients {
             None
         };
 
-        Self { sns, webhook, rabbitmq, kafka }
+        let redis = if let Some(config) = stream_config.redis.as_ref() {
+            Some(RedisStream {
+                config: config.clone(),
+                client: Arc::new(
+                    Redis::new(&config.connection_uri)
+                )
+            })
+        } else {
+            None
+        };
+
+        Self { sns, webhook, rabbitmq, kafka, redis }
     }
 
     fn has_any_streams(&self) -> bool {
         self.sns.is_some() ||
             self.webhook.is_some() ||
             self.rabbitmq.is_some() ||
-            self.kafka.is_some()
+            self.kafka.is_some() ||
+            self.redis.is_some()
     }
 
     fn chunk_data(&self, data_array: &Vec<Value>) -> Vec<Vec<Value>> {
@@ -359,6 +380,38 @@ impl StreamsClients {
         tasks
     }
 
+    fn redis_stream_tasks(
+        &self,
+        config: &RedisStreamStreamConfig,
+        client: Arc<Redis>,
+        id: &str,
+        event_message: &EventMessage,
+        chunks: Arc<Vec<Vec<Value>>>,
+    ) -> StreamPublishes {
+        let tasks: Vec<_> = chunks
+            .iter()
+            .enumerate()
+            .map(|(index, chunk)| {
+                let filtered_chunk: Vec<Value> = self.filter_chunk_event_data_by_conditions(
+                    &config.events,
+                    event_message,
+                    chunk
+                );
+
+                let publish_message_id = self.generate_publish_message_id(id, index, &None);
+                let client = Arc::clone(&client);
+                let stream_name = config.stream_name.clone();
+                let publish_message = self.create_chunk_message_json(event_message, &filtered_chunk);
+
+                task::spawn(async move {
+                    client.publish(&publish_message_id, &stream_name, &publish_message)
+                        .await?;
+                    Ok(filtered_chunk.len())
+                })
+            }).collect();
+        tasks
+    }
+
     pub async fn stream(
         &self,
         id: String,
@@ -430,6 +483,22 @@ impl StreamsClients {
                         streams.push(self.kafka_stream_tasks(
                             config,
                             Arc::clone(&kafka.client),
+                            &id,
+                            event_message,
+                            Arc::clone(&chunks),
+                        ));
+                    }
+                }
+            }
+
+            if let Some(redis) = &self.redis {
+                for config in &redis.config.streams {
+                    if config.events.iter().any(|e| e.event_name == event_message.event_name) &&
+                        config.networks.contains(&event_message.network)
+                    {
+                        streams.push(self.redis_stream_tasks(
+                            config,
+                            Arc::clone(&redis.client),
                             &id,
                             event_message,
                             Arc::clone(&chunks),

--- a/core/src/streams/mod.rs
+++ b/core/src/streams/mod.rs
@@ -10,6 +10,10 @@ pub use rabbitmq::{RabbitMQ, RabbitMQError};
 mod kafka;
 
 mod clients;
+
+mod redis;
+pub use redis::{Redis, RedisError};
+
 pub use clients::StreamsClients;
 
 pub const STREAM_MESSAGE_ID_KEY: &str = "x-rindexer-id";

--- a/core/src/streams/redis.rs
+++ b/core/src/streams/redis.rs
@@ -1,0 +1,54 @@
+use log::{error, info};
+use thiserror::Error;
+use redis::{cmd, AsyncCommands};
+use redis::aio::MultiplexedConnection;
+use serde_json::Value;
+
+#[derive(Error, Debug)]
+pub enum RedisError {
+    #[error("Redis error: {0}")]
+    RedisError(#[from] redis::RedisError),
+}
+
+#[derive(Debug, Clone)]
+pub struct Redis {
+    client: redis::Client,
+}
+
+impl Redis {
+    pub fn new(url: &str) -> Self {
+        let client = redis::Client::open(url).unwrap();
+        match client.get_connection() {
+            Ok(mut c) => {
+                match cmd("PING").query::<String>(&mut c) {
+                    Ok(_) => info!("Successfully connected to Redis."),
+                    Err(error) => {
+                        error!("Error connecting to Redis: {}", error);
+                        panic!("Error connecting to Redis: {}", error);
+                    }
+                }
+            },
+            Err(e) => {
+                error!("Error connecting to Redis: {}", e);
+                panic!("Error connecting to Redis: {}", e);
+            }
+        };
+
+        Self { client }
+    }
+
+    pub async fn publish(&self, message_id: &str, stream_name: &str, message: &Value) -> Result<(), RedisError> {
+        // redis stream message ids need to be a timestamp with guaranteed unique identification
+        // so instead, we attach the message_id to the message value.
+        let mut message_with_id = message.clone();
+        if let Value::Object(ref mut map) = message_with_id {
+            map.insert("message_id".to_string(), Value::String(message_id.to_string()));
+        }
+
+        let json_value = serde_json::to_string(&message_with_id).unwrap();
+        let mut con: MultiplexedConnection = self.client.get_multiplexed_async_connection().await?;
+        let _: String = con.xadd(stream_name, "*", &[("payload", &json_value)]).await?;
+
+        Ok(())
+    }
+}

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -6,6 +6,8 @@
 ### Features
 -------------------------------------------------
 
+feat: Redis Streams
+
 ### Bug fixes
 -------------------------------------------------
 - fix: issue two's complement on large u256 values

--- a/documentation/docs/pages/docs/start-building/streams/index.mdx
+++ b/documentation/docs/pages/docs/start-building/streams/index.mdx
@@ -14,7 +14,7 @@ Rust projects do not get exposed to the stream clients yet but it can easily be 
 :::
 
 Note you can use all the streams together they are independent of each other, so if you wanted to us `kafka`,
-`webhooks`, `rabbitmq` and `sns` together you can do that.
+`webhooks`, `rabbitmq`, `sns` and `redis` together you can do that.
 
 Supported stream providers:
 
@@ -22,3 +22,4 @@ Supported stream providers:
 - [Kafka](/docs/start-building/streams/kafka) - Find out more about [Apache Kafka](https://kafka.apache.org/)
 - [RabbitMQ](/docs/start-building/streams/rabbitmq) - Find out more about [RabbitMQ](https://www.rabbitmq.com/)
 - [SNS/SQS](/docs/start-building/streams/sns) - Find out more about [Simple Notification Service](https://aws.amazon.com/sns/) and [Simple Queue Service](https://aws.amazon.com/sqs/)
+- [Redis Streams](/docs/start-building/streams/redis) - Find out more about [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/)

--- a/documentation/docs/pages/docs/start-building/streams/redis.mdx
+++ b/documentation/docs/pages/docs/start-building/streams/redis.mdx
@@ -160,7 +160,7 @@ contracts:
 
 #### conditions
 
-This accepts an array of conditions you want to apply to the event data before streaming to this SNS topic.
+This accepts an array of conditions you want to apply to the event data before streaming to this Redis Stream topic.
 
 :::info
 This is optional, if you do not provide any conditions all data will be streamed.

--- a/documentation/docs/pages/docs/start-building/streams/redis.mdx
+++ b/documentation/docs/pages/docs/start-building/streams/redis.mdx
@@ -1,0 +1,353 @@
+# Redis Streams
+
+:::info
+rindexer streams can be used without any other storage providers. It can also be used with storage providers.
+:::
+
+rindexer allows you to configure [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/) to stream any data to. This goes under
+the [contracts](docs/start-building/yaml-config/contracts) section.
+
+Found out more about [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/).
+
+## Configuration with rindexer
+`redis` `streams` property accepts an array allowing you to split up the streams any way you wish.
+
+## Example
+```yaml [rindexer.yaml]
+name: RocketPoolETHIndexer
+description: My first rindexer project
+repository: https://github.com/joshstevens19/rindexer
+project_type: no-code
+networks:
+- name: ethereum
+  chain_id: 1
+  rpc: https://mainnet.gateway.tenderly.co
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    redis: // [!code focus]
+      connection_uri: ${REDIS_CONNECTION_URI} // [!code focus]
+      streams: // [!code focus]
+        - stream_name: "ethereum_rocketpool_transfer_stream" // [!code focus]
+          networks: // [!code focus]
+            - ethereum // [!code focus]
+          events: // [!code focus]
+            - event_name: Transfer // [!code focus]
+```
+
+## Response
+
+:::info
+Redis streams may wrap the message body into their own object so the below is just what we send to the stream.
+:::
+
+The response sent to you is already decoded and parsed into a JSON stringify object.
+
+- `event_name` - The name of the event
+- `event_data` - The event data which has all the event fields decoded and the transaction information which is under `transaction_information`
+- `network` - The network the event was emitted on
+
+For example a transfer event would look like:
+
+```json
+{
+    "event_name": "Transfer",
+    "event_data": {
+        "from": "0x0338ce5020c447f7e668dc2ef778025ce3982662",
+        "to": "0x0338ce5020c447f7e668dc2ef778025ce3982662",
+        "value": "1000000000000000000",
+        "transaction_information": {
+            "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+            "block_hash": "0x8461da7a1d4b47190a01fa6eae219be40aacffab0dd64af7259b2d404572c3d9",
+            "block_number": "18718011",
+            "log_index": "0",
+            "network": "ethereum",
+            "transaction_hash": "0x145c6705ffbf461e85d08b4a7f5850d6b52a7364d93a057722ca1194034f3ba4",
+            "transaction_index": "0"
+        }
+    },
+    "network": "ethereum"
+}
+```
+
+## connection_uri
+
+This is the Redis connection url we advise to put this in a environment variable.
+
+```yaml [rindexer.yaml]
+...
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    redis: // [!code focus]
+      # we advise to put this in a environment variables // [!code focus]
+      connection_uri: ${REDIS_CONNECTION_URI} // [!code focus]
+```
+
+## streams
+
+This is where you configure each of the Redis Streams you want to push to.
+
+### stream_name
+
+The name of the stream that you are streaming events to.
+
+```yaml [rindexer.yaml]
+...
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    redis: // [!code focus]
+      connection_uri: ${REDIS_CONNECTION_URI}
+      streams: // [!code focus]
+        - stream_name: "ethereum_rocketpool_transfer_stream" // [!code focus]
+```
+
+### events
+
+This is an array of events you want to stream to this Redis Stream..
+
+#### event_name
+
+This is the name of the event you want to stream to this Redis Stream, must match the ABI event name.
+
+```yaml [rindexer.yaml]
+...
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    redis: // [!code focus]
+      connection_uri: ${REDIS_CONNECTION_URI}
+      streams: // [!code focus]
+        - stream_name: "ethereum_rocketpool_transfer_stream"
+          networks:
+            - ethereum
+          events: // [!code focus]
+            - event_name: Transfer // [!code focus]
+```
+
+#### conditions
+
+This accepts an array of conditions you want to apply to the event data before streaming to this SNS topic.
+
+:::info
+This is optional, if you do not provide any conditions all data will be streamed.
+:::
+
+You may want to filter on the stream based on the event data, if the event data has not got an index on the on the
+solidity event you can not filter it over the logs. The `conditions` filter is here to help you with this,
+based on your ABI you can filter on the event data.
+
+rindexer has enabled a special syntax which allows you to define on your ABI fields what you want to filter on.
+
+1. `>` - higher then (for numbers only)
+2. `<` - lower then (for numbers only)
+3. `=` - equals
+4. `>=` - higher then or equals (for numbers only)
+5. `<=` - lower then or equals (for numbers only)
+6. `||` - or
+7. `&&` - and
+
+So lets look at an example lets say i only want to get transfer events which are higher then `2000000000000000000` RETH wei
+
+```yaml [rindexer.yaml]
+...
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    redis: // [!code focus]
+      connection_uri: ${REDIS_CONNECTION_URI}
+      streams: // [!code focus]
+        - stream_name: "ethereum_rocketpool_transfer_stream"
+          networks:
+            - ethereum
+          events: // [!code focus]
+            - event_name: Transfer
+              conditions: // [!code focus]
+                - "value": ">=2000000000000000000" // [!code focus]
+```
+
+We use the ABI input name `value` to filter on the value field, you can find these names in the ABI file.
+
+```json
+{
+    "anonymous":false,
+    "inputs":[
+      {
+        "indexed":true,
+        "internalType":"address",
+        "name":"from",
+        "type":"address"
+      },
+      {
+        "indexed":true,
+        "internalType":"address",
+        "name":"to",
+        "type":"address"
+      },
+      {
+        "indexed":false,
+        "internalType":"uint256",
+        "name":"value", // [!code focus]
+        "type":"uint256"
+      }
+    ],
+    "name":"Transfer",
+    "type":"event"
+}
+```
+
+You can use the `||` or `&&` to combine conditions.
+
+```yaml [rindexer.yaml]
+...
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    redis: // [!code focus]
+      connection_uri: ${REDIS_CONNECTION_URI}
+      streams: // [!code focus]
+        - stream_name: "ethereum_rocketpool_transfer_stream"
+          networks:
+            - ethereum
+          events: // [!code focus]
+            - event_name: Transfer
+              conditions: // [!code focus]
+                - "value": ">=2000000000000000000 && value <=4000000000000000000" // [!code focus]
+```
+
+You can use the `=` to filter on other aspects like the `from` or `to` address.
+
+```yaml [rindexer.yaml]
+...
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    redis: // [!code focus]
+      connection_uri: ${REDIS_CONNECTION_URI}
+      streams: // [!code focus]
+        - stream_name: "ethereum_rocketpool_transfer_stream"
+          networks:
+            - ethereum
+          events: // [!code focus]
+            - event_name: Transfer
+              conditions: // [!code focus]
+                - "from": "0x0338ce5020c447f7e668dc2ef778025ce3982662 || 0x0338ce5020c447f7e668dc2ef778025ce398266u" // [!code focus]
+                - "value": ">=2000000000000000000 || value <=4000000000000000000" // [!code focus]
+```
+
+:::info
+Note we advise you to filer any `indexed` fields in the contract details in the `rindexer.yaml` file.
+As these can be filtered out on the request level and not filtered out in rindexer itself.
+You can read more about it [here](/docs/start-building/yaml-config/contracts#indexed_1-indexed_2-indexed_3).
+:::
+
+If you have a tuple and you want to get that value you just use the object notation.
+
+For example lets say we want to only get the events for `profileId` from the `quoteParams` tuple which equals `1`:
+
+```json
+{
+     "anonymous": false,
+     "inputs": [
+       {
+         "components": [
+           {
+             "internalType": "uint256",
+             "name": "profileId", // [!code focus]
+             "type": "uint256"
+           },
+           ...
+         ],
+         "indexed": false,
+         "internalType": "struct Types.QuoteParams",
+         "name": "quoteParams", // [!code focus]
+         "type": "tuple"
+       },
+       ...
+     ],
+     "name": "QuoteCreated", // [!code focus]
+     "type": "event"
+}
+```
+
+```yaml [rindexer.yaml]
+...
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    redis: // [!code focus]
+      connection_uri: ${REDIS_CONNECTION_URI}
+      streams: // [!code focus]
+        - stream_name: "ethereum_rocketpool_transfer_stream"
+          networks:
+            - ethereum
+          events: // [!code focus]
+            - event_name: Transfer
+              conditions: // [!code focus]
+                - "quoteParams.profileId": "=1" // [!code focus]
+```

--- a/documentation/vocs.config.ts
+++ b/documentation/vocs.config.ts
@@ -87,6 +87,7 @@ export default defineConfig({
             { text: 'Kafka', link: '/docs/start-building/streams/kafka' },
             { text: 'Rabbitmq', link: '/docs/start-building/streams/rabbitmq' },
             { text: 'SNS/SQS', link: '/docs/start-building/streams/sns' },
+            { text: "Redis", link: '/docs/start-building/streams/redis' }
           ],
         },
         {

--- a/streams_playground/redis/docker-compose.yml
+++ b/streams_playground/redis/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  redis:
+    image: redis
+    container_name: rindexer-redis
+    logging:
+      driver: none
+    ports:
+      - "6379:6379"
+    command: [ "redis-server", "--bind", "redis", "--port", "6379" ]


### PR DESCRIPTION
Introduces Redis Streams as a form of message streaming.

To use, you can add something like:
```yaml
contracts:
  - name: UniswapV3Pool_Base
    details:
      - network: base
        filter:
          event_name: Swap
        start_block: 19953475
        end_block: 19953475
    abi: ./abis/UniswapV3Pool.abi.json
    streams:
      redis:
        connection_uri: redis://localhost:6379
        streams:
          - stream_name: uniswap-v3-stream-base
            networks:
              - base
            events:
              - event_name: Swap
```

As the rindexer contract config.