### PR TITLE
Fix Docker compatibility: Use x86-64-v2 target-cpu instead of native

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /app
 WORKDIR /app
 COPY . .
 RUN rustup target add x86_64-unknown-linux-musl
-RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --target x86_64-unknown-linux-musl --features jemalloc
+RUN RUSTFLAGS='-C target-cpu=x86-64-v2' cargo build --release --target x86_64-unknown-linux-musl --features jemalloc
 
 FROM --platform=linux/amd64 scratch
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/rindexer_cli /app/rindexer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=linux/amd64 clux/muslrust:stable as builder
+FROM --platform=linux/amd64 clux/muslrust:1.87.0-stable-2025-05-18 as builder
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-RUN mkdir /app
+
 WORKDIR /app
 COPY . .
 RUN rustup target add x86_64-unknown-linux-musl

--- a/bundled.Dockerfile
+++ b/bundled.Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt install -y libssl-dev pkg-config build-essential
 
 WORKDIR /app
 COPY . .
-RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --features jemalloc
+RUN RUSTFLAGS='-C target-cpu=x86-64-v2' cargo build --release --features jemalloc
 
 FROM --platform=linux/amd64 node:lts-bookworm as node-builder
 RUN apt update && apt install -y ca-certificates


### PR DESCRIPTION
## Problem
The current Dockerfiles uses `RUSTFLAGS='-C target-cpu=native'` which optimizes the Rust binary for the GitHub Actions runner's CPU architecture. This causes `Illegal instruction (core dumped)` errors when running the Docker images (`ghcr.io/joshstevens19/rindexer` and `ghcr.io/joshstevens19/rindexer-bundled`) on processors that don't support the same instruction sets as the build environment.

## Current Behavior
- ❌ Docker image crashes with "Illegal instruction (core dumped)" on various x86-64 processors (confirmed on Intel i7 10th gen)
- ❌ Binary is optimized for GitHub's build infrastructure rather than target deployment environments
- ❌ Limits portability across different CPU generations

## Proposed Solution
Change the RUSTFLAGS from:
```dockerfile
RUN RUSTFLAGS='-C target-cpu=native' ...
```

To:
```dockerfile
RUN RUSTFLAGS='-C target-cpu=x86-64-v2' ...
```

## Benefits
- ✅ Maintains good performance optimization (x86-64-v2 includes SSE4.2, POPCNT, etc.)
- ✅ Compatible with virtually all modern x86-64 processors (2009+)
- ✅ Prevents runtime crashes on older but still widely-used CPUs
- ✅ Better portability for Docker deployments across different environments

## Testing
Tested on Intel i7 10th gen where trying to use rindexer with the current image fails with "Illegal instruction (core dumped)" but making this change has resolved the issue.

## References
- [x86-64 microarchitecture levels](https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels)
- [Rust target-cpu documentation](https://doc.rust-lang.org/rustc/codegen-options/index.html#target-cpu)