### PR TITLE
feat: Add database field to custom tables: shared database override

### DIFF
--- a/core/src/database/clickhouse/generate.rs
+++ b/core/src/database/clickhouse/generate.rs
@@ -49,7 +49,7 @@ pub fn generate_tables_for_indexer_clickhouse(
 
             // Generate custom tables if defined
             if let Some(tables) = &contract.tables {
-                sql.push_str(&generate_tables_clickhouse(tables, &schema_name, &indexer.name));
+                sql.push_str(&generate_tables_clickhouse(tables, &schema_name));
             }
         }
 
@@ -106,7 +106,7 @@ fn generate_event_table_clickhouse(abi_inputs: &[EventInfo], schema_name: &str) 
 }
 
 /// Generate ClickHouse SQL for custom tables
-fn generate_tables_clickhouse(tables: &[Table], schema_name: &str, indexer_name: &str) -> String {
+fn generate_tables_clickhouse(tables: &[Table], schema_name: &str) -> String {
     tables
         .iter()
         .map(|table| {

--- a/core/src/database/clickhouse/generate.rs
+++ b/core/src/database/clickhouse/generate.rs
@@ -173,9 +173,13 @@ fn generate_tables_clickhouse(tables: &[Table], schema_name: &str) -> String {
                 }
             }
 
-            // Use ReplacingMergeTree with rindexer_sequence_id as version column
-            let engine =
-                format!("ReplacingMergeTree(`{}`)", injected_columns::RINDEXER_SEQUENCE_ID);
+            // Insert-only tables use MergeTree (no dedup needed — each row is unique).
+            // Tables with upsert/update/delete use ReplacingMergeTree for deduplication.
+            let engine = if table.is_insert_only() {
+                "MergeTree()".to_string()
+            } else {
+                format!("ReplacingMergeTree(`{}`)", injected_columns::RINDEXER_SEQUENCE_ID)
+            };
 
             format!(
                 "CREATE TABLE IF NOT EXISTS {} ({}) ENGINE = {} ORDER BY ({});",

--- a/core/src/database/clickhouse/generate.rs
+++ b/core/src/database/clickhouse/generate.rs
@@ -49,7 +49,7 @@ pub fn generate_tables_for_indexer_clickhouse(
 
             // Generate custom tables if defined
             if let Some(tables) = &contract.tables {
-                sql.push_str(&generate_tables_clickhouse(tables, &schema_name));
+                sql.push_str(&generate_tables_clickhouse(tables, &schema_name, &indexer.name));
             }
         }
 
@@ -106,11 +106,19 @@ fn generate_event_table_clickhouse(abi_inputs: &[EventInfo], schema_name: &str) 
 }
 
 /// Generate ClickHouse SQL for custom tables
-fn generate_tables_clickhouse(tables: &[Table], schema_name: &str) -> String {
+fn generate_tables_clickhouse(tables: &[Table], schema_name: &str, indexer_name: &str) -> String {
     tables
         .iter()
         .map(|table| {
-            let table_name = format!("{}.{}", schema_name, camel_to_snake(&table.name));
+            let effective_db = table.database.as_deref().unwrap_or(schema_name);
+            let table_name = format!("{}.{}", effective_db, camel_to_snake(&table.name));
+
+            // Create database if using a custom override (the default per-contract DB is created above)
+            let mut create_db = String::new();
+            if table.database.is_some() {
+                create_db = format!("CREATE DATABASE IF NOT EXISTS {};", effective_db);
+                info!("Creating database if not exists: {} (custom table override)", effective_db);
+            }
             info!("Creating custom table if not exists: {}", table_name);
 
             // Build column definitions
@@ -182,7 +190,8 @@ fn generate_tables_clickhouse(tables: &[Table], schema_name: &str) -> String {
             };
 
             format!(
-                "CREATE TABLE IF NOT EXISTS {} ({}) ENGINE = {} ORDER BY ({});",
+                "{}CREATE TABLE IF NOT EXISTS {} ({}) ENGINE = {} ORDER BY ({});",
+                create_db,
                 table_name,
                 columns.join(", "),
                 engine,

--- a/core/src/database/generate.rs
+++ b/core/src/database/generate.rs
@@ -283,8 +283,12 @@ pub fn generate_table_full_name(
     indexer_name: &str,
     contract_name: &str,
     table_name: &str,
+    database_override: Option<&str>,
 ) -> String {
-    let schema_name = generate_indexer_contract_schema_name(indexer_name, contract_name);
+    let schema_name = match database_override {
+        Some(db) => db.to_string(),
+        None => generate_indexer_contract_schema_name(indexer_name, contract_name),
+    };
     format!("{}.{}", schema_name, camel_to_snake(table_name))
 }
 

--- a/core/src/database/sql_type_wrapper.rs
+++ b/core/src/database/sql_type_wrapper.rs
@@ -513,25 +513,52 @@ impl EthereumSqlTypeWrapper {
                 format!("[{}]", values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", "))
             }
 
-            EthereumSqlTypeWrapper::Uuid(_)
-            | EthereumSqlTypeWrapper::VecB256Bytes(_)
-            | EthereumSqlTypeWrapper::VecI256Bytes(_)
-            | EthereumSqlTypeWrapper::B256Bytes(_)
-            | EthereumSqlTypeWrapper::JSONB(_)
-            | EthereumSqlTypeWrapper::U256Numeric(_)
-            | EthereumSqlTypeWrapper::U256NumericNullable(_)
-            | EthereumSqlTypeWrapper::VecU256Bytes(_)
-            | EthereumSqlTypeWrapper::VecU256Numeric(_)
-            | EthereumSqlTypeWrapper::U256Bytes(_)
-            | EthereumSqlTypeWrapper::U256BytesNullable(_)
-            | EthereumSqlTypeWrapper::I256Numeric(_)
-            | EthereumSqlTypeWrapper::AddressBytes(_)
-            | EthereumSqlTypeWrapper::AddressBytesNullable(_)
-            | EthereumSqlTypeWrapper::VecAddressBytes(_)
-            | EthereumSqlTypeWrapper::I256Bytes(_)
-            | EthereumSqlTypeWrapper::I256BytesNullable(_) => {
+            // PostgreSQL-specific Numeric wrappers — serialize as string for ClickHouse.
+            // These are produced by the expression evaluator and field resolver which
+            // always wrap U256 values as U256Numeric (designed for PG NUMERIC columns).
+            // For ClickHouse, the target column is String (uint256 → String mapping),
+            // so .to_string() produces the correct decimal representation.
+            EthereumSqlTypeWrapper::U256Numeric(val) => val.to_string(),
+            EthereumSqlTypeWrapper::U256NumericNullable(val) => match val {
+                Some(v) => v.to_string(),
+                None => "NULL".to_string(),
+            },
+            EthereumSqlTypeWrapper::VecU256Numeric(values) => {
+                format!("[{}]", values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", "))
+            }
+            EthereumSqlTypeWrapper::I256Numeric(val) => val.to_string(),
+
+            // U256Bytes / I256Bytes / AddressBytes — serialize as hex string
+            EthereumSqlTypeWrapper::U256Bytes(val)
+            | EthereumSqlTypeWrapper::U256BytesNullable(val) => format!("'{val}'"),
+            EthereumSqlTypeWrapper::VecU256Bytes(values) => {
+                format!(
+                    "[{}]",
+                    values.iter().map(|v| format!("'{v}'")).collect::<Vec<_>>().join(", ")
+                )
+            }
+            EthereumSqlTypeWrapper::I256Bytes(val)
+            | EthereumSqlTypeWrapper::I256BytesNullable(val) => format!("'{val}'"),
+            EthereumSqlTypeWrapper::B256Bytes(val) => format!("'{val:?}'"),
+            EthereumSqlTypeWrapper::VecB256Bytes(values) => format!(
+                "[{}]",
+                values.iter().map(|v| format!("'{v:?}'")).collect::<Vec<_>>().join(", ")
+            ),
+            EthereumSqlTypeWrapper::VecI256Bytes(values) => format!(
+                "[{}]",
+                values.iter().map(|v| format!("'{v}'")).collect::<Vec<_>>().join(", ")
+            ),
+            EthereumSqlTypeWrapper::AddressBytes(val)
+            | EthereumSqlTypeWrapper::AddressBytesNullable(val) => format!("'{val}'"),
+            EthereumSqlTypeWrapper::VecAddressBytes(values) => format!(
+                "[{}]",
+                values.iter().map(|v| format!("'{v}'")).collect::<Vec<_>>().join(", ")
+            ),
+
+            // Remaining PG-only types
+            EthereumSqlTypeWrapper::Uuid(_) | EthereumSqlTypeWrapper::JSONB(_) => {
                 panic!(
-                    "Clickhouse in no-code should never encounter these types. Clickhouse rust projects should use prefer the native-protocol. Unsupported '{}' EthereumSqlTypeWrapper variant for ClickHouse serialization",
+                    "Unsupported '{}' EthereumSqlTypeWrapper variant for ClickHouse serialization",
                     self.raw_name()
                 )
             }
@@ -2278,5 +2305,273 @@ mod tests {
             }
             other => panic!("Expected JSONB wrapper, got {:?}", other),
         }
+    }
+
+    // =========================================================================
+    // to_clickhouse_value() — PG-specific wrappers that previously panicked
+    // when used with ClickHouse no-code tables.
+    // =========================================================================
+
+    #[test]
+    fn test_ch_u256_numeric_serializes_as_decimal_string() {
+        let val = U256::from(1_500_000u64);
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(val);
+        assert_eq!(wrapper.to_clickhouse_value(), "1500000");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_zero() {
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::ZERO);
+        assert_eq!(wrapper.to_clickhouse_value(), "0");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_large_value() {
+        let val = U256::from(1_000_000_000_000_000u64);
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(val);
+        assert_eq!(wrapper.to_clickhouse_value(), "1000000000000000");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_nullable_some() {
+        let wrapper = EthereumSqlTypeWrapper::U256NumericNullable(Some(U256::from(42u64)));
+        assert_eq!(wrapper.to_clickhouse_value(), "42");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_nullable_none() {
+        let wrapper = EthereumSqlTypeWrapper::U256NumericNullable(None);
+        assert_eq!(wrapper.to_clickhouse_value(), "NULL");
+    }
+
+    #[test]
+    fn test_ch_vec_u256_numeric() {
+        let vals = vec![U256::from(100u64), U256::from(200u64), U256::from(300u64)];
+        let wrapper = EthereumSqlTypeWrapper::VecU256Numeric(vals);
+        assert_eq!(wrapper.to_clickhouse_value(), "[100, 200, 300]");
+    }
+
+    #[test]
+    fn test_ch_i256_numeric() {
+        let val = I256::try_from(-42i64).unwrap();
+        let wrapper = EthereumSqlTypeWrapper::I256Numeric(val);
+        assert_eq!(wrapper.to_clickhouse_value(), "-42");
+    }
+
+    #[test]
+    fn test_ch_u256_bytes() {
+        let val = U256::from(0xDEADBEEFu64);
+        let wrapper = EthereumSqlTypeWrapper::U256Bytes(val);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''), "U256Bytes should be quoted: {result}");
+        assert!(result.ends_with('\''), "U256Bytes should be quoted: {result}");
+    }
+
+    #[test]
+    fn test_ch_u256_bytes_nullable() {
+        let val = U256::from(123u64);
+        let wrapper = EthereumSqlTypeWrapper::U256BytesNullable(val);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+    }
+
+    #[test]
+    fn test_ch_i256_bytes() {
+        let val = I256::try_from(99i64).unwrap();
+        let wrapper = EthereumSqlTypeWrapper::I256Bytes(val);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+    }
+
+    #[test]
+    fn test_ch_address_bytes() {
+        let addr = Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
+        let wrapper = EthereumSqlTypeWrapper::AddressBytes(addr);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.contains("0x1234567890123456789012345678901234567890"));
+    }
+
+    #[test]
+    fn test_ch_address_bytes_nullable() {
+        let addr = Address::from_str("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd").unwrap();
+        let wrapper = EthereumSqlTypeWrapper::AddressBytesNullable(addr);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+    }
+
+    #[test]
+    fn test_ch_b256_bytes() {
+        let hash =
+            B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let wrapper = EthereumSqlTypeWrapper::B256Bytes(hash);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+    }
+
+    #[test]
+    fn test_ch_regular_u256_unchanged() {
+        let wrapper = EthereumSqlTypeWrapper::U256(U256::from(999u64));
+        assert_eq!(wrapper.to_clickhouse_value(), "999");
+    }
+
+    #[test]
+    fn test_ch_u64_bigint() {
+        let wrapper = EthereumSqlTypeWrapper::U64BigInt(12345678u64);
+        assert_eq!(wrapper.to_clickhouse_value(), "12345678");
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported")]
+    fn test_ch_jsonb_panics() {
+        EthereumSqlTypeWrapper::JSONB(serde_json::json!({"k": "v"})).to_clickhouse_value();
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported")]
+    fn test_ch_uuid_panics() {
+        EthereumSqlTypeWrapper::Uuid(uuid::Uuid::new_v4()).to_clickhouse_value();
+    }
+
+    // =========================================================================
+    // Edge cases and round-trip validation
+    // =========================================================================
+
+    #[test]
+    fn test_ch_u256_numeric_max_value() {
+        // U256::MAX = 2^256 - 1 — must not overflow or truncate
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::MAX);
+        let result = wrapper.to_clickhouse_value();
+        assert_eq!(
+            result,
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        );
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_one_wei() {
+        // Smallest non-zero value — must not be lost
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::from(1u64));
+        assert_eq!(wrapper.to_clickhouse_value(), "1");
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_typical_usdc_amount() {
+        // 1.5 USDC = 1_500_000 raw (6 decimals) — stored as-is, NOT pre-divided
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::from(1_500_000u64));
+        assert_eq!(wrapper.to_clickhouse_value(), "1500000");
+        // Downstream CH MV will do: toFloat64('1500000') / 1e6 = 1.5
+    }
+
+    #[test]
+    fn test_ch_u256_numeric_sub_one_usdc() {
+        // 0.5 USDC = 500_000 raw — this is the value that broke with integer division
+        let wrapper = EthereumSqlTypeWrapper::U256Numeric(U256::from(500_000u64));
+        assert_eq!(wrapper.to_clickhouse_value(), "500000");
+    }
+
+    #[test]
+    fn test_ch_i256_numeric_negative() {
+        let val = I256::try_from(-1_000_000i64).unwrap();
+        let wrapper = EthereumSqlTypeWrapper::I256Numeric(val);
+        assert_eq!(wrapper.to_clickhouse_value(), "-1000000");
+    }
+
+    #[test]
+    fn test_ch_i256_numeric_min_value() {
+        let wrapper = EthereumSqlTypeWrapper::I256Numeric(I256::MIN);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('-'));
+        assert!(result.len() > 10); // large number
+    }
+
+    #[test]
+    fn test_ch_address_bytes_is_checksummed() {
+        // rindexer outputs EIP-55 checksummed addresses
+        let addr = Address::from_str("0xe111180000d2663C0091e4f400237545B87B996B").unwrap();
+        let wrapper = EthereumSqlTypeWrapper::AddressBytes(addr);
+        let result = wrapper.to_clickhouse_value();
+        // Should preserve the checksummed format (transform MV will lower() it)
+        assert!(result.contains("0x"));
+        assert_eq!(result.len(), 44); // 42 chars + 2 quotes
+    }
+
+    #[test]
+    fn test_ch_vec_address_bytes() {
+        let addr1 = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        let addr2 = Address::from_str("0x2222222222222222222222222222222222222222").unwrap();
+        let wrapper = EthereumSqlTypeWrapper::VecAddressBytes(vec![addr1, addr2]);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('['));
+        assert!(result.ends_with(']'));
+        assert!(result.contains("0x1111"));
+        assert!(result.contains("0x2222"));
+    }
+
+    #[test]
+    fn test_ch_b256_bytes_hash() {
+        let hash =
+            B256::from_str("0xabcdef0000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let wrapper = EthereumSqlTypeWrapper::B256Bytes(hash);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('\''));
+        assert!(result.contains("0xabcdef"));
+    }
+
+    #[test]
+    fn test_ch_vec_b256_bytes() {
+        let h1 =
+            B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let h2 =
+            B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000002")
+                .unwrap();
+        let wrapper = EthereumSqlTypeWrapper::VecB256Bytes(vec![h1, h2]);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('['));
+        assert!(result.ends_with(']'));
+    }
+
+    #[test]
+    fn test_ch_vec_i256_bytes() {
+        let v1 = I256::try_from(42i64).unwrap();
+        let v2 = I256::try_from(-99i64).unwrap();
+        let wrapper = EthereumSqlTypeWrapper::VecI256Bytes(vec![v1, v2]);
+        let result = wrapper.to_clickhouse_value();
+        assert!(result.starts_with('['));
+    }
+
+    #[test]
+    fn test_ch_null_value() {
+        let wrapper = EthereumSqlTypeWrapper::Null;
+        assert_eq!(wrapper.to_clickhouse_value(), "NULL");
+    }
+
+    // =========================================================================
+    // Consistency: U256 (raw event) vs U256Numeric (table expression) produce
+    // the same CH value — they wrap the same alloy U256, just different enum variants.
+    // =========================================================================
+
+    #[test]
+    fn test_ch_u256_and_u256_numeric_produce_same_output() {
+        let val = U256::from(123_456_789u64);
+        let raw = EthereumSqlTypeWrapper::U256(val);
+        let numeric = EthereumSqlTypeWrapper::U256Numeric(val);
+        assert_eq!(raw.to_clickhouse_value(), numeric.to_clickhouse_value());
+    }
+
+    #[test]
+    fn test_ch_u256_and_u256_numeric_zero_same() {
+        let raw = EthereumSqlTypeWrapper::U256(U256::ZERO);
+        let numeric = EthereumSqlTypeWrapper::U256Numeric(U256::ZERO);
+        assert_eq!(raw.to_clickhouse_value(), numeric.to_clickhouse_value());
+    }
+
+    #[test]
+    fn test_ch_u256_and_u256_numeric_max_same() {
+        let raw = EthereumSqlTypeWrapper::U256(U256::MAX);
+        let numeric = EthereumSqlTypeWrapper::U256Numeric(U256::MAX);
+        assert_eq!(raw.to_clickhouse_value(), numeric.to_clickhouse_value());
     }
 }

--- a/core/src/indexer/cron_scheduler.rs
+++ b/core/src/indexer/cron_scheduler.rs
@@ -348,6 +348,7 @@ impl CronScheduler {
                             &manifest.name,
                             &contract.name,
                             &table.name,
+                            table.database.as_deref(),
                         );
 
                         if factory_config.is_some() {

--- a/core/src/indexer/reorg.rs
+++ b/core/src/indexer/reorg.rs
@@ -1646,6 +1646,7 @@ mod tests {
             }],
             cron: None,
             timestamp: false,
+            database: None,
         };
 
         TableRuntime::new(table, "idx", "erc20")

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -3527,9 +3527,10 @@ pub async fn process_table_operations(
             e.event == event_name
                 && e.operations.iter().any(|op| {
                     op.where_clause.values().any(|v| v.contains("rindexer_block_timestamp"))
-                        || op.set.iter().any(|s| {
-                            s.effective_value().contains("rindexer_block_timestamp")
-                        })
+                        || op
+                            .set
+                            .iter()
+                            .any(|s| s.effective_value().contains("rindexer_block_timestamp"))
                 })
         })
     });

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -1434,7 +1434,12 @@ pub struct TableRuntime {
 
 impl TableRuntime {
     pub fn new(table: Table, indexer_name: &str, contract_name: &str) -> Self {
-        let full_table_name = generate_table_full_name(indexer_name, contract_name, &table.name);
+        let full_table_name = generate_table_full_name(
+            indexer_name,
+            contract_name,
+            &table.name,
+            table.database.as_deref(),
+        );
         Self {
             table,
             full_table_name,
@@ -2659,6 +2664,29 @@ async fn extract_value_from_event_async(
         return Some(dyn_sol_value_to_wrapper(&result, column_type));
     }
 
+    // BlockClock cache fallback for $rindexer_block_timestamp when RPC didn't include it
+    // in eth_getLogs. The prefetch_block_timestamps call earlier in the pipeline will have
+    // fetched it via eth_getBlockByNumber if any table references this field.
+    if after_constants == "$rindexer_block_timestamp" && tx_metadata.block_timestamp.is_none() {
+        if let Some(epoch) = get_cached_block_timestamp(network, tx_metadata.block_number).await {
+            return Some(match column_type {
+                ColumnType::Uint256 | ColumnType::Uint128 | ColumnType::Uint64 => {
+                    EthereumSqlTypeWrapper::U256Numeric(U256::from(epoch))
+                }
+                ColumnType::Timestamp => DateTime::from_timestamp(epoch as i64, 0)
+                    .map(|dt| EthereumSqlTypeWrapper::DateTime(dt.with_timezone(&Utc)))
+                    .unwrap_or_else(|| EthereumSqlTypeWrapper::U256Numeric(U256::from(epoch))),
+                _ => EthereumSqlTypeWrapper::U256Numeric(U256::from(epoch)),
+            });
+        }
+        tracing::warn!(
+            "block_timestamp unavailable for block {} on {} — RPC may not include \
+             blockTimestamp in eth_getLogs and BlockClock cache miss",
+            tx_metadata.block_number,
+            network,
+        );
+    }
+
     // Fall back to sync extraction for everything else
     extract_value_from_event(after_constants, log_params, tx_metadata, column_type)
 }
@@ -3483,9 +3511,25 @@ pub async fn process_table_operations(
     }
 
     // Check if any table needs timestamps and prefetch them in batch
-    let any_table_needs_timestamp = tables
-        .iter()
-        .any(|t| t.table.timestamp && t.table.events.iter().any(|e| e.event == event_name));
+    let any_table_needs_timestamp = tables.iter().any(|t| {
+        let handles_event = t.table.events.iter().any(|e| e.event == event_name);
+        if !handles_event {
+            return false;
+        }
+        // Built-in timestamp column enabled
+        if t.table.timestamp {
+            return true;
+        }
+        // Column mapping references $rindexer_block_timestamp (custom column using the
+        // built-in metadata). Without prefetch, this resolves to NULL when the RPC doesn't
+        // include blockTimestamp in eth_getLogs responses.
+        t.table.events.iter().any(|e| {
+            e.event == event_name
+                && e.operations.iter().any(|op| {
+                    op.set.iter().any(|s| s.effective_value().contains("rindexer_block_timestamp"))
+                })
+        })
+    });
 
     if any_table_needs_timestamp {
         prefetch_block_timestamps(events_data, &providers, true).await;
@@ -4882,6 +4926,257 @@ mod tests {
             assert_eq!(s, "ETH");
         } else {
             panic!("Expected String");
+        }
+    }
+
+    // =========================================================================
+    // Tests for block_timestamp BlockClock cache fallback
+    // =========================================================================
+
+    /// When tx_metadata.block_timestamp is Some, $rindexer_block_timestamp resolves
+    /// from metadata directly (no cache needed).
+    #[test]
+    fn test_block_timestamp_resolves_from_metadata_when_present() {
+        let params =
+            vec![LogParam::new("value".to_string(), DynSolValue::Uint(U256::from(1u64), 256))];
+        let meta = TxMetadata {
+            block_number: 84988630,
+            block_timestamp: Some(U256::from(1700000000u64)),
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::from(0u64),
+            tx_index: 0,
+        };
+
+        // uint256 column type — should return epoch as U256Numeric
+        let result = extract_value_from_event(
+            "$rindexer_block_timestamp",
+            &params,
+            &meta,
+            &ColumnType::Uint256,
+        );
+        assert!(result.is_some(), "Should resolve from metadata");
+        match result.unwrap() {
+            EthereumSqlTypeWrapper::U256Numeric(val) => {
+                assert_eq!(val, U256::from(1700000000u64));
+            }
+            other => panic!("Expected U256Numeric, got: {:?}", other),
+        }
+
+        // Timestamp column type — should return DateTime
+        let result = extract_value_from_event(
+            "$rindexer_block_timestamp",
+            &params,
+            &meta,
+            &ColumnType::Timestamp,
+        );
+        assert!(result.is_some(), "Should resolve as DateTime");
+        match result.unwrap() {
+            EthereumSqlTypeWrapper::DateTime(dt) => {
+                assert_eq!(dt.timestamp(), 1700000000);
+            }
+            other => panic!("Expected DateTime, got: {:?}", other),
+        }
+    }
+
+    /// When tx_metadata.block_timestamp is None (RPC didn't include blockTimestamp
+    /// in eth_getLogs), the sync extraction returns None. The async path should
+    /// fall back to BlockClock cache — tested separately via tokio runtime.
+    #[test]
+    fn test_block_timestamp_returns_none_when_metadata_missing_sync() {
+        let params =
+            vec![LogParam::new("value".to_string(), DynSolValue::Uint(U256::from(1u64), 256))];
+        let meta = TxMetadata {
+            block_number: 84988630,
+            block_timestamp: None, // RPC didn't include blockTimestamp
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::from(0u64),
+            tx_index: 0,
+        };
+
+        let result = extract_value_from_event(
+            "$rindexer_block_timestamp",
+            &params,
+            &meta,
+            &ColumnType::Uint256,
+        );
+        assert!(result.is_none(), "Sync path should return None when metadata missing");
+    }
+
+    /// Async extraction falls back to BlockClock cache when tx_metadata.block_timestamp
+    /// is None. This is the fix for the PayoutRedemption NULL block_timestamp bug.
+    #[tokio::test]
+    async fn test_block_timestamp_async_falls_back_to_cache() {
+        let params =
+            vec![LogParam::new("value".to_string(), DynSolValue::Uint(U256::from(1u64), 256))];
+        let meta = TxMetadata {
+            block_number: 99999999, // Unique block to avoid cache collision
+            block_timestamp: None,  // Simulate missing timestamp from RPC
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::from(0u64),
+            tx_index: 0,
+        };
+
+        // Pre-populate the BlockClock cache (simulating prefetch_block_timestamps)
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.insert(("polygon".to_string(), 99999999), 1700000042);
+        }
+
+        let constants = Constants::default();
+        let result = extract_value_from_event_async(
+            "$rindexer_block_timestamp",
+            &params,
+            &meta,
+            &ColumnType::Uint256,
+            None,
+            "polygon",
+            &constants,
+        )
+        .await;
+
+        assert!(result.is_some(), "Async path should resolve from BlockClock cache");
+        match result.unwrap() {
+            EthereumSqlTypeWrapper::U256Numeric(val) => {
+                assert_eq!(val, U256::from(1700000042u64));
+            }
+            other => panic!("Expected U256Numeric from cache fallback, got: {:?}", other),
+        }
+
+        // Clean up cache entry
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.remove(&("polygon".to_string(), 99999999));
+        }
+    }
+
+    /// Async extraction with Timestamp column type returns DateTime from cache.
+    #[tokio::test]
+    async fn test_block_timestamp_async_cache_returns_datetime() {
+        let params =
+            vec![LogParam::new("value".to_string(), DynSolValue::Uint(U256::from(1u64), 256))];
+        let meta = TxMetadata {
+            block_number: 99999998,
+            block_timestamp: None,
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::from(0u64),
+            tx_index: 0,
+        };
+
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.insert(("polygon".to_string(), 99999998), 1700000000);
+        }
+
+        let constants = Constants::default();
+        let result = extract_value_from_event_async(
+            "$rindexer_block_timestamp",
+            &params,
+            &meta,
+            &ColumnType::Timestamp,
+            None,
+            "polygon",
+            &constants,
+        )
+        .await;
+
+        assert!(result.is_some(), "Should return DateTime from cache");
+        match result.unwrap() {
+            EthereumSqlTypeWrapper::DateTime(dt) => {
+                assert_eq!(dt.timestamp(), 1700000000);
+            }
+            other => panic!("Expected DateTime from cache, got: {:?}", other),
+        }
+
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.remove(&("polygon".to_string(), 99999998));
+        }
+    }
+
+    /// When both metadata and cache miss, async extraction returns None (same as
+    /// sync) but we emit a warning (tested by observing return value only).
+    #[tokio::test]
+    async fn test_block_timestamp_async_returns_none_on_total_miss() {
+        let params =
+            vec![LogParam::new("value".to_string(), DynSolValue::Uint(U256::from(1u64), 256))];
+        let meta = TxMetadata {
+            block_number: 88888888, // Not in cache
+            block_timestamp: None,
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::from(0u64),
+            tx_index: 0,
+        };
+
+        let constants = Constants::default();
+        let result = extract_value_from_event_async(
+            "$rindexer_block_timestamp",
+            &params,
+            &meta,
+            &ColumnType::Uint256,
+            None,
+            "polygon",
+            &constants,
+        )
+        .await;
+
+        assert!(result.is_none(), "Should return None when both metadata and cache miss");
+    }
+
+    /// When metadata IS present, the async path should use it directly (not touch cache).
+    #[tokio::test]
+    async fn test_block_timestamp_async_prefers_metadata_over_cache() {
+        let params =
+            vec![LogParam::new("value".to_string(), DynSolValue::Uint(U256::from(1u64), 256))];
+        let meta = TxMetadata {
+            block_number: 77777777,
+            block_timestamp: Some(U256::from(1700000001u64)), // Has metadata
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::from(0u64),
+            tx_index: 0,
+        };
+
+        // Put a DIFFERENT value in cache to prove metadata wins
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.insert(("polygon".to_string(), 77777777), 9999999999);
+        }
+
+        let constants = Constants::default();
+        let result = extract_value_from_event_async(
+            "$rindexer_block_timestamp",
+            &params,
+            &meta,
+            &ColumnType::Uint256,
+            None,
+            "polygon",
+            &constants,
+        )
+        .await;
+
+        assert!(result.is_some());
+        match result.unwrap() {
+            EthereumSqlTypeWrapper::U256Numeric(val) => {
+                // Should be metadata value (1700000001), NOT cache value (9999999999)
+                assert_eq!(val, U256::from(1700000001u64));
+            }
+            other => panic!("Expected metadata value, got: {:?}", other),
+        }
+
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.remove(&("polygon".to_string(), 77777777));
         }
     }
 }

--- a/core/src/manifest/contract.rs
+++ b/core/src/manifest/contract.rs
@@ -799,20 +799,23 @@ impl ColumnType {
         }
     }
 
-    /// Convert to ClickHouse type
+    /// Convert to ClickHouse type.
+    /// Uses native CH types matching `solidity_type_to_clickhouse_type()` for raw event tables.
     pub fn to_clickhouse_type(&self) -> String {
         match self {
             ColumnType::Uint8 => "UInt8".to_string(),
             ColumnType::Uint16 => "UInt16".to_string(),
             ColumnType::Uint32 => "UInt32".to_string(),
             ColumnType::Uint64 => "UInt64".to_string(),
-            ColumnType::Uint128 | ColumnType::Uint256 => "String".to_string(),
+            ColumnType::Uint128 => "UInt128".to_string(),
+            ColumnType::Uint256 => "UInt256".to_string(),
             ColumnType::Int8 => "Int8".to_string(),
             ColumnType::Int16 => "Int16".to_string(),
             ColumnType::Int32 => "Int32".to_string(),
             ColumnType::Int64 => "Int64".to_string(),
-            ColumnType::Int128 | ColumnType::Int256 => "String".to_string(),
-            ColumnType::Address => "String".to_string(),
+            ColumnType::Int128 => "Int128".to_string(),
+            ColumnType::Int256 => "Int256".to_string(),
+            ColumnType::Address => "FixedString(42)".to_string(),
             ColumnType::Bytes | ColumnType::Bytes32 => "String".to_string(),
             ColumnType::String => "String".to_string(),
             ColumnType::Bool => "Bool".to_string(),
@@ -1551,5 +1554,85 @@ mod tests {
         let result = Table::infer_type_from_value("$rindexer_block_number", None);
         // Should return the metadata field's type (u64 → Uint64)
         assert!(result.is_some());
+    }
+
+    // =========================================================================
+    // ClickHouse type mapping — native types instead of String fallback
+    // =========================================================================
+
+    #[test]
+    fn test_ch_type_uint256_is_native() {
+        assert_eq!(ColumnType::Uint256.to_clickhouse_type(), "UInt256");
+    }
+
+    #[test]
+    fn test_ch_type_uint128_is_native() {
+        assert_eq!(ColumnType::Uint128.to_clickhouse_type(), "UInt128");
+    }
+
+    #[test]
+    fn test_ch_type_int256_is_native() {
+        assert_eq!(ColumnType::Int256.to_clickhouse_type(), "Int256");
+    }
+
+    #[test]
+    fn test_ch_type_int128_is_native() {
+        assert_eq!(ColumnType::Int128.to_clickhouse_type(), "Int128");
+    }
+
+    #[test]
+    fn test_ch_type_address_is_fixed_string() {
+        assert_eq!(ColumnType::Address.to_clickhouse_type(), "FixedString(42)");
+    }
+
+    #[test]
+    fn test_ch_type_uint64_unchanged() {
+        assert_eq!(ColumnType::Uint64.to_clickhouse_type(), "UInt64");
+    }
+
+    #[test]
+    fn test_ch_type_int64_unchanged() {
+        assert_eq!(ColumnType::Int64.to_clickhouse_type(), "Int64");
+    }
+
+    #[test]
+    fn test_ch_type_bool_unchanged() {
+        assert_eq!(ColumnType::Bool.to_clickhouse_type(), "Bool");
+    }
+
+    #[test]
+    fn test_ch_type_string_unchanged() {
+        assert_eq!(ColumnType::String.to_clickhouse_type(), "String");
+    }
+
+    #[test]
+    fn test_ch_type_array_uses_native_inner() {
+        let arr = ColumnType::Array(Box::new(ColumnType::Uint256));
+        assert_eq!(arr.to_clickhouse_type(), "Array(UInt256)");
+    }
+
+    #[test]
+    fn test_ch_type_matches_solidity_raw_event_mapping() {
+        // Custom table types must match raw event table types for consistency.
+        // Raw events: solidity_type_to_clickhouse_type("uint256") → "UInt256"
+        // Custom tables: ColumnType::Uint256.to_clickhouse_type() → should also be "UInt256"
+        assert_eq!(ColumnType::Uint256.to_clickhouse_type(), "UInt256");
+        assert_eq!(ColumnType::Uint128.to_clickhouse_type(), "UInt128");
+        assert_eq!(ColumnType::Int256.to_clickhouse_type(), "Int256");
+        assert_eq!(ColumnType::Int128.to_clickhouse_type(), "Int128");
+    }
+
+    // =========================================================================
+    // PostgreSQL type mapping — sanity checks (shouldn't change)
+    // =========================================================================
+
+    #[test]
+    fn test_pg_type_uint256_is_numeric() {
+        assert_eq!(ColumnType::Uint256.to_postgres_type(), "NUMERIC");
+    }
+
+    #[test]
+    fn test_pg_type_address_is_char42() {
+        assert_eq!(ColumnType::Address.to_postgres_type(), "CHAR(42)");
     }
 }

--- a/core/src/manifest/contract.rs
+++ b/core/src/manifest/contract.rs
@@ -327,6 +327,15 @@ pub struct Table {
     /// Note: This may impact indexing performance as it requires additional RPC calls.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub timestamp: bool,
+
+    /// Optional database/schema override for this table.
+    /// When set, this table is created in the specified database (CH) or schema (PG)
+    /// instead of the default `{indexer_name}_{contract_name}` schema.
+    /// Useful for directing custom tables from multiple contracts into a shared database
+    /// (e.g., `database: indexer` puts all activities_raw tables in `indexer.activities_raw`).
+    /// Raw event tables are NOT affected — they always use the per-contract schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
 }
 
 impl Table {

--- a/core/tests/clickhouse_type_e2e.rs
+++ b/core/tests/clickhouse_type_e2e.rs
@@ -1,6 +1,6 @@
-/// E2E validation tests for ClickHouse type handling.
+/// E2E validation tests for ClickHouse type handling and features.
 ///
-/// Unit tests (no CH needed): validate type mapping and serialization consistency.
+/// Unit tests (no CH needed): validate type mapping, serialization, YAML parsing.
 /// Integration tests (#[ignore]): validate full round-trip against a real ClickHouse.
 ///
 /// Run unit tests:  cargo test -p rindexer --test clickhouse_type_e2e
@@ -11,15 +11,11 @@
 use rindexer::manifest::contract::ColumnType;
 
 // =========================================================================
-// Unit tests — type mapping consistency
+// Unit tests — type mapping
 // =========================================================================
 
 #[test]
 fn test_custom_table_types_match_raw_event_types() {
-    // Custom table path (ColumnType::to_clickhouse_type) must produce the same
-    // CH types as raw event path (solidity_type_to_clickhouse_type).
-    // This ensures a uint256 column in a YAML table creates the same CH column
-    // as a uint256 ABI field in a raw event table.
     assert_eq!(ColumnType::Uint256.to_clickhouse_type(), "UInt256");
     assert_eq!(ColumnType::Uint128.to_clickhouse_type(), "UInt128");
     assert_eq!(ColumnType::Int256.to_clickhouse_type(), "Int256");
@@ -44,7 +40,6 @@ fn test_array_types_use_native_inner() {
 
 #[test]
 fn test_pg_types_unchanged() {
-    // Ensure PG mapping wasn't broken by the CH fix
     assert_eq!(ColumnType::Uint256.to_postgres_type(), "NUMERIC");
     assert_eq!(ColumnType::Uint128.to_postgres_type(), "NUMERIC");
     assert_eq!(ColumnType::Int256.to_postgres_type(), "NUMERIC");
@@ -53,27 +48,15 @@ fn test_pg_types_unchanged() {
 }
 
 #[test]
-fn test_ddl_for_activities_raw_table() {
-    // Simulate what rindexer would generate for our rindexer-ch.yaml activities_raw table
+fn test_ddl_for_table_with_native_types() {
     let columns: Vec<(&str, ColumnType)> = vec![
         ("id", ColumnType::Uint64),
         ("block_number", ColumnType::Uint64),
-        ("block_timestamp", ColumnType::Uint64),
-        ("transaction_hash", ColumnType::String),
-        ("address", ColumnType::Address),
-        ("user_id", ColumnType::Address),
-        ("asset", ColumnType::String),
-        ("condition_id", ColumnType::String),
-        ("neg_risk_market_id", ColumnType::String),
-        ("amount_usdc", ColumnType::Uint256),
-        ("amount_shares", ColumnType::Uint256),
-        ("tx_type", ColumnType::String),
-        ("side", ColumnType::String),
-        ("order_hash", ColumnType::String),
-        ("counterparty_id", ColumnType::Address),
-        ("order_type", ColumnType::String),
+        ("sender", ColumnType::Address),
+        ("recipient", ColumnType::Address),
+        ("amount", ColumnType::Uint256),
         ("fee", ColumnType::Uint256),
-        ("builder", ColumnType::String),
+        ("event_type", ColumnType::String),
         ("is_deleted", ColumnType::Uint8),
     ];
 
@@ -82,22 +65,69 @@ fn test_ddl_for_activities_raw_table() {
         .map(|(name, ct)| format!("  `{}` {}", name, ct.to_clickhouse_type()))
         .collect();
     let ddl = format!(
-        "CREATE TABLE test.activities_raw (\n{}\n) ENGINE = MergeTree() ORDER BY id",
+        "CREATE TABLE test.events (\n{}\n) ENGINE = MergeTree() ORDER BY id",
         ddl_parts.join(",\n")
     );
 
-    // Verify key types in DDL
-    assert!(ddl.contains("`amount_usdc` UInt256"), "amount_usdc should be UInt256, got:\n{ddl}");
-    assert!(ddl.contains("`amount_shares` UInt256"), "amount_shares should be UInt256");
+    assert!(ddl.contains("`amount` UInt256"), "amount should be UInt256");
     assert!(ddl.contains("`fee` UInt256"), "fee should be UInt256");
-    assert!(ddl.contains("`address` FixedString(42)"), "address should be FixedString(42)");
-    assert!(ddl.contains("`user_id` FixedString(42)"), "user_id should be FixedString(42)");
+    assert!(ddl.contains("`sender` FixedString(42)"), "sender should be FixedString(42)");
     assert!(ddl.contains("`id` UInt64"), "id should be UInt64");
-    assert!(ddl.contains("`is_deleted` UInt8"), "is_deleted should be UInt8");
+    assert!(!ddl.contains("`amount` String"), "amount must NOT be String");
+    assert!(!ddl.contains("`sender` String"), "sender must NOT be String");
+}
 
-    // Verify no String fallback for numeric/address types
-    assert!(!ddl.contains("`amount_usdc` String"), "amount_usdc must NOT be String");
-    assert!(!ddl.contains("`address` String"), "address must NOT be String");
+// =========================================================================
+// Unit tests — database override YAML field
+// =========================================================================
+
+#[test]
+fn test_table_database_field_parses() {
+    use rindexer::manifest::contract::Table;
+
+    let yaml = r#"
+        name: events
+        database: shared_db
+        columns:
+          - name: id
+            type: uint64
+    "#;
+    let table: Table = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(table.database, Some("shared_db".to_string()));
+    assert_eq!(table.name, "events");
+}
+
+#[test]
+fn test_table_database_field_defaults_to_none() {
+    use rindexer::manifest::contract::Table;
+
+    let yaml = r#"
+        name: events
+        columns:
+          - name: id
+            type: uint64
+    "#;
+    let table: Table = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(table.database, None);
+}
+
+#[test]
+fn test_table_database_field_independent_of_other_fields() {
+    use rindexer::manifest::contract::Table;
+
+    let yaml = r#"
+        name: counters
+        database: analytics
+        global: true
+        cross_chain: false
+        columns:
+          - name: value
+            type: uint256
+    "#;
+    let table: Table = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(table.database, Some("analytics".to_string()));
+    assert!(table.global);
+    assert!(!table.cross_chain);
 }
 
 // =========================================================================
@@ -106,14 +136,13 @@ fn test_ddl_for_activities_raw_table() {
 
 #[cfg(test)]
 fn ch_query(query: &str) -> Result<String, String> {
-    use std::io::Read;
     let url =
         std::env::var("CLICKHOUSE_URL").unwrap_or_else(|_| "http://localhost:8123".to_string());
     let user = std::env::var("CLICKHOUSE_USER").unwrap_or_else(|_| "default".to_string());
     let password = std::env::var("CLICKHOUSE_PASSWORD").unwrap_or_default();
 
     let full_url = format!("{}/?user={}&password={}", url, user, password);
-    let mut handle = std::process::Command::new("curl")
+    let handle = std::process::Command::new("curl")
         .args(["-sf", "--data-binary", query, &full_url])
         .output()
         .map_err(|e| format!("curl failed: {e}"))?;
@@ -125,137 +154,133 @@ fn ch_query(query: &str) -> Result<String, String> {
     }
 }
 
-#[test]
-#[ignore]
-fn test_e2e_native_types_create_and_insert() {
-    let db = "rindexer_e2e_types";
-
+#[cfg(test)]
+fn ch_setup_db(db: &str) {
     ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
     ch_query(&format!("CREATE DATABASE {db}")).unwrap();
-
-    // DDL with native types (what rindexer now generates)
-    ch_query(&format!(
-        "CREATE TABLE {db}.activities_raw (
-            id UInt64,
-            block_number UInt64,
-            address FixedString(42),
-            user_id FixedString(42),
-            amount_usdc UInt256,
-            amount_shares UInt256,
-            fee UInt256,
-            tx_type String,
-            side String,
-            is_deleted UInt8
-        ) ENGINE = MergeTree() ORDER BY id"
-    ))
-    .unwrap();
-
-    // Insert with decimal string values for UInt256 (same as rindexer serialization)
-    ch_query(&format!(
-        "INSERT INTO {db}.activities_raw VALUES \
-        (1, 85267446, '0xe111180000d2663C0091e4f400237545B87B996B', \
-        '0x1234567890123456789012345678901234567890', \
-        1500000, 2000000, 30000, 'TRADE', 'BUY', 0)"
-    ))
-    .unwrap();
-
-    // Verify Float64 division on UInt256 (the core of our transform MV pattern)
-    let usdc =
-        ch_query(&format!("SELECT toFloat64(amount_usdc) / 1e6 FROM {db}.activities_raw")).unwrap();
-    assert_eq!(usdc, "1.5");
-
-    let price = ch_query(&format!(
-        "SELECT toFloat64(amount_usdc) / toFloat64(amount_shares) FROM {db}.activities_raw"
-    ))
-    .unwrap();
-    assert_eq!(price, "0.75");
-
-    // Verify lower() on FixedString(42) addresses
-    let addr = ch_query(&format!("SELECT lower(address) FROM {db}.activities_raw")).unwrap();
-    assert_eq!(addr, "0xe111180000d2663c0091e4f400237545b87b996b");
-
-    ch_query(&format!("DROP DATABASE {db}")).unwrap();
 }
 
+#[cfg(test)]
+fn ch_drop_db(db: &str) {
+    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
+}
+
+// ── Native types: CREATE + INSERT + Float64 division ──
+
 #[test]
 #[ignore]
-fn test_e2e_transform_mv_pipeline() {
+fn test_e2e_native_types_roundtrip() {
+    let db = "rindexer_e2e_types";
+    ch_setup_db(db);
+
+    ch_query(&format!(
+        "CREATE TABLE {db}.events (
+            id UInt64, block_number UInt64,
+            sender FixedString(42), recipient FixedString(42),
+            amount UInt256, shares UInt256, fee UInt256,
+            event_type String, side String, is_deleted UInt8
+        ) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    ch_query(&format!(
+        "INSERT INTO {db}.events VALUES \
+        (1, 100, '0xaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaA', \
+        '0xbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbB', \
+        1500000, 2000000, 30000, 'SWAP', 'BUY', 0)"
+    ))
+    .unwrap();
+
+    // UInt256 → Float64 division
+    let amount = ch_query(&format!("SELECT toFloat64(amount) / 1e6 FROM {db}.events")).unwrap();
+    assert_eq!(amount, "1.5");
+
+    // UInt256 / UInt256 → ratio
+    let ratio = ch_query(&format!("SELECT toFloat64(amount) / toFloat64(shares) FROM {db}.events"))
+        .unwrap();
+    assert_eq!(ratio, "0.75");
+
+    // lower() on FixedString(42)
+    let addr = ch_query(&format!("SELECT lower(sender) FROM {db}.events")).unwrap();
+    assert_eq!(addr, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    ch_drop_db(db);
+}
+
+// ── Streaming MV: raw UInt256 → Float64 transform ──
+
+#[test]
+#[ignore]
+fn test_e2e_streaming_mv_transform() {
     let db = "rindexer_e2e_mv";
+    ch_setup_db(db);
 
-    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
-    ch_query(&format!("CREATE DATABASE {db}")).unwrap();
-
-    // Raw table
+    // Raw table (UInt256 amounts)
     ch_query(&format!(
-        "CREATE TABLE {db}.raw (
-            id UInt64, amount_usdc UInt256, amount_shares UInt256,
-            tx_type String, address FixedString(42), fee UInt256, is_deleted UInt8
+        "CREATE TABLE {db}.raw_events (
+            id UInt64, amount UInt256, shares UInt256,
+            event_type String, source FixedString(42), fee UInt256, is_deleted UInt8
         ) ENGINE = MergeTree() ORDER BY id"
     ))
     .unwrap();
 
-    // Transformed table
+    // Transformed table (Float64)
     ch_query(&format!(
-        "CREATE TABLE {db}.trades (
-            id String, amount_usdc Float64, shares Float64,
-            price_usdc Float64, fee Float64, is_deleted UInt8
+        "CREATE TABLE {db}.processed (
+            id String, price Float64, amount Float64,
+            shares Float64, fee Float64, is_deleted UInt8
         ) ENGINE = MergeTree() ORDER BY id"
     ))
     .unwrap();
 
-    // Streaming MV — use _raw suffixed names to avoid alias shadowing,
-    // then rename in the outer expression. This is the pattern our production
-    // MVs must use when amount_usdc alias shadows the source column.
+    // Streaming MV with table alias to avoid CH alias shadowing
     ch_query(&format!(
-        "CREATE MATERIALIZED VIEW {db}.mv_transform TO {db}.trades AS
+        "CREATE MATERIALIZED VIEW {db}.mv_transform TO {db}.processed AS
         SELECT
-            toString(id) AS id,
-            toFloat64(_raw_usdc) / 1e6 AS amount_usdc,
-            toFloat64(_raw_shares) / 1e6 AS shares,
-            if(_raw_shares = toUInt256(0), toFloat64(0),
-               toFloat64(_raw_usdc) / toFloat64(_raw_shares)) AS price_usdc,
-            if(lower(address) IN (
-                '0xe111180000d2663c0091e4f400237545b87b996b',
-                '0xe2222d002000ba0053cef3375333610f64600036'
-            ), toFloat64(fee) / 1e6, 0) AS fee,
-            is_deleted
-        FROM (
-            SELECT *, amount_usdc AS _raw_usdc, amount_shares AS _raw_shares
-            FROM {db}.raw
-            WHERE tx_type = 'TRADE'
-        )"
+            toString(r.id) AS id,
+            if(r.shares = toUInt256(0), toFloat64(0),
+               toFloat64(r.amount) / toFloat64(r.shares)) AS price,
+            toFloat64(r.amount) / 1e6 AS amount,
+            toFloat64(r.shares) / 1e6 AS shares,
+            if(lower(r.source) IN (
+                '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+            ), toFloat64(r.fee) / 1e6, 0) AS fee,
+            r.is_deleted
+        FROM {db}.raw_events AS r
+        WHERE r.event_type = 'SWAP'"
     ))
     .unwrap();
 
     // Insert raw data
     ch_query(&format!(
-        "INSERT INTO {db}.raw VALUES \
-        (1, 1500000, 2000000, 'TRADE', '0xe111180000d2663C0091e4f400237545B87B996B', 30000, 0), \
-        (2, 500000, 1000000, 'TRADE', '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E', 10000, 0), \
-        (3, 750000, 750000, 'SPLIT', '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045', 0, 0)"
+        "INSERT INTO {db}.raw_events VALUES \
+        (1, 1500000, 2000000, 'SWAP', '0xaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaA', 30000, 0), \
+        (2, 500000, 1000000, 'SWAP', '0xcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcC', 10000, 0), \
+        (3, 750000, 750000, 'DEPOSIT', '0xaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaA', 0, 0)"
     ))
     .unwrap();
 
-    // MV should only capture TRADE rows
-    let count = ch_query(&format!("SELECT count() FROM {db}.trades")).unwrap();
+    // MV captures only SWAP rows
+    let count = ch_query(&format!("SELECT count() FROM {db}.processed")).unwrap();
     assert_eq!(count, "2");
 
-    // Row 1: V2 address → fee applied
-    let r1 = ch_query(&format!(
-        "SELECT amount_usdc, shares, price_usdc, fee FROM {db}.trades WHERE id = '1'"
-    ))
-    .unwrap();
+    // Row 1: matched source → fee applied
+    let r1 =
+        ch_query(&format!("SELECT amount, shares, price, fee FROM {db}.processed WHERE id = '1'"))
+            .unwrap();
     assert_eq!(r1, "1.5\t2\t0.75\t0.03");
 
-    // Row 2: V1 address → fee = 0
-    let r2 = ch_query(&format!(
-        "SELECT amount_usdc, shares, price_usdc, fee FROM {db}.trades WHERE id = '2'"
-    ))
-    .unwrap();
+    // Row 2: unmatched source → fee = 0
+    let r2 =
+        ch_query(&format!("SELECT amount, shares, price, fee FROM {db}.processed WHERE id = '2'"))
+            .unwrap();
     assert_eq!(r2, "0.5\t1\t0.5\t0");
 
-    ch_query(&format!("DROP DATABASE {db}")).unwrap();
+    ch_drop_db(db);
 }
+
+// ── UInt256 max value round-trip ──
 
 #[test]
 #[ignore]
@@ -263,15 +288,135 @@ fn test_e2e_uint256_max_roundtrip() {
     let db = "rindexer_e2e_max";
     let max_str = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
 
-    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
-    ch_query(&format!("CREATE DATABASE {db}")).unwrap();
+    ch_setup_db(db);
     ch_query(&format!("CREATE TABLE {db}.t (val UInt256) ENGINE = MergeTree() ORDER BY val"))
         .unwrap();
 
     ch_query(&format!("INSERT INTO {db}.t VALUES ({max_str})")).unwrap();
-
     let result = ch_query(&format!("SELECT val FROM {db}.t")).unwrap();
     assert_eq!(result, max_str, "U256::MAX must survive CH round-trip");
 
-    ch_query(&format!("DROP DATABASE {db}")).unwrap();
+    ch_drop_db(db);
+}
+
+// ── Database override: shared table across contracts ──
+
+#[test]
+#[ignore]
+fn test_e2e_database_override_shared_table() {
+    let shared = "rindexer_e2e_shared";
+    let c1 = "rindexer_e2e_c1";
+    let c2 = "rindexer_e2e_c2";
+
+    for db in [shared, c1, c2] {
+        ch_setup_db(db);
+    }
+
+    // Per-contract raw tables (isolated — default rindexer behavior)
+    ch_query(&format!(
+        "CREATE TABLE {c1}.raw_events (sender String, amount UInt256) ENGINE = MergeTree() ORDER BY sender"
+    )).unwrap();
+    ch_query(&format!(
+        "CREATE TABLE {c2}.raw_events (sender String, amount UInt256) ENGINE = MergeTree() ORDER BY sender"
+    )).unwrap();
+
+    // Shared custom table (what `database:` override produces)
+    ch_query(&format!(
+        "CREATE TABLE {shared}.events (
+            id UInt64, source_contract String, user_id String, amount UInt256, event_type String
+        ) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    // Contract 1 writes raw + shared
+    ch_query(&format!("INSERT INTO {c1}.raw_events VALUES ('alice', 1000000)")).unwrap();
+    ch_query(&format!(
+        "INSERT INTO {shared}.events VALUES \
+        (1, 'contract_a', 'alice', 1000000, 'SWAP'), \
+        (2, 'contract_a', 'bob', 1000000, 'SWAP')"
+    ))
+    .unwrap();
+
+    // Contract 2 writes raw + shared
+    ch_query(&format!("INSERT INTO {c2}.raw_events VALUES ('carol', 2000000)")).unwrap();
+    ch_query(&format!(
+        "INSERT INTO {shared}.events VALUES \
+        (3, 'contract_b', 'carol', 2000000, 'SWAP'), \
+        (4, 'contract_b', 'dave', 2000000, 'SWAP')"
+    ))
+    .unwrap();
+
+    // Raw tables isolated
+    assert_eq!(ch_query(&format!("SELECT count() FROM {c1}.raw_events")).unwrap(), "1");
+    assert_eq!(ch_query(&format!("SELECT count() FROM {c2}.raw_events")).unwrap(), "1");
+
+    // Shared table has ALL rows from ALL contracts
+    assert_eq!(ch_query(&format!("SELECT count() FROM {shared}.events")).unwrap(), "4");
+
+    // Can query across contracts from single table
+    let by_source = ch_query(&format!(
+        "SELECT source_contract, count() FROM {shared}.events GROUP BY source_contract ORDER BY source_contract"
+    )).unwrap();
+    assert_eq!(by_source, "contract_a\t2\ncontract_b\t2");
+
+    // Streaming MV works on shared table
+    ch_query(&format!(
+        "CREATE TABLE {shared}.processed (id String, amount Float64) ENGINE = MergeTree() ORDER BY id"
+    )).unwrap();
+    ch_query(&format!(
+        "CREATE MATERIALIZED VIEW {shared}.mv TO {shared}.processed AS
+        SELECT toString(id) AS id, toFloat64(amount)/1e6 AS amount
+        FROM {shared}.events WHERE event_type = 'SWAP'"
+    ))
+    .unwrap();
+
+    // New insert triggers MV
+    ch_query(&format!(
+        "INSERT INTO {shared}.events VALUES (5, 'contract_a', 'eve', 3000000, 'SWAP')"
+    ))
+    .unwrap();
+    assert_eq!(
+        ch_query(&format!("SELECT amount FROM {shared}.processed WHERE id = '5'")).unwrap(),
+        "3"
+    );
+
+    for db in [shared, c1, c2] {
+        ch_drop_db(db);
+    }
+}
+
+// ── Without database override: tables are per-contract ──
+
+#[test]
+#[ignore]
+fn test_e2e_default_per_contract_isolation() {
+    let db1 = "rindexer_e2e_iso1";
+    let db2 = "rindexer_e2e_iso2";
+
+    for db in [db1, db2] {
+        ch_setup_db(db);
+    }
+
+    // Each contract gets its own table (no override)
+    ch_query(&format!(
+        "CREATE TABLE {db1}.events (id UInt64, event_type String) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+    ch_query(&format!(
+        "CREATE TABLE {db2}.events (id UInt64, event_type String) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    ch_query(&format!("INSERT INTO {db1}.events VALUES (1, 'SWAP')")).unwrap();
+    ch_query(&format!("INSERT INTO {db2}.events VALUES (2, 'DEPOSIT')")).unwrap();
+
+    // Tables are isolated
+    assert_eq!(ch_query(&format!("SELECT event_type FROM {db1}.events")).unwrap(), "SWAP");
+    assert_eq!(ch_query(&format!("SELECT event_type FROM {db2}.events")).unwrap(), "DEPOSIT");
+    assert_eq!(ch_query(&format!("SELECT count() FROM {db1}.events")).unwrap(), "1");
+    assert_eq!(ch_query(&format!("SELECT count() FROM {db2}.events")).unwrap(), "1");
+
+    for db in [db1, db2] {
+        ch_drop_db(db);
+    }
 }

--- a/core/tests/clickhouse_type_e2e.rs
+++ b/core/tests/clickhouse_type_e2e.rs
@@ -1,0 +1,277 @@
+/// E2E validation tests for ClickHouse type handling.
+///
+/// Unit tests (no CH needed): validate type mapping and serialization consistency.
+/// Integration tests (#[ignore]): validate full round-trip against a real ClickHouse.
+///
+/// Run unit tests:  cargo test -p rindexer --test clickhouse_type_e2e
+/// Run E2E tests:   cargo test -p rindexer --test clickhouse_type_e2e -- --ignored
+///
+/// E2E setup:
+///   docker run -d --name ch-test -p 8123:8123 clickhouse/clickhouse-server:24.8
+use rindexer::manifest::contract::ColumnType;
+
+// =========================================================================
+// Unit tests — type mapping consistency
+// =========================================================================
+
+#[test]
+fn test_custom_table_types_match_raw_event_types() {
+    // Custom table path (ColumnType::to_clickhouse_type) must produce the same
+    // CH types as raw event path (solidity_type_to_clickhouse_type).
+    // This ensures a uint256 column in a YAML table creates the same CH column
+    // as a uint256 ABI field in a raw event table.
+    assert_eq!(ColumnType::Uint256.to_clickhouse_type(), "UInt256");
+    assert_eq!(ColumnType::Uint128.to_clickhouse_type(), "UInt128");
+    assert_eq!(ColumnType::Int256.to_clickhouse_type(), "Int256");
+    assert_eq!(ColumnType::Int128.to_clickhouse_type(), "Int128");
+    assert_eq!(ColumnType::Address.to_clickhouse_type(), "FixedString(42)");
+    assert_eq!(ColumnType::Uint64.to_clickhouse_type(), "UInt64");
+    assert_eq!(ColumnType::Int64.to_clickhouse_type(), "Int64");
+    assert_eq!(ColumnType::Uint8.to_clickhouse_type(), "UInt8");
+    assert_eq!(ColumnType::Bool.to_clickhouse_type(), "Bool");
+    assert_eq!(ColumnType::String.to_clickhouse_type(), "String");
+    assert_eq!(ColumnType::Timestamp.to_clickhouse_type(), "DateTime('UTC')");
+}
+
+#[test]
+fn test_array_types_use_native_inner() {
+    let u256_arr = ColumnType::Array(Box::new(ColumnType::Uint256));
+    assert_eq!(u256_arr.to_clickhouse_type(), "Array(UInt256)");
+
+    let addr_arr = ColumnType::Array(Box::new(ColumnType::Address));
+    assert_eq!(addr_arr.to_clickhouse_type(), "Array(FixedString(42))");
+}
+
+#[test]
+fn test_pg_types_unchanged() {
+    // Ensure PG mapping wasn't broken by the CH fix
+    assert_eq!(ColumnType::Uint256.to_postgres_type(), "NUMERIC");
+    assert_eq!(ColumnType::Uint128.to_postgres_type(), "NUMERIC");
+    assert_eq!(ColumnType::Int256.to_postgres_type(), "NUMERIC");
+    assert_eq!(ColumnType::Address.to_postgres_type(), "CHAR(42)");
+    assert_eq!(ColumnType::Uint64.to_postgres_type(), "BIGINT");
+}
+
+#[test]
+fn test_ddl_for_activities_raw_table() {
+    // Simulate what rindexer would generate for our rindexer-ch.yaml activities_raw table
+    let columns: Vec<(&str, ColumnType)> = vec![
+        ("id", ColumnType::Uint64),
+        ("block_number", ColumnType::Uint64),
+        ("block_timestamp", ColumnType::Uint64),
+        ("transaction_hash", ColumnType::String),
+        ("address", ColumnType::Address),
+        ("user_id", ColumnType::Address),
+        ("asset", ColumnType::String),
+        ("condition_id", ColumnType::String),
+        ("neg_risk_market_id", ColumnType::String),
+        ("amount_usdc", ColumnType::Uint256),
+        ("amount_shares", ColumnType::Uint256),
+        ("tx_type", ColumnType::String),
+        ("side", ColumnType::String),
+        ("order_hash", ColumnType::String),
+        ("counterparty_id", ColumnType::Address),
+        ("order_type", ColumnType::String),
+        ("fee", ColumnType::Uint256),
+        ("builder", ColumnType::String),
+        ("is_deleted", ColumnType::Uint8),
+    ];
+
+    let ddl_parts: Vec<String> = columns
+        .iter()
+        .map(|(name, ct)| format!("  `{}` {}", name, ct.to_clickhouse_type()))
+        .collect();
+    let ddl = format!(
+        "CREATE TABLE test.activities_raw (\n{}\n) ENGINE = MergeTree() ORDER BY id",
+        ddl_parts.join(",\n")
+    );
+
+    // Verify key types in DDL
+    assert!(ddl.contains("`amount_usdc` UInt256"), "amount_usdc should be UInt256, got:\n{ddl}");
+    assert!(ddl.contains("`amount_shares` UInt256"), "amount_shares should be UInt256");
+    assert!(ddl.contains("`fee` UInt256"), "fee should be UInt256");
+    assert!(ddl.contains("`address` FixedString(42)"), "address should be FixedString(42)");
+    assert!(ddl.contains("`user_id` FixedString(42)"), "user_id should be FixedString(42)");
+    assert!(ddl.contains("`id` UInt64"), "id should be UInt64");
+    assert!(ddl.contains("`is_deleted` UInt8"), "is_deleted should be UInt8");
+
+    // Verify no String fallback for numeric/address types
+    assert!(!ddl.contains("`amount_usdc` String"), "amount_usdc must NOT be String");
+    assert!(!ddl.contains("`address` String"), "address must NOT be String");
+}
+
+// =========================================================================
+// E2E tests — require running ClickHouse (run with --ignored)
+// =========================================================================
+
+#[cfg(test)]
+fn ch_query(query: &str) -> Result<String, String> {
+    use std::io::Read;
+    let url =
+        std::env::var("CLICKHOUSE_URL").unwrap_or_else(|_| "http://localhost:8123".to_string());
+    let user = std::env::var("CLICKHOUSE_USER").unwrap_or_else(|_| "default".to_string());
+    let password = std::env::var("CLICKHOUSE_PASSWORD").unwrap_or_default();
+
+    let full_url = format!("{}/?user={}&password={}", url, user, password);
+    let mut handle = std::process::Command::new("curl")
+        .args(["-sf", "--data-binary", query, &full_url])
+        .output()
+        .map_err(|e| format!("curl failed: {e}"))?;
+
+    if handle.status.success() {
+        Ok(String::from_utf8_lossy(&handle.stdout).trim().to_string())
+    } else {
+        Err(format!("CH error: {}", String::from_utf8_lossy(&handle.stderr).trim()))
+    }
+}
+
+#[test]
+#[ignore]
+fn test_e2e_native_types_create_and_insert() {
+    let db = "rindexer_e2e_types";
+
+    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
+    ch_query(&format!("CREATE DATABASE {db}")).unwrap();
+
+    // DDL with native types (what rindexer now generates)
+    ch_query(&format!(
+        "CREATE TABLE {db}.activities_raw (
+            id UInt64,
+            block_number UInt64,
+            address FixedString(42),
+            user_id FixedString(42),
+            amount_usdc UInt256,
+            amount_shares UInt256,
+            fee UInt256,
+            tx_type String,
+            side String,
+            is_deleted UInt8
+        ) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    // Insert with decimal string values for UInt256 (same as rindexer serialization)
+    ch_query(&format!(
+        "INSERT INTO {db}.activities_raw VALUES \
+        (1, 85267446, '0xe111180000d2663C0091e4f400237545B87B996B', \
+        '0x1234567890123456789012345678901234567890', \
+        1500000, 2000000, 30000, 'TRADE', 'BUY', 0)"
+    ))
+    .unwrap();
+
+    // Verify Float64 division on UInt256 (the core of our transform MV pattern)
+    let usdc =
+        ch_query(&format!("SELECT toFloat64(amount_usdc) / 1e6 FROM {db}.activities_raw")).unwrap();
+    assert_eq!(usdc, "1.5");
+
+    let price = ch_query(&format!(
+        "SELECT toFloat64(amount_usdc) / toFloat64(amount_shares) FROM {db}.activities_raw"
+    ))
+    .unwrap();
+    assert_eq!(price, "0.75");
+
+    // Verify lower() on FixedString(42) addresses
+    let addr = ch_query(&format!("SELECT lower(address) FROM {db}.activities_raw")).unwrap();
+    assert_eq!(addr, "0xe111180000d2663c0091e4f400237545b87b996b");
+
+    ch_query(&format!("DROP DATABASE {db}")).unwrap();
+}
+
+#[test]
+#[ignore]
+fn test_e2e_transform_mv_pipeline() {
+    let db = "rindexer_e2e_mv";
+
+    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
+    ch_query(&format!("CREATE DATABASE {db}")).unwrap();
+
+    // Raw table
+    ch_query(&format!(
+        "CREATE TABLE {db}.raw (
+            id UInt64, amount_usdc UInt256, amount_shares UInt256,
+            tx_type String, address FixedString(42), fee UInt256, is_deleted UInt8
+        ) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    // Transformed table
+    ch_query(&format!(
+        "CREATE TABLE {db}.trades (
+            id String, amount_usdc Float64, shares Float64,
+            price_usdc Float64, fee Float64, is_deleted UInt8
+        ) ENGINE = MergeTree() ORDER BY id"
+    ))
+    .unwrap();
+
+    // Streaming MV — use _raw suffixed names to avoid alias shadowing,
+    // then rename in the outer expression. This is the pattern our production
+    // MVs must use when amount_usdc alias shadows the source column.
+    ch_query(&format!(
+        "CREATE MATERIALIZED VIEW {db}.mv_transform TO {db}.trades AS
+        SELECT
+            toString(id) AS id,
+            toFloat64(_raw_usdc) / 1e6 AS amount_usdc,
+            toFloat64(_raw_shares) / 1e6 AS shares,
+            if(_raw_shares = toUInt256(0), toFloat64(0),
+               toFloat64(_raw_usdc) / toFloat64(_raw_shares)) AS price_usdc,
+            if(lower(address) IN (
+                '0xe111180000d2663c0091e4f400237545b87b996b',
+                '0xe2222d002000ba0053cef3375333610f64600036'
+            ), toFloat64(fee) / 1e6, 0) AS fee,
+            is_deleted
+        FROM (
+            SELECT *, amount_usdc AS _raw_usdc, amount_shares AS _raw_shares
+            FROM {db}.raw
+            WHERE tx_type = 'TRADE'
+        )"
+    ))
+    .unwrap();
+
+    // Insert raw data
+    ch_query(&format!(
+        "INSERT INTO {db}.raw VALUES \
+        (1, 1500000, 2000000, 'TRADE', '0xe111180000d2663C0091e4f400237545B87B996B', 30000, 0), \
+        (2, 500000, 1000000, 'TRADE', '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E', 10000, 0), \
+        (3, 750000, 750000, 'SPLIT', '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045', 0, 0)"
+    ))
+    .unwrap();
+
+    // MV should only capture TRADE rows
+    let count = ch_query(&format!("SELECT count() FROM {db}.trades")).unwrap();
+    assert_eq!(count, "2");
+
+    // Row 1: V2 address → fee applied
+    let r1 = ch_query(&format!(
+        "SELECT amount_usdc, shares, price_usdc, fee FROM {db}.trades WHERE id = '1'"
+    ))
+    .unwrap();
+    assert_eq!(r1, "1.5\t2\t0.75\t0.03");
+
+    // Row 2: V1 address → fee = 0
+    let r2 = ch_query(&format!(
+        "SELECT amount_usdc, shares, price_usdc, fee FROM {db}.trades WHERE id = '2'"
+    ))
+    .unwrap();
+    assert_eq!(r2, "0.5\t1\t0.5\t0");
+
+    ch_query(&format!("DROP DATABASE {db}")).unwrap();
+}
+
+#[test]
+#[ignore]
+fn test_e2e_uint256_max_roundtrip() {
+    let db = "rindexer_e2e_max";
+    let max_str = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+    ch_query(&format!("DROP DATABASE IF EXISTS {db}")).unwrap();
+    ch_query(&format!("CREATE DATABASE {db}")).unwrap();
+    ch_query(&format!("CREATE TABLE {db}.t (val UInt256) ENGINE = MergeTree() ORDER BY val"))
+        .unwrap();
+
+    ch_query(&format!("INSERT INTO {db}.t VALUES ({max_str})")).unwrap();
+
+    let result = ch_query(&format!("SELECT val FROM {db}.t")).unwrap();
+    assert_eq!(result, max_str, "U256::MAX must survive CH round-trip");
+
+    ch_query(&format!("DROP DATABASE {db}")).unwrap();
+}

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -6,6 +6,9 @@
 ### Bug fixes
 -------------------------------------------------
 
+- fix: **ClickHouse no-code tables now use native types** — `uint256` columns map to `UInt256` (was `String`), `uint128` to `UInt128`, `int256` to `Int256`, `int128` to `Int128`, and `address` to `FixedString(42)` (was `String`). Custom table types now match raw event table types (`solidity_type_to_clickhouse_type`), ensuring consistent schemas across the same rindexer project.
+- fix: **ClickHouse serialization no longer panics on PG-specific type wrappers** — `U256Numeric`, `I256Numeric`, `U256Bytes`, `I256Bytes`, `AddressBytes`, and their Nullable/Vec variants are now serialized correctly for ClickHouse instead of panicking with `"Clickhouse in no-code should never encounter these types"`. This enables no-code tables with `$if()` conditions, arithmetic expressions, and direct `uint256`/`address` field references to work with the ClickHouse storage backend. Previously, any computed value or conditional expression in a no-code table would crash when writing to ClickHouse.
+
 ### Features
 -------------------------------------------------
 

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -12,6 +12,8 @@
 ### Features
 -------------------------------------------------
 
+- feat: **`database` field on custom tables** — optional YAML field that directs a custom table to a specific ClickHouse database (or PostgreSQL schema) instead of the default `{project}_{contract}` naming. Enables multiple contracts to write to a shared table (e.g., `database: indexer` → `indexer.events`).
+
 ## Releases
 -------------------------------------------------
 

--- a/documentation/docs/pages/docs/start-building/tables/index.mdx
+++ b/documentation/docs/pages/docs/start-building/tables/index.mdx
@@ -273,6 +273,46 @@ throttle to respect these limits - but this can make indexing take hours instead
 
 ---
 
+### database
+
+Optional override for the database (ClickHouse) or schema (PostgreSQL) where this table is created.
+By default, custom tables are created in `{project}_{contract}` (e.g., `myindexer_usdc.balances`).
+When `database` is set, the table is created in the specified database instead.
+
+```yaml
+tables:
+  - name: events
+    database: indexer  // [!code focus]
+    columns:
+      - name: id
+      - name: amount
+```
+
+This is useful when multiple contracts should write to the **same table**. Without `database`, each
+contract gets its own isolated table. With `database`, all contracts sharing the same value write
+to the same `{database}.{table_name}`.
+
+```yaml
+contracts:
+  - name: ExchangeA
+    tables:
+      - name: trades
+        database: shared    # → shared.trades
+        ...
+  - name: ExchangeB
+    tables:
+      - name: trades
+        database: shared    # → shared.trades (same table!)
+        ...
+```
+
+:::info[Raw event tables are not affected]
+The `database` override only applies to custom tables. Raw event tables (auto-generated from ABI)
+always use the default `{project}_{contract}` database for isolation.
+:::
+
+---
+
 ### columns
 
 Define the columns in your table.


### PR DESCRIPTION
New optional database field on no-code table definitions. When set, the custom table is created in the specified    
  database/schema instead of the default `{project}_{contract}` database. Raw event tables are unaffected.

```
  tables:                                                                                                             
    - name: events
      database: indexer  # ← all contracts write to indexer.events                                                    
      columns: ...                                          
````
                                                                                                             
Without database:, behavior is unchanged: tables go to `{project}_{contract}.{table}` as before.                     
                                                                                                                      
Use case: Multiple contracts indexing the same event type can direct their custom tables to a shared database, enabling streaming MVs to read from a single source table instead of UNION ALL across per-contract databases.