### PR TITLE
fix: use calculated end_block for native_transfer_block_fetch

### DIFF
--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -263,7 +263,7 @@ async fn start_indexing_traces(
             network_details.cached_provider.clone(),
             block_tx,
             start_block,
-            network_details.end_block,
+            Some(end_block),
             indexing_distance_from_head,
             network_name.clone(),
         ));


### PR DESCRIPTION
## Summary

Pass the calculated `end_block` from `get_start_end_block()` instead of `network_details.end_block` to `native_transfer_block_fetch()`.

## Problem

When `end_block` is not set in the manifest, `network_details.end_block` is `None`, causing `native_transfer_block_fetch` to loop forever waiting for new blocks. This blocks `try_join_all` in `start_indexing`, preventing:
- Historical indexing from completing
- Live indexing from ever starting
- All contract events from being indexed

## Fix

Use the calculated `end_block` (which defaults to `latest_block` when not specified in manifest) instead of the raw manifest value. This aligns native transfer behavior with contract events.

Fixes #367