### PR TITLE
ClickHouse no-code tables: native types + serialization fix

### DIFF
--- a/core/src/database/clickhouse/generate.rs
+++ b/core/src/database/clickhouse/generate.rs
@@ -173,9 +173,13 @@ fn generate_tables_clickhouse(tables: &[Table], schema_name: &str) -> String {
                 }
             }
 
-            // Use ReplacingMergeTree with rindexer_sequence_id as version column
-            let engine =
-                format!("ReplacingMergeTree(`{}`)", injected_columns::RINDEXER_SEQUENCE_ID);
+            // Insert-only tables use MergeTree (no dedup needed — each row is unique).
+            // Tables with upsert/update/delete use ReplacingMergeTree for deduplication.
+            let engine = if table.is_insert_only() {
+                "MergeTree()".to_string()
+            } else {
+                format!("ReplacingMergeTree(`{}`)", injected_columns::RINDEXER_SEQUENCE_ID)
+            };
 
             format!(
                 "CREATE TABLE IF NOT EXISTS {} ({}) ENGINE = {} ORDER BY ({});",

--- a/core/src/database/sql_type_wrapper.rs
+++ b/core/src/database/sql_type_wrapper.rs
@@ -513,25 +513,52 @@ impl EthereumSqlTypeWrapper {
                 format!("[{}]", values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", "))
             }
 
-            EthereumSqlTypeWrapper::Uuid(_)
-            | EthereumSqlTypeWrapper::VecB256Bytes(_)
-            | EthereumSqlTypeWrapper::VecI256Bytes(_)
-            | EthereumSqlTypeWrapper::B256Bytes(_)
-            | EthereumSqlTypeWrapper::JSONB(_)
-            | EthereumSqlTypeWrapper::U256Numeric(_)
-            | EthereumSqlTypeWrapper::U256NumericNullable(_)
-            | EthereumSqlTypeWrapper::VecU256Bytes(_)
-            | EthereumSqlTypeWrapper::VecU256Numeric(_)
-            | EthereumSqlTypeWrapper::U256Bytes(_)
-            | EthereumSqlTypeWrapper::U256BytesNullable(_)
-            | EthereumSqlTypeWrapper::I256Numeric(_)
-            | EthereumSqlTypeWrapper::AddressBytes(_)
-            | EthereumSqlTypeWrapper::AddressBytesNullable(_)
-            | EthereumSqlTypeWrapper::VecAddressBytes(_)
-            | EthereumSqlTypeWrapper::I256Bytes(_)
-            | EthereumSqlTypeWrapper::I256BytesNullable(_) => {
+            // PostgreSQL-specific Numeric wrappers — serialize as string for ClickHouse.
+            // These are produced by the expression evaluator and field resolver which
+            // always wrap U256 values as U256Numeric (designed for PG NUMERIC columns).
+            // For ClickHouse, the target column is String (uint256 → String mapping),
+            // so .to_string() produces the correct decimal representation.
+            EthereumSqlTypeWrapper::U256Numeric(val) => val.to_string(),
+            EthereumSqlTypeWrapper::U256NumericNullable(val) => match val {
+                Some(v) => v.to_string(),
+                None => "NULL".to_string(),
+            },
+            EthereumSqlTypeWrapper::VecU256Numeric(values) => {
+                format!("[{}]", values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", "))
+            }
+            EthereumSqlTypeWrapper::I256Numeric(val) => val.to_string(),
+
+            // U256Bytes / I256Bytes / AddressBytes — serialize as hex string
+            EthereumSqlTypeWrapper::U256Bytes(val)
+            | EthereumSqlTypeWrapper::U256BytesNullable(val) => format!("'{val}'"),
+            EthereumSqlTypeWrapper::VecU256Bytes(values) => {
+                format!(
+                    "[{}]",
+                    values.iter().map(|v| format!("'{v}'")).collect::<Vec<_>>().join(", ")
+                )
+            }
+            EthereumSqlTypeWrapper::I256Bytes(val)
+            | EthereumSqlTypeWrapper::I256BytesNullable(val) => format!("'{val}'"),
+            EthereumSqlTypeWrapper::B256Bytes(val) => format!("'{val:?}'"),
+            EthereumSqlTypeWrapper::VecB256Bytes(values) => format!(
+                "[{}]",
+                values.iter().map(|v| format!("'{v:?}'")).collect::<Vec<_>>().join(", ")
+            ),
+            EthereumSqlTypeWrapper::VecI256Bytes(values) => format!(
+                "[{}]",
+                values.iter().map(|v| format!("'{v}'")).collect::<Vec<_>>().join(", ")
+            ),
+            EthereumSqlTypeWrapper::AddressBytes(val)
+            | EthereumSqlTypeWrapper::AddressBytesNullable(val) => format!("'{val}'"),
+            EthereumSqlTypeWrapper::VecAddressBytes(values) => format!(
+                "[{}]",
+                values.iter().map(|v| format!("'{v}'")).collect::<Vec<_>>().join(", ")
+            ),
+
+            // Remaining PG-only types
+            EthereumSqlTypeWrapper::Uuid(_) | EthereumSqlTypeWrapper::JSONB(_) => {
                 panic!(
-                    "Clickhouse in no-code should never encounter these types. Clickhouse rust projects should use prefer the native-protocol. Unsupported '{}' EthereumSqlTypeWrapper variant for ClickHouse serialization",
+                    "Unsupported '{}' EthereumSqlTypeWrapper variant for ClickHouse serialization",
                     self.raw_name()
                 )
             }
@@ -2278,5 +2305,273 @@ mod tests {
             }
             other => panic!("Expected JSONB wrapper, got {:?}", other),
         }
+    }
+
+    // =========================================================================
+    // to_clickhouse_value() — PG-specific wrappers that previously panicked
+    // when used with ClickHouse no-code tables.
+    // =========================================================================
+
+    #[test]
+    fn test_ch_u256_numeric_serializes_as_decimal_string() {
+        let val = U256::from(1_500_000u64);
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(val);
+        assert_eq!(wrapper.to_clickhouse_value(), "1500000");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_zero() {
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::ZERO);
+        assert_eq!(wrapper.to_clickhouse_value(), "0");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_large_value() {
+        let val = U256::from(1_000_000_000_000_000u64);
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(val);
+        assert_eq!(wrapper.to_clickhouse_value(), "1000000000000000");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_nullable_some() {
+        let wrapper = EthereumSqlTypeWrapper::U256NumericNullable(Some(U256::from(42u64)));
+        assert_eq!(wrapper.to_clickhouse_value(), "42");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_nullable_none() {
+        let wrapper = EthereumSqlTypeWrapper::U256NumericNullable(None);
+        assert_eq!(wrapper.to_clickhouse_value(), "NULL");
+    }
+
+    #[test]
+    fn test_ch_vec_u256_numeric() {
+        let vals = vec![U256::from(100u64), U256::from(200u64), U256::from(300u64)];
+        let wrapper = EthereumSqlTypeWrapper::VecU256Numeric(vals);
+        assert_eq!(wrapper.to_clickhouse_value(), "[100, 200, 300]");
+    }
+
+    #[test]
+    fn test_ch_i256_numeric() {
+        let val = I256::try_from(-42i64).unwrap();
+        let wrapper = EthereumSqlTypeWrapper::I256Numeric(val);
+        assert_eq!(wrapper.to_clickhouse_value(), "-42");
+    }
+
+    #[test]
+    fn test_ch_u256_bytes() {
+        let val = U256::from(0xDEADBEEFu64);
+        let wrapper = EthereumSqlTypeWrapper::U256Bytes(val);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''), "U256Bytes should be quoted: {result}");
+        assert!(result.ends_with('\''), "U256Bytes should be quoted: {result}");
+    }
+
+    #[test]
+    fn test_ch_u256_bytes_nullable() {
+        let val = U256::from(123u64);
+        let wrapper = EthereumSqlTypeWrapper::U256BytesNullable(val);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+    }
+
+    #[test]
+    fn test_ch_i256_bytes() {
+        let val = I256::try_from(99i64).unwrap();
+        let wrapper = EthereumSqlTypeWrapper::I256Bytes(val);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+    }
+
+    #[test]
+    fn test_ch_address_bytes() {
+        let addr = Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
+        let wrapper = EthereumSqlTypeWrapper::AddressBytes(addr);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.contains("0x1234567890123456789012345678901234567890"));
+    }
+
+    #[test]
+    fn test_ch_address_bytes_nullable() {
+        let addr = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+        let wrapper = EthereumSqlTypeWrapper::AddressBytesNullable(addr);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+    }
+
+    #[test]
+    fn test_ch_b256_bytes() {
+        let hash =
+            B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let wrapper = EthereumSqlTypeWrapper::B256Bytes(hash);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+    }
+
+    #[test]
+    fn test_ch_regular_u256_unchanged() {
+        let wrapper = EthereumSqlTypeWrapper::U256(U256::from(999u64));
+        assert_eq!(wrapper.to_clickhouse_value(), "999");
+    }
+
+    #[test]
+    fn test_ch_u64_bigint() {
+        let wrapper = EthereumSqlTypeWrapper::U64BigInt(12345678u64);
+        assert_eq!(wrapper.to_clickhouse_value(), "12345678");
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported")]
+    fn test_ch_jsonb_panics() {
+        EthereumSqlTypeWrapper::JSONB(serde_json::json!({"k": "v"})).to_clickhouse_value();
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported")]
+    fn test_ch_uuid_panics() {
+        EthereumSqlTypeWrapper::Uuid(uuid::Uuid::new_v4()).to_clickhouse_value();
+    }
+
+    // =========================================================================
+    // Edge cases and round-trip validation
+    // =========================================================================
+
+    #[test]
+    fn test_ch_u256_numeric_max_value() {
+        // U256::MAX = 2^256 - 1 — must not overflow or truncate
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::MAX);
+        let result = wrapper.to_clickhouse_value();
+        assert_eq!(
+            result,
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        );
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_one_wei() {
+        // Smallest non-zero value — must not be lost
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::from(1u64));
+        assert_eq!(wrapper.to_clickhouse_value(), "1");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_typical_usdc_amount() {
+        // 1.5 USDC = 1_500_000 raw (6 decimals) — stored as-is, NOT pre-divided
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::from(1_500_000u64));
+        assert_eq!(wrapper.to_clickhouse_value(), "1500000");
+        // Downstream CH MV will do: toFloat64('1500000') / 1e6 = 1.5
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_sub_one_usdc() {
+        // 0.5 USDC = 500_000 raw — this is the value that broke with integer division
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::from(500_000u64));
+        assert_eq!(wrapper.to_clickhouse_value(), "500000");
+    }
+
+    #[test]
+    fn test_ch_i256_numeric_negative() {
+        let val = I256::try_from(-1_000_000i64).unwrap();
+        let wrapper = EthereumSqlTypeWrapper::I256Numeric(val);
+        assert_eq!(wrapper.to_clickhouse_value(), "-1000000");
+    }
+
+    #[test]
+    fn test_ch_i256_numeric_min_value() {
+        let wrapper = EthereumSqlTypeWrapper::I256Numeric(I256::MIN);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('-'));
+        assert!(result.len() > 10); // large number
+    }
+
+    #[test]
+    fn test_ch_address_bytes_is_checksummed() {
+        // rindexer outputs EIP-55 checksummed addresses
+        let addr = Address::from_str("0xe111180000d2663C0091e4f400237545B87B996B").unwrap();
+        let wrapper = EthereumSqlTypeWrapper::AddressBytes(addr);
+        let result = wrapper.to_clickhouse_value();
+        // Should preserve the checksummed format (transform MV will lower() it)
+        assert!(result.contains("0x"));
+        assert_eq!(result.len(), 44); // 42 chars + 2 quotes
+    }
+
+    #[test]
+    fn test_ch_vec_address_bytes() {
+        let addr1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        let addr2 = Address::from_str("0x2222222222222222222222222222222222222222").unwrap();
+        let wrapper = EthereumSqlTypeWrapper::VecAddressBytes(vec![addr1, addr2]);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('['));
+        assert!(result.ends_with(']'));
+        assert!(result.contains("0x1111"));
+        assert!(result.contains("0x2222"));
+    }
+
+    #[test]
+    fn test_ch_b256_bytes_hash() {
+        let hash =
+            B256::from_str("0xabcdef0000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let wrapper = EthereumSqlTypeWrapper::B256Bytes(hash);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+        assert!(result.contains("0xabcdef"));
+    }
+
+    #[test]
+    fn test_ch_vec_b256_bytes() {
+        let h1 =
+            B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let h2 =
+            B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000002")
+                .unwrap();
+        let wrapper = EthereumSqlTypeWrapper::VecB256Bytes(vec![h1, h2]);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('['));
+        assert!(result.ends_with(']'));
+    }
+
+    #[test]
+    fn test_ch_vec_i256_bytes() {
+        let v1 = I256::try_from(42i64).unwrap();
+        let v2 = I256::try_from(-99i64).unwrap();
+        let wrapper = EthereumSqlTypeWrapper::VecI256Bytes(vec![v1, v2]);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('['));
+    }
+
+    #[test]
+    fn test_ch_null_value() {
+        let wrapper = EthereumSqlTypeWrapper::Null;
+        assert_eq!(wrapper.to_clickhouse_value(), "NULL");
+    }
+
+    // =========================================================================
+    // Consistency: U256 (raw event) vs U256Numeric (table expression) produce
+    // the same CH value — they wrap the same alloy U256, just different enum variants.
+    // =========================================================================
+
+    #[test]
+    fn test_ch_u256_and_u256_numeric_produce_same_output() {
+        let val = U256::from(123_456_789u64);
+        let raw = EthereumSqlTypeWrapper::U256(val);
+        let numeric = EthereumSqlTypeWrapper::U256Numeric(val);
+        assert_eq!(raw.to_clickhouse_value(), numeric.to_clickhouse_value());
+    }
+
+    #[test]
+    fn test_ch_u256_and_u256_numeric_zero_same() {
+        let raw = EthereumSqlTypeWrapper::U256(U256::ZERO);
+        let numeric = EthereumSqlTypeWrapper::U256Numeric(U256::ZERO);
+        assert_eq!(raw.to_clickhouse_value(), numeric.to_clickhouse_value());
+    }
+
+    #[test]
+    fn test_ch_u256_and_u256_numeric_max_same() {
+        let raw = EthereumSqlTypeWrapper::U256(U256::MAX);
+        let numeric = EthereumSqlTypeWrapper::U256Numeric(U256::MAX);
+        assert_eq!(raw.to_clickhouse_value(), numeric.to_clickhouse_value());
     }
 }

--- a/core/src/manifest/contract.rs
+++ b/core/src/manifest/contract.rs
@@ -799,20 +799,23 @@ impl ColumnType {
         }
     }
 
-    /// Convert to ClickHouse type
+    /// Convert to ClickHouse type.
+    /// Uses native CH types matching `solidity_type_to_clickhouse_type()` for raw event tables.
     pub fn to_clickhouse_type(&self) -> String {
         match self {
             ColumnType::Uint8 => "UInt8".to_string(),
             ColumnType::Uint16 => "UInt16".to_string(),
             ColumnType::Uint32 => "UInt32".to_string(),
             ColumnType::Uint64 => "UInt64".to_string(),
-            ColumnType::Uint128 | ColumnType::Uint256 => "String".to_string(),
+            ColumnType::Uint128 => "UInt128".to_string(),
+            ColumnType::Uint256 => "UInt256".to_string(),
             ColumnType::Int8 => "Int8".to_string(),
             ColumnType::Int16 => "Int16".to_string(),
             ColumnType::Int32 => "Int32".to_string(),
             ColumnType::Int64 => "Int64".to_string(),
-            ColumnType::Int128 | ColumnType::Int256 => "String".to_string(),
-            ColumnType::Address => "String".to_string(),
+            ColumnType::Int128 => "Int128".to_string(),
+            ColumnType::Int256 => "Int256".to_string(),
+            ColumnType::Address => "FixedString(42)".to_string(),
             ColumnType::Bytes | ColumnType::Bytes32 => "String".to_string(),
             ColumnType::String => "String".to_string(),
             ColumnType::Bool => "Bool".to_string(),
@@ -1551,5 +1554,85 @@ mod tests {
         let result = Table::infer_type_from_value("$rindexer_block_number", None);
         // Should return the metadata field's type (u64 → Uint64)
         assert!(result.is_some());
+    }
+
+    // =========================================================================
+    // ClickHouse type mapping — native types instead of String fallback
+    // =========================================================================
+
+    #[test]
+    fn test_ch_type_uint256_is_native() {
+        assert_eq!(ColumnType::Uint256.to_clickhouse_type(), "UInt256");
+    }
+
+    #[test]
+    fn test_ch_type_uint128_is_native() {
+        assert_eq!(ColumnType::Uint128.to_clickhouse_type(), "UInt128");
+    }
+
+    #[test]
+    fn test_ch_type_int256_is_native() {
+        assert_eq!(ColumnType::Int256.to_clickhouse_type(), "Int256");
+    }
+
+    #[test]
+    fn test_ch_type_int128_is_native() {
+        assert_eq!(ColumnType::Int128.to_clickhouse_type(), "Int128");
+    }
+
+    #[test]
+    fn test_ch_type_address_is_fixed_string() {
+        assert_eq!(ColumnType::Address.to_clickhouse_type(), "FixedString(42)");
+    }
+
+    #[test]
+    fn test_ch_type_uint64_unchanged() {
+        assert_eq!(ColumnType::Uint64.to_clickhouse_type(), "UInt64");
+    }
+
+    #[test]
+    fn test_ch_type_int64_unchanged() {
+        assert_eq!(ColumnType::Int64.to_clickhouse_type(), "Int64");
+    }
+
+    #[test]
+    fn test_ch_type_bool_unchanged() {
+        assert_eq!(ColumnType::Bool.to_clickhouse_type(), "Bool");
+    }
+
+    #[test]
+    fn test_ch_type_string_unchanged() {
+        assert_eq!(ColumnType::String.to_clickhouse_type(), "String");
+    }
+
+    #[test]
+    fn test_ch_type_array_uses_native_inner() {
+        let arr = ColumnType::Array(Box::new(ColumnType::Uint256));
+        assert_eq!(arr.to_clickhouse_type(), "Array(UInt256)");
+    }
+
+    #[test]
+    fn test_ch_type_matches_solidity_raw_event_mapping() {
+        // Custom table types must match raw event table types for consistency.
+        // Raw events: solidity_type_to_clickhouse_type("uint256") → "UInt256"
+        // Custom tables: ColumnType::Uint256.to_clickhouse_type() → should also be "UInt256"
+        assert_eq!(ColumnType::Uint256.to_clickhouse_type(), "UInt256");
+        assert_eq!(ColumnType::Uint128.to_clickhouse_type(), "UInt128");
+        assert_eq!(ColumnType::Int256.to_clickhouse_type(), "Int256");
+        assert_eq!(ColumnType::Int128.to_clickhouse_type(), "Int128");
+    }
+
+    // =========================================================================
+    // PostgreSQL type mapping — sanity checks (shouldn't change)
+    // =========================================================================
+
+    #[test]
+    fn test_pg_type_uint256_is_numeric() {
+        assert_eq!(ColumnType::Uint256.to_postgres_type(), "NUMERIC");
+    }
+
+    #[test]
+    fn test_pg_type_address_is_char42() {
+        assert_eq!(ColumnType::Address.to_postgres_type(), "CHAR(42)");
     }
 }

--- a/core/tests/clickhouse_type_e2e.rs
+++ b/core/tests/clickhouse_type_e2e.rs
@@ -1,0 +1,277 @@
+/// E2E validation tests for ClickHouse type handling.
+///
+/// Unit tests (no CH needed): validate type mapping and serialization consistency.
+/// Integration tests (#[ignore]): validate full round-trip against a real ClickHouse.
+///
+/// Run unit tests:  cargo test -p rindexer --test clickhouse_type_e2e
+/// Run E2E tests:   cargo test -p rindexer --test clickhouse_type_e2e -- --ignored
+///
+/// E2E setup:
+///   docker run -d --name ch-test -p 8123:8123 clickhouse/clickhouse-server:24.8
+use rindexer::manifest::contract::ColumnType;
+
+// =========================================================================
+// Unit tests — type mapping consistency
+// =========================================================================
+
+#[test]
+fn test_custom_table_types_match_raw_event_types() {
+    // Custom table path (ColumnType::to_clickhouse_type) must produce the same
+    // CH types as raw event path (solidity_type_to_clickhouse_type).
+    // This ensures a uint256 column in a YAML table creates the same CH column
+    // as a uint256 ABI field in a raw event table.
+    assert_eq!(ColumnType::Uint256.to_clickhouse_type(), "UInt256");
+    assert_eq!(ColumnType::Uint128.to_clickhouse_type(), "UInt128");
+    assert_eq!(ColumnType::Int256.to_clickhouse_type(), "Int256");
+    assert_eq!(ColumnType::Int128.to_clickhouse_type(), "Int128");
+    assert_eq!(ColumnType::Address.to_clickhouse_type(), "FixedString(42)");
+    assert_eq!(ColumnType::Uint64.to_clickhouse_type(), "UInt64");
+    assert_eq!(ColumnType::Int64.to_clickhouse_type(), "Int64");
+    assert_eq!(ColumnType::Uint8.to_clickhouse_type(), "UInt8");
+    assert_eq!(ColumnType::Bool.to_clickhouse_type(), "Bool");
+    assert_eq!(ColumnType::String.to_clickhouse_type(), "String");
+    assert_eq!(ColumnType::Timestamp.to_clickhouse_type(), "DateTime('UTC')");
+}
+
+#[test]
+fn test_array_types_use_native_inner() {
+    let u256_arr = ColumnType::Array(Box::new(ColumnType::Uint256));
+    assert_eq!(u256_arr.to_clickhouse_type(), "Array(UInt256)");
+
+    let addr_arr = ColumnType::Array(Box::new(ColumnType::Address));
+    assert_eq!(addr_arr.to_clickhouse_type(), "Array(FixedString(42))");
+}
+
+#[test]
+fn test_pg_types_unchanged() {
+    // Ensure PG mapping wasn't broken by the CH fix
+    assert_eq!(ColumnType::Uint256.to_postgres_type(), "NUMERIC");
+    assert_eq!(ColumnType::Uint128.to_postgres_type(), "NUMERIC");
+    assert_eq!(ColumnType::Int256.to_postgres_type(), "NUMERIC");
+    assert_eq!(ColumnType::Address.to_postgres_type(), "CHAR(42)");
+    assert_eq!(ColumnType::Uint64.to_postgres_type(), "BIGINT");
+}
+
+#[test]
+fn test_ddl_for_activities_raw_table() {
+    // Simulate what rindexer would generate for our rindexer-ch.yaml activities_raw table
+    let columns: Vec<(&str, ColumnType)> = vec![
+        ("id", ColumnType::Uint64),
+        ("block_number", ColumnType::Uint64),
+        ("block_timestamp", ColumnType::Uint64),
+        ("transaction_hash", ColumnType::String),
+        ("address", ColumnType::Address),
+        ("user_id", ColumnType::Address),
+        ("asset", ColumnType::String),
+        ("condition_id", ColumnType::String),
+        ("neg_risk_market_id", ColumnType::String),
+        ("amount_usdc", ColumnType::Uint256),
+        ("amount_shares", ColumnType::Uint256),
+        ("tx_type", ColumnType::String),
+        ("side", ColumnType::String),
+        ("order_hash", ColumnType::String),
+        ("counterparty_id", ColumnType::Address),
+        ("order_type", ColumnType::String),
+        ("fee", ColumnType::Uint256),
+        ("builder", ColumnType::String),
+        ("is_deleted", ColumnType::Uint8),
+    ];
+
+    let ddl_parts: Vec<String> = columns
+        .iter()
+        .map(|(name, ct)| format!("  `{}` {}", name, ct.to_clickhouse_type()))
+        .collect();
+    let ddl = format!(
+        "CREATE TABLE test.activities_raw (\n{}\n) ENGINE = MergeTree() ORDER BY id",
+        ddl_parts.join(",\n")
+    );
+
+    // Verify key types in DDL
+    assert!(ddl.contains("`amount_usdc` UInt256"), "amount_usdc should be UInt256, got:\n{ddl}");
+    assert!(ddl.contains("`amount_shares` UInt256"), "amount_shares should be UInt256");
+    assert!(ddl.contains("`fee` UInt256"), "fee should be UInt256");
+    assert!(ddl.contains("`address` FixedString(42)"), "address should be FixedString(42)");
+    assert!(ddl.contains("`user_id` FixedString(42)"), "user_id should be FixedString(42)");
+    assert!(ddl.contains("`id` UInt64"), "id should be UInt64");
+    assert!(ddl.contains("`is_deleted` UInt8"), "is_deleted should be UInt8");
+
+    // Verify no String fallback for numeric/address types
+    assert!(!ddl.contains("`amount_usdc` String"), "amount_usdc must NOT be String");
+    assert!(!ddl.contains("`address` String"), "address must NOT be String");
+}
+
+// =========================================================================
+// E2E tests — require running ClickHouse (run with --ignored)
+// =========================================================================
+
+#[cfg(test)]
+fn ch_query(query: &str) -> Result<String, String> {
+    use std::io::Read;
+    let url =
+        std::env::var("CLICKHOUSE_URL").unwrap_or_else(|_| "http://localhost:8123".to_string());
+    let user = std::env::var("CLICKHOUSE_USER").unwrap_or_else(|_| "default".to_string());
+    let password = std::env::var("CLICKHOUSE_PASSWORD").unwrap_or_default();
+
+    let full_url = format!("{}/?user={}&password={}", url, user, password);
+    let mut handle = std::process::Command::new("curl")
+        .args(["-sf", "--data-binary", query, &full_url])
+        .output()
+        .map_err(|e| format!("curl failed: {e}"))?;
+
+    if handle.status.success() {
+        Ok(String::from_utf8_lossy(&handle.stdout).trim().to_string())
+    } else {
+        Err(format!("CH error: {}", String::from_utf8_lossy(&handle.stderr).trim()))
+    }
+}
+
+#[test]
+#[ignore]
+fn test_e2e_native_types_create_and_insert() {
+    let db = "rindexer_e2e_types";
+
+    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
+    ch_query(&format!("CREATE DATABASE {db}")).unwrap();
+
+    // DDL with native types (what rindexer now generates)
+    ch_query(&format!(
+        "CREATE TABLE {db}.activities_raw (
+            id UInt64,
+            block_number UInt64,
+            address FixedString(42),
+            user_id FixedString(42),
+            amount_usdc UInt256,
+            amount_shares UInt256,
+            fee UInt256,
+            tx_type String,
+            side String,
+            is_deleted UInt8
+        ) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    // Insert with decimal string values for UInt256 (same as rindexer serialization)
+    ch_query(&format!(
+        "INSERT INTO {db}.activities_raw VALUES \
+        (1, 85267446, '0xe111180000d2663C0091e4f400237545B87B996B', \
+        '0x1234567890123456789012345678901234567890', \
+        1500000, 2000000, 30000, 'TRADE', 'BUY', 0)"
+    ))
+    .unwrap();
+
+    // Verify Float64 division on UInt256 (the core of our transform MV pattern)
+    let usdc =
+        ch_query(&format!("SELECT toFloat64(amount_usdc) / 1e6 FROM {db}.activities_raw")).unwrap();
+    assert_eq!(usdc, "1.5");
+
+    let price = ch_query(&format!(
+        "SELECT toFloat64(amount_usdc) / toFloat64(amount_shares) FROM {db}.activities_raw"
+    ))
+    .unwrap();
+    assert_eq!(price, "0.75");
+
+    // Verify lower() on FixedString(42) addresses
+    let addr = ch_query(&format!("SELECT lower(address) FROM {db}.activities_raw")).unwrap();
+    assert_eq!(addr, "0xe111180000d2663c0091e4f400237545b87b996b");
+
+    ch_query(&format!("DROP DATABASE {db}")).unwrap();
+}
+
+#[test]
+#[ignore]
+fn test_e2e_transform_mv_pipeline() {
+    let db = "rindexer_e2e_mv";
+
+    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
+    ch_query(&format!("CREATE DATABASE {db}")).unwrap();
+
+    // Raw table
+    ch_query(&format!(
+        "CREATE TABLE {db}.raw (
+            id UInt64, amount_usdc UInt256, amount_shares UInt256,
+            tx_type String, address FixedString(42), fee UInt256, is_deleted UInt8
+        ) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    // Transformed table
+    ch_query(&format!(
+        "CREATE TABLE {db}.trades (
+            id String, amount_usdc Float64, shares Float64,
+            price_usdc Float64, fee Float64, is_deleted UInt8
+        ) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    // Streaming MV — use _raw suffixed names to avoid alias shadowing,
+    // then rename in the outer expression. This is the pattern our production
+    // MVs must use when amount_usdc alias shadows the source column.
+    ch_query(&format!(
+        "CREATE MATERIALIZED VIEW {db}.mv_transform TO {db}.trades AS
+        SELECT
+            toString(id) AS id,
+            toFloat64(_raw_usdc) / 1e6 AS amount_usdc,
+            toFloat64(_raw_shares) / 1e6 AS shares,
+            if(_raw_shares = toUInt256(0), toFloat64(0),
+               toFloat64(_raw_usdc) / toFloat64(_raw_shares)) AS price_usdc,
+            if(lower(address) IN (
+                '0xe111180000d2663c0091e4f400237545b87b996b',
+                '0xe2222d002000ba0053cef3375333610f64600036'
+            ), toFloat64(fee) / 1e6, 0) AS fee,
+            is_deleted
+        FROM (
+            SELECT *, amount_usdc AS _raw_usdc, amount_shares AS _raw_shares
+            FROM {db}.raw
+            WHERE tx_type = 'TRADE'
+        )"
+    ))
+    .unwrap();
+
+    // Insert raw data
+    ch_query(&format!(
+        "INSERT INTO {db}.raw VALUES \
+        (1, 1500000, 2000000, 'TRADE', '0xe111180000d2663C0091e4f400237545B87B996B', 30000, 0), \
+        (2, 500000, 1000000, 'TRADE', '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E', 10000, 0), \
+        (3, 750000, 750000, 'SPLIT', '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045', 0, 0)"
+    ))
+    .unwrap();
+
+    // MV should only capture TRADE rows
+    let count = ch_query(&format!("SELECT count() FROM {db}.trades")).unwrap();
+    assert_eq!(count, "2");
+
+    // Row 1: V2 address → fee applied
+    let r1 = ch_query(&format!(
+        "SELECT amount_usdc, shares, price_usdc, fee FROM {db}.trades WHERE id = '1'"
+    ))
+    .unwrap();
+    assert_eq!(r1, "1.5\t2\t0.75\t0.03");
+
+    // Row 2: V1 address → fee = 0
+    let r2 = ch_query(&format!(
+        "SELECT amount_usdc, shares, price_usdc, fee FROM {db}.trades WHERE id = '2'"
+    ))
+    .unwrap();
+    assert_eq!(r2, "0.5\t1\t0.5\t0");
+
+    ch_query(&format!("DROP DATABASE {db}")).unwrap();
+}
+
+#[test]
+#[ignore]
+fn test_e2e_uint256_max_roundtrip() {
+    let db = "rindexer_e2e_max";
+    let max_str = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
+    ch_query(&format!("CREATE DATABASE {db}")).unwrap();
+    ch_query(&format!("CREATE TABLE {db}.t (val UInt256) ENGINE = MergeTree() ORDER BY val"))
+        .unwrap();
+
+    ch_query(&format!("INSERT INTO {db}.t VALUES ({max_str})")).unwrap();
+
+    let result = ch_query(&format!("SELECT val FROM {db}.t")).unwrap();
+    assert_eq!(result, max_str, "U256::MAX must survive CH round-trip");
+
+    ch_query(&format!("DROP DATABASE {db}")).unwrap();
+}

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -6,6 +6,9 @@
 ### Bug fixes
 -------------------------------------------------
 
+- fix: **ClickHouse no-code tables now use native types** — `uint256` columns map to `UInt256` (was `String`), `uint128` to `UInt128`, `int256` to `Int256`, `int128` to `Int128`, and `address` to `FixedString(42)` (was `String`). Custom table types now match raw event table types (`solidity_type_to_clickhouse_type`), ensuring consistent schemas across the same rindexer project.
+- fix: **ClickHouse serialization no longer panics on PG-specific type wrappers** — `U256Numeric`, `I256Numeric`, `U256Bytes`, `I256Bytes`, `AddressBytes`, and their Nullable/Vec variants are now serialized correctly for ClickHouse instead of panicking with `"Clickhouse in no-code should never encounter these types"`. This enables no-code tables with `$if()` conditions, arithmetic expressions, and direct `uint256`/`address` field references to work with the ClickHouse storage backend. Previously, any computed value or conditional expression in a no-code table would crash when writing to ClickHouse.
+
 ### Features
 -------------------------------------------------
 


### PR DESCRIPTION
Fix two issues that prevented rindexer no-code tables from working with ClickHouse:
  1. Native CH type mapping : `to_clickhouse_type()` now produces `UInt256, UInt128, Int256, Int128, FixedString(42)  `   
  instead of falling back to String. Custom table types now match raw event table types
  (`solidity_type_to_clickhouse_type`).
  2. Serialization panic fix: `to_clickhouse_value()` now handles PG-specific wrappers (```
U256Numeric, I256Numeric,
  U256Bytes, AddressBytes, and Nullable/Vec 
```variants) instead of panicking with "Clickhouse in no-code should never   
  encounter these types". These wrappers are produced by the expression evaluator for $if() conditions, arithmetic,
  and direct uint256/address field references.                                                                        



Root cause: The expression evaluator always wraps computed values as `U256Numeric` (designed for PG NUMERIC columns). 
The CH serialization path had no handler for these: only for the U256 variant used by raw event tables. The type mapping similarly only handled types up to UInt64 natively, falling back to String for larger integers.   