### PR TITLE
Parallelize client creation

### DIFF
--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -29,6 +29,7 @@ use alloy::{
         RpcError, TransportErrorKind,
     },
 };
+use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error;
@@ -340,8 +341,7 @@ impl CreateNetworkProvider {
     pub async fn create(
         manifest: &Manifest,
     ) -> Result<Vec<CreateNetworkProvider>, RetryClientError> {
-        let mut result: Vec<CreateNetworkProvider> = vec![];
-        for network in &manifest.networks {
+        let provider_futures = manifest.networks.iter().map(|network| async move {
             let provider = create_client(
                 &network.rpc,
                 network.chain_id,
@@ -350,14 +350,14 @@ impl CreateNetworkProvider {
                 manifest.get_custom_headers(),
             )
             .await?;
-            result.push(CreateNetworkProvider {
+
+            Ok::<_, RetryClientError>(CreateNetworkProvider {
                 network_name: network.name.clone(),
                 disable_logs_bloom_checks: network.disable_logs_bloom_checks.unwrap_or_default(),
                 client: provider,
-            });
-        }
-
-        Ok(result)
+            })
+        });
+        try_join_all(provider_futures).await
     }
 }
 


### PR DESCRIPTION
We're testing rindexer with a large number of networks, and initialization can take a bit. We propose making it concurrent, which will make initialization faster in almost every multi-chain case. What do you think?

Thanks for your time!