### PR TITLE
Never exceed safe threshold

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -73,6 +73,7 @@ url = "2.5.0"
 jemallocator = { version = "0.6.0", package = "tikv-jemallocator", optional = true }
 jemalloc-ctl = { version = "0.6.0", package = "tikv-jemalloc-ctl", optional = true }
 foundry-compilers = "0.16.1"
+log = "0.4.27"
 
 [target.'cfg(not(windows))'.dependencies]
 rdkafka = { version = "0.37.0", features = ["tokio"] }

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1,9 +1,16 @@
 use std::{error::Error, str::FromStr, sync::Arc, time::Duration};
 
+use crate::{
+    event::{config::EventProcessingConfig, RindexerEventFilter},
+    indexer::{
+        log_helpers::{halved_block_number, is_relevant_block},
+        IndexingEventProgressStatus,
+    },
+    provider::{JsonRpcCachedProvider, ProviderError},
+};
 use alloy::{
     primitives::{Address, BlockNumber, B256, U64},
     rpc::types::{Log, ValueOrArray},
-    transports::RpcError,
 };
 use rand::random_ratio;
 use regex::Regex;
@@ -13,15 +20,6 @@ use tokio::{
 };
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, warn};
-
-use crate::{
-    event::{config::EventProcessingConfig, RindexerEventFilter},
-    indexer::{
-        log_helpers::{halved_block_number, is_relevant_block},
-        IndexingEventProgressStatus,
-    },
-    provider::{JsonRpcCachedProvider, ProviderError},
-};
 
 pub struct FetchLogsResult {
     pub logs: Vec<Log>,
@@ -593,22 +591,22 @@ fn retry_with_block_range(
     from_block: U64,
     to_block: U64,
 ) -> Option<RetryWithBlockRangeResult> {
-    let error = match error {
-        ProviderError::RequestFailed(RpcError::ErrorResp(json_rpc_err)) => json_rpc_err,
-        // Break early if not a Server JSON-RPC Error.
-        _ => {
-            warn!("Unexpected error kind fetching block range.");
-            return None;
-        }
+    let error_struct = match error {
+        ProviderError::RequestFailed(json_rpc_err) => json_rpc_err.as_error_resp(),
+        _ => None,
     };
 
-    let error_message = &error.message;
-    // some providers put the data in the data field
-    let error_data_binding = error.data.as_ref().map(|data| data.to_string());
-    let empty_string = String::from("");
-    let error_data = match &error_data_binding {
-        Some(data) => data,
-        None => &empty_string,
+    let (error_message, error_data) = if let Some(error) = error_struct {
+        let error_message = error.message.to_string();
+        let error_data_binding = error.data.as_ref().map(|data| data.to_string());
+        let empty_string = String::from("");
+        let error_data = error_data_binding.unwrap_or_else(|| empty_string);
+
+        (error_message, error_data)
+    } else {
+        let str_err = error.to_string();
+        debug!("Failed to parse structured error, trying with raw string: {}", &str_err);
+        (str_err, "".to_string())
     };
 
     fn compile_regex(pattern: &str) -> Result<Regex, regex::Error> {
@@ -621,7 +619,7 @@ fn retry_with_block_range(
     if let Ok(re) =
         compile_regex(r"this block range should work: \[(0x[0-9a-fA-F]+),\s*(0x[0-9a-fA-F]+)]")
     {
-        if let Some(captures) = re.captures(error_message).or_else(|| re.captures(error_data)) {
+        if let Some(captures) = re.captures(&error_message).or_else(|| re.captures(&error_data)) {
             if let (Some(start_block), Some(end_block)) = (captures.get(1), captures.get(2)) {
                 let start_block_str = start_block.as_str();
                 let end_block_str = end_block.as_str();
@@ -655,10 +653,7 @@ fn retry_with_block_range(
     if let Ok(re) =
         compile_regex(r"Try with this block range \[0x([0-9a-fA-F]+),\s*0x([0-9a-fA-F]+)\]")
     {
-        if let Some(captures) = re.captures(error_message).or_else(|| {
-            let blah = re.captures(error_data);
-            blah
-        }) {
+        if let Some(captures) = re.captures(&error_message).or_else(|| re.captures(&error_data)) {
             if let (Some(start_block), Some(end_block)) = (captures.get(1), captures.get(2)) {
                 let start_block_str = format!("0x{}", start_block.as_str());
                 let end_block_str = format!("0x{}", end_block.as_str());
@@ -676,7 +671,7 @@ fn retry_with_block_range(
     }
 
     // Ankr
-    if error_message.contains("block range is too wide") && error.code == -32600 {
+    if error_message.contains("block range is too wide") {
         return Some(RetryWithBlockRangeResult {
             from: from_block,
             to: from_block + U64::from(3000),
@@ -686,7 +681,7 @@ fn retry_with_block_range(
 
     // QuickNode, 1RPC, zkEVM, Blast, BlockPI
     if let Ok(re) = compile_regex(r"limited to a ([\d,.]+)") {
-        if let Some(captures) = re.captures(error_message).or_else(|| re.captures(error_data)) {
+        if let Some(captures) = re.captures(&error_message).or_else(|| re.captures(&error_data)) {
             if let Some(range_str_match) = captures.get(1) {
                 let range_str = range_str_match.as_str().replace(&['.', ','][..], "");
                 if let Ok(range) = U64::from_str(&range_str) {

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -596,7 +596,10 @@ fn retry_with_block_range(
     let error = match error {
         ProviderError::RequestFailed(RpcError::ErrorResp(json_rpc_err)) => json_rpc_err,
         // Break early if not a Server JSON-RPC Error.
-        _ => return None,
+        _ => {
+            warn!("Unexpected error kind fetching block range.");
+            return None;
+        }
     };
 
     let error_message = &error.message;

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -600,7 +600,7 @@ fn retry_with_block_range(
         let error_message = error.message.to_string();
         let error_data_binding = error.data.as_ref().map(|data| data.to_string());
         let empty_string = String::from("");
-        let error_data = error_data_binding.unwrap_or_else(|| empty_string);
+        let error_data = error_data_binding.unwrap_or(empty_string);
 
         (error_message, error_data)
     } else {

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -109,15 +109,9 @@ pub async fn native_transfer_block_fetch(
         match latest_block {
             Ok(Some(latest_block)) => {
                 let block = U64::from(latest_block.header.number);
-                let safe_block_number = block - indexing_distance_from_head;
 
-                if block > safe_block_number {
-                    info!(
-                        "{} - not in safe reorg block range yet block: {} > range: {}",
-                        "NativeEvmTraces", block, safe_block_number
-                    );
-                    continue;
-                }
+                // Always trim back to the safe indexing threshold (which is zero if disabled)
+                let block = block - indexing_distance_from_head;
 
                 if block > last_seen_block {
                     let to_block = end_block.map(|end| block.min(end)).unwrap_or(block);

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -78,6 +78,11 @@ async fn push_range(block_tx: &mpsc::Sender<U64>, last: U64, latest: U64) {
 
     while let Some(block) = range.pop_front() {
         if let Err(e) = block_tx.send(U64::from(block)).await {
+            if block_tx.is_closed() {
+                error!("Failed to send block via channel. Channel closed: {}", e.to_string());
+                break;
+            }
+
             error!("Failed to send block via channel. Re-queuing: {}", e.to_string());
             range.push_front(block);
         }

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -16,6 +16,8 @@
 
 - Fix a bug with broken binary copy in the Postgres client. `finish` should be called manually on a bad write.
 - Fix bug with breaking out of historical indexing on log fetch error.
+- Fix native transfer indexing bug by adjusting the reorg safe condition to be correct
+- Fix `fetch_logs` block range parsing to include fallback string if no Err variant found (fixes Lens indexing)
 
 ### Breaking changes
 -------------------------------------------------


### PR DESCRIPTION
1. Fixes #193 by adjusting the reorg safe condition to be correct
2. Adds a fallback to `string` error match handling in `fetch_logs` due to a bug with Alchemy Lens chain not returning the expected error variant (possibly an upstream alloy_rpc bug), and so it never successfully fetches logs.