### PR TITLE
Do not log error if we are backwards, but in safe reorg range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10870,7 +10870,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -10939,7 +10939,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_cli"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -9,11 +9,10 @@ use tokio::{
     task::{JoinError, JoinHandle},
     time::Instant,
 };
-use tracing::{debug, error, event, info, Level};
+use tracing::{debug, error, info};
 
 use crate::helpers::is_relevant_block;
 use crate::indexer::reorg::reorg_safe_distance_for_chain;
-use crate::indexer::start::StartIndexingError;
 use crate::provider::JsonRpcCachedProvider;
 use crate::{
     event::{

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -9,9 +9,11 @@ use tokio::{
     task::{JoinError, JoinHandle},
     time::Instant,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, event, info, Level};
 
 use crate::helpers::is_relevant_block;
+use crate::indexer::reorg::reorg_safe_distance_for_chain;
+use crate::indexer::start::StartIndexingError;
 use crate::provider::JsonRpcCachedProvider;
 use crate::{
     event::{
@@ -387,14 +389,32 @@ async fn live_indexing_for_contract_event_dependencies(
             // check reorg distance and skip if not safe
             if from_block > safe_block_number {
                 if reorg_safe_distance.is_zero() {
-                    error!(
-                        "{}::{} - {} - RPC has gone back on latest block: rpc returned {}, last seen: {}",
-                        &config.info_log_name(),
-                        &config.network_contract().network,
-                        IndexingEventProgressStatus::Live.log(),
-                        latest_block_number,
-                        from_block
-                    );
+                    let block_distance = latest_block_number - from_block;
+                    let is_outside_reorg_range =
+                        block_distance > reorg_safe_distance_for_chain(cached_provider.chain.id());
+
+                    // it should never get under normal conditions outside the reorg range,
+                    // therefore, we log an error as means RCP state is not in sync with the blockchain
+                    if is_outside_reorg_range {
+                        error!(
+                            "{}::{} - {} - RPC has gone back on latest block: rpc returned {}, last seen: {}",
+                            &config.info_log_name(),
+                            &config.network_contract().network,
+                            IndexingEventProgressStatus::Live.log(),
+                            latest_block_number,
+                            from_block
+                        );
+                    } else {
+                        info!(
+                            "{}::{} - {} - RPC has gone back on latest block: rpc returned {}, last seen: {}",
+                            &config.info_log_name(),
+                            &config.network_contract().network,
+                            IndexingEventProgressStatus::Live.log(),
+                            latest_block_number,
+                            from_block
+                        );
+                    }
+
                     continue;
                 } else {
                     info!(

--- a/core/src/indexer/reorg.rs
+++ b/core/src/indexer/reorg.rs
@@ -43,8 +43,8 @@ pub fn handle_chain_notification(
     }
 }
 
-pub fn reorg_safe_distance_for_chain(chain_id: &U256) -> U64 {
-    if chain_id == &U256::from(1) {
+pub fn reorg_safe_distance_for_chain(chain_id: u64) -> U64 {
+    if chain_id == 1 {
         U64::from(12)
     } else {
         U64::from(64)
@@ -53,19 +53,17 @@ pub fn reorg_safe_distance_for_chain(chain_id: &U256) -> U64 {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::U256;
-
     use super::*;
 
     #[test]
     fn test_reorg_safe_distance_for_chain() {
-        let mainnet_chain_id = U256::from(1);
-        assert_eq!(reorg_safe_distance_for_chain(&mainnet_chain_id), U64::from(12));
+        let mainnet_chain_id = 1;
+        assert_eq!(reorg_safe_distance_for_chain(mainnet_chain_id), U64::from(12));
 
-        let testnet_chain_id = U256::from(3);
-        assert_eq!(reorg_safe_distance_for_chain(&testnet_chain_id), U64::from(64));
+        let testnet_chain_id = 3;
+        assert_eq!(reorg_safe_distance_for_chain(testnet_chain_id), U64::from(64));
 
-        let other_chain_id = U256::from(42);
-        assert_eq!(reorg_safe_distance_for_chain(&other_chain_id), U64::from(64));
+        let other_chain_id = 42;
+        assert_eq!(reorg_safe_distance_for_chain(other_chain_id), U64::from(64));
     }
 }

--- a/core/src/indexer/reorg.rs
+++ b/core/src/indexer/reorg.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{U256, U64};
+use alloy::primitives::U64;
 use tracing::{debug, warn};
 
 use crate::notifications::ChainStateNotification;

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -155,8 +155,7 @@ async fn get_start_end_block(
     }
 
     let (end_block, indexing_distance_from_head) =
-        calculate_safe_block_number(reorg_safe_distance, &provider, latest_block, end_block)
-            .await?;
+        calculate_safe_block_number(reorg_safe_distance, &provider, latest_block, end_block);
 
     Ok((start_block, end_block, indexing_distance_from_head))
 }
@@ -630,22 +629,21 @@ pub async fn initialize_database(
     }
 }
 
-pub async fn calculate_safe_block_number(
+pub fn calculate_safe_block_number(
     reorg_safe_distance: bool,
     provider: &Arc<JsonRpcCachedProvider>,
     latest_block: U64,
     mut end_block: U64,
-) -> Result<(U64, U64), StartIndexingError> {
+) -> (U64, U64) {
     let mut indexing_distance_from_head = U64::ZERO;
     if reorg_safe_distance {
-        let chain_id =
-            provider.get_chain_id().await.map_err(StartIndexingError::GetChainIdError)?;
-        let reorg_safe_distance = reorg_safe_distance_for_chain(&chain_id);
+        let chain_id = provider.chain.id();
+        let reorg_safe_distance = reorg_safe_distance_for_chain(chain_id);
         let safe_block_number = latest_block - reorg_safe_distance;
         if end_block > safe_block_number {
             end_block = safe_block_number;
         }
         indexing_distance_from_head = reorg_safe_distance;
     }
-    Ok((end_block, indexing_distance_from_head))
+    (end_block, indexing_distance_from_head)
 }

--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -752,29 +752,3 @@ pub fn get_network_provider<'a>(
 ) -> Option<&'a CreateNetworkProvider> {
     providers.iter().find(|item| item.network_name == network)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_create_retry_client() {
-        let rpc_url = "http://localhost:8545";
-        let result =
-            create_client(rpc_url, 1, Some(660), None, None, HeaderMap::new(), None, None).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_create_retry_client_invalid_url() {
-        let rpc_url = "invalid_url";
-        let result =
-            create_client(rpc_url, 1, Some(660), None, None, HeaderMap::new(), None, None).await;
-        assert!(result.is_err());
-        if let Err(RetryClientError::ProviderCantBeCreated(url, _)) = result {
-            assert_eq!(url, rpc_url);
-        } else {
-            panic!("Expected HttpProviderCantBeCreated error");
-        }
-    }
-}

--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -563,6 +563,29 @@ impl JsonRpcCachedProvider {
     pub fn get_chain_state_notification(&self) -> Option<Sender<ChainStateNotification>> {
         self.chain_state_notification.clone()
     }
+
+    #[cfg(test)]
+    pub fn mock(chain_id: u64) -> Arc<Self> {
+        let chain = Chain::from(chain_id);
+        let client = RpcClient::new_http(
+            Url::parse("http://localhost:8545").expect("mock URL must be valid"),
+        );
+        let provider =
+            ProviderBuilder::new().network::<AnyNetwork>().connect_client(client.clone());
+        let is_zk_chain = is_known_zk_evm_compatible_chain(chain).unwrap_or(false);
+
+        Arc::new(Self {
+            provider: Arc::new(provider),
+            client,
+            cache: Mutex::new(None),
+            is_zk_chain,
+            chain,
+            block_poll_frequency: None,
+            address_filtering: None,
+            max_block_range: None,
+            chain_state_notification: None,
+        })
+    }
 }
 #[derive(Error, Debug)]
 pub enum RetryClientError {

--- a/core/src/reth/utils.rs
+++ b/core/src/reth/utils.rs
@@ -25,7 +25,7 @@ pub async fn wait_for_ipc_ready(ipc_path: &str, timeout: Duration) -> Result<(),
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    Err(RetryClientError::HttpProviderCantBeCreated(
+    Err(RetryClientError::ProviderCantBeCreated(
         ipc_path.to_string(),
         "IPC connection timeout".to_string(),
     ))

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -5,9 +5,11 @@
 
 ### Features
 -------------------------------------------------
+- feat: check if the RPC chain id is matching the configured chain id in the yaml config on startup
 
 ### Bug fixes
 -------------------------------------------------
+- fix: only log error when the current block lumber is lower than the last seen when range is outside chain reorg safe
 
 ### Breaking changes
 -------------------------------------------------

--- a/examples/rindexer_factory_indexing/Cargo.lock
+++ b/examples/rindexer_factory_indexing/Cargo.lock
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "alloy",
  "alloy-chains",


### PR DESCRIPTION
Cleanup provider handling
Throw error when a provider chain id is different from one in rindexer config