### PR TITLE
Fix build break after alloy v2.10.0: remove NamedChain::PolygonZkEvm usage

### DIFF
--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -147,7 +147,6 @@ fn is_known_zk_evm_compatible_chain(chain: Chain) -> Option<bool> {
             | NamedChain::Sophon
             | NamedChain::Abstract
             | NamedChain::Scroll
-            | NamedChain::PolygonZkEvm
             | NamedChain::Linea => Some(true),
 
             // Known non-zkEVM chains

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 -------------------------------------------------
-fix: build break after alloy v2.10.0: remove NamedChain::PolygonZkEvm usage
+- fix: build break after alloy v2.10.0: remove NamedChain::PolygonZkEvm usage
 
 ### Breaking changes
 -------------------------------------------------

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 -------------------------------------------------
+fix: build break after alloy v2.10.0: remove NamedChain::PolygonZkEvm usage
 
 ### Breaking changes
 -------------------------------------------------


### PR DESCRIPTION
After updating alloy to v2.10.0, rindexer started failing to build because
`alloy_chains` removed the `NamedChain::PolygonZkEvm` variant. This PR fixes the
build error by removing our reference to that variant.

**Failure**
Rust E0599 with message similar to:

```
no variant or associated item named `PolygonZkEvm` found for enum `NamedChain`
```

**images**

<img width="1005" height="252" alt="image" src="https://github.com/user-attachments/assets/ed33e220-f316-45c3-84a1-af06ee24f1c1" />

**Changes**

* Delete the `NamedChain::PolygonZkEvm` match arm.

**Why**

* Resolve the build failure introduced by the alloy v2.10.0 update.

**Changelog reference**

https://github.com/alloy-rs/chains/blob/d12dcd4542cf74dfd03ac185638cc68dd3662792/CHANGELOG.md?plain=1#L56
