### PR TITLE
Fix: bytes were stored wrong

### DIFF
--- a/core/src/database/sql_type_wrapper.rs
+++ b/core/src/database/sql_type_wrapper.rs
@@ -450,12 +450,12 @@ impl EthereumSqlTypeWrapper {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            EthereumSqlTypeWrapper::Bytes(value) => format!("0x{}", hex::encode(value)),
+            EthereumSqlTypeWrapper::Bytes(value) => format!("'0x{}'", hex::encode(value)),
             EthereumSqlTypeWrapper::VecBytes(values) => format!(
                 "[{}]",
                 values
                     .iter()
-                    .map(|v| format!("0x{}", hex::encode(v)))
+                    .map(|v| format!("'0x{}'", hex::encode(v)))
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
@@ -489,7 +489,7 @@ impl EthereumSqlTypeWrapper {
             EthereumSqlTypeWrapper::StringVarcharNullable(v) => v.to_string(),
             EthereumSqlTypeWrapper::StringCharNullable(v) => v.to_string(),
             EthereumSqlTypeWrapper::AddressNullable(v) => v.to_string(),
-            EthereumSqlTypeWrapper::BytesNullable(v) => v.to_string(),
+            EthereumSqlTypeWrapper::BytesNullable(v) => format!("'0x{}'", hex::encode(v)),
 
             #[allow(deprecated)]
             EthereumSqlTypeWrapper::H160(v) => v.to_string(),


### PR DESCRIPTION
Context: bytes32 values for example were getting stored as integers in clickhouse.
Reason: string values must be quoted with single quotes to be valid SQL syntax.