### PR TITLE
chore: support custom AWS endpoints

### DIFF
--- a/core/src/streams/sns.rs
+++ b/core/src/streams/sns.rs
@@ -27,12 +27,22 @@ impl SNS {
             "manual",
         );
 
-        let config = aws_config::defaults(BehaviorVersion::latest())
+        let mut sdk_config = aws_config::defaults(BehaviorVersion::latest())
             .region(region_provider)
             .credentials_provider(credentials_provider)
             .load()
             .await;
-        let client = Client::new(&config);
+
+        // Conditionally set endpoint if it exists
+        if let Some(endpoint_url) = &config.endpoint_url {
+            if !endpoint_url.trim().is_empty() {
+                sdk_config = sdk_config.to_builder()
+                    .endpoint_url(endpoint_url)
+                    .build();
+            }
+        }
+
+        let client = Client::new(&sdk_config);
 
         // Test the connection by listing SNS topics
         match client.list_topics().send().await {

--- a/core/src/types/aws_config.rs
+++ b/core/src/types/aws_config.rs
@@ -8,4 +8,7 @@ pub struct AwsConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_token: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_url: Option<String>,
 }

--- a/documentation/docs/pages/docs/start-building/streams/sns.mdx
+++ b/documentation/docs/pages/docs/start-building/streams/sns.mdx
@@ -215,7 +215,7 @@ We advise you to put this in a environment variables.
 :::
 
 
-The AWS session token to connect to.
+The AWS endpoint to connect to.
 
 ```yaml [rindexer.yaml]
 ...

--- a/documentation/docs/pages/docs/start-building/streams/sns.mdx
+++ b/documentation/docs/pages/docs/start-building/streams/sns.mdx
@@ -42,6 +42,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY} // [!code focus]
         # session_token is optional // [!code focus]
         session_token: ${AWS_SESSION_TOKEN} // [!code focus]
+        # endpoint_url is optional // [!code focus]
+        endpoint_url: ${ENDPOINT_URL} // ![code focus]
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test" // [!code focus]
           networks: // [!code focus]
@@ -202,6 +204,41 @@ contracts:
         session_token: ${AWS_SESSION_TOKEN} // [!code focus]
 ```
 
+### endpoint_url
+
+:::info
+This is optional
+:::
+
+:::info
+We advise you to put this in a environment variables.
+:::
+
+
+The AWS session token to connect to.
+
+```yaml [rindexer.yaml]
+...
+contracts:
+- name: RocketPoolETH
+  details:
+  - network: ethereum
+    address: "0xae78736cd615f374d3085123a210448e74fc6393"
+    start_block: "18600000"
+    end_block: "18600181"
+  abi: "./abis/RocketTokenRETH.abi.json"
+  include_events:
+  - Transfer
+  streams: // [!code focus]
+    sns: // [!code focus]
+      aws_config: // [!code focus]
+        region: us-east-1
+        access_key: ${AWS_ACCESS_KEY_ID}
+        secret_key: ${AWS_SECRET_ACCESS_KEY}
+        session_token: ${AWS_SESSION_TOKEN}
+        endpoint_url: ${ENDPOINT_URL} // ![code focus]
+```
+
 ## topics
 
 This is an array of topics you want to stream to this sns.
@@ -233,6 +270,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY}
         # session_token is optional
         session_token: ${AWS_SESSION_TOKEN}
+        # endpoint_url is optional
+        endpoint_url: ${ENDPOINT_URL}
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test" // [!code focus]
 ```
@@ -257,6 +296,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY}
         # session_token is optional
         session_token: ${AWS_SESSION_TOKEN}
+        # endpoint_url is optional
+        endpoint_url: ${ENDPOINT_URL}
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test.fifo" // [!code focus]
 ```
@@ -287,6 +328,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY}
         # session_token is optional
         session_token: ${AWS_SESSION_TOKEN}
+        # endpoint_url is optional
+        endpoint_url: ${ENDPOINT_URL}
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test"
           networks: // [!code focus]
@@ -321,6 +364,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY}
         # session_token is optional
         session_token: ${AWS_SESSION_TOKEN}
+        # endpoint_url is optional
+        endpoint_url: ${ENDPOINT_URL}
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test"
           networks:
@@ -373,6 +418,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY}
         # session_token is optional
         session_token: ${AWS_SESSION_TOKEN}
+        # endpoint_url is optional
+        endpoint_url: ${ENDPOINT_URL}
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test"
           networks:
@@ -435,6 +482,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY}
         # session_token is optional
         session_token: ${AWS_SESSION_TOKEN}
+        # endpoint_url is optional
+        endpoint_url: ${ENDPOINT_URL}
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test"
           networks:
@@ -467,6 +516,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY}
         # session_token is optional
         session_token: ${AWS_SESSION_TOKEN}
+        # endpoint_url is optional
+        endpoint_url: ${ENDPOINT_URL}
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test"
           networks:
@@ -533,6 +584,8 @@ contracts:
         secret_key: ${AWS_SECRET_ACCESS_KEY}
         # session_token is optional
         session_token: ${AWS_SESSION_TOKEN}
+        # endpoint_url is optional
+        endpoint_url: ${ENDPOINT_URL}
       topics: // [!code focus]
         - topic_arn: "arn:aws:sns:us-east-1:664643779377:test"
           networks:


### PR DESCRIPTION
To run rindexer via localstack or run against seperate endpoints, a custom URL is required.