### PR TITLE
fix for no-code panic bug

### DIFF
--- a/core/src/event/callback_registry.rs
+++ b/core/src/event/callback_registry.rs
@@ -47,8 +47,7 @@ pub enum CallbackResult {
 }
 
 impl CallbackResult {
-    ///return the (from_block, to_block, network) entry regardless of variant
-
+    /// return the (from_block, to_block, network) entry regardless of variant
     pub fn first_metadata(&self) -> Option<(U64, U64, String)> {
         match self {
             Self::Event(events) => events.first().map(|e| {

--- a/core/src/event/callback_registry.rs
+++ b/core/src/event/callback_registry.rs
@@ -46,6 +46,33 @@ pub enum CallbackResult {
     Trace(Vec<TraceResult>),
 }
 
+impl CallbackResult {
+    ///return the (from_block, to_block, network) entry regardless of variant
+
+    pub fn first_metadata(&self) -> Option<(U64, U64, String)> {
+        match self {
+            Self::Event(events) => events.first().map(|e| {
+                (
+                    e.found_in_request.from_block,
+                    e.found_in_request.to_block,
+                    e.tx_information.network.clone(),
+                )
+            }),
+            Self::Trace(traces) => traces.first().map(|t| {
+                let (fir, tx) = match t {
+                    TraceResult::NativeTransfer { found_in_request, tx_information, .. } => {
+                        (found_in_request, tx_information)
+                    }
+                    TraceResult::Block { found_in_request, tx_information, .. } => {
+                        (found_in_request, tx_information)
+                    }
+                };
+                (fir.from_block, fir.to_block, tx.network.clone())
+            }),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TxInformation {
     pub chain_id: u64,
@@ -505,5 +532,130 @@ where
                 sleep(delay).await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::network::AnyRpcBlock;
+
+    fn test_tx_information(network: &str) -> TxInformation {
+        TxInformation {
+            chain_id: 31337,
+            network: network.to_string(),
+            address: Address::ZERO,
+            block_hash: BlockHash::ZERO,
+            block_number: 0,
+            block_timestamp: None,
+            transaction_hash: TxHash::ZERO,
+            transaction_index: 0,
+            log_index: U256::ZERO,
+        }
+    }
+
+    fn test_found_in_request(from_block: u64, to_block: u64) -> LogFoundInRequest {
+        LogFoundInRequest { from_block: U64::from(from_block), to_block: U64::from(to_block) }
+    }
+
+    //Minimal valid json for alloy::network::AnyRpcBlock deserialization
+    const TEST_BLOCK_JSON: &str = r#"{
+        "number": "0x0",
+        "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "transactionsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "receiptsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "miner": "0x0000000000000000000000000000000000000000",
+        "difficulty": "0x0",
+        "extraData": "0x",
+        "size": "0x0",
+        "gasLimit": "0x0",
+        "gasUsed": "0x0",
+        "timestamp": "0x0",
+        "transactions": [],
+        "uncles": []
+    }"#;
+
+    const TEST_LOG_JSON: &str = r#"{
+        "address": "0x0000000000000000000000000000000000000000",
+        "topics": [],
+        "data": "0x",
+        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "blockNumber": "0x0",
+        "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "transactionIndex": "0x0",
+        "logIndex": "0x0",
+        "removed": false
+    }"#;
+
+    fn test_block() -> AnyRpcBlock {
+        serde_json::from_str(TEST_BLOCK_JSON).expect("test block JSON should deserialize")
+    }
+
+    fn test_log() -> Log {
+        serde_json::from_str(TEST_LOG_JSON).expect("test log JSON should deserialize")
+    }
+
+    #[test]
+    fn first_metadata_event_returns_fields_from_first_entry() {
+        let event = EventResult {
+            log: test_log(),
+            decoded_data: Arc::new(()),
+            tx_information: test_tx_information("mainnet"),
+            found_in_request: test_found_in_request(10, 20),
+        };
+        let result = CallbackResult::Event(vec![event]);
+        let (from_block, to_block, network) = result.first_metadata().expect("non-empty batch");
+        assert_eq!(from_block, U64::from(10));
+        assert_eq!(to_block, U64::from(20));
+        assert_eq!(network, "mainnet");
+    }
+
+    #[test]
+    fn first_metadata_trace_native_transfer_returns_fields() {
+        let nt = TraceResult::NativeTransfer {
+            from: Address::ZERO,
+            to: Address::ZERO,
+            value: U256::ZERO,
+            tx_information: test_tx_information("anvil"),
+            found_in_request: test_found_in_request(5, 15),
+        };
+        let result = CallbackResult::Trace(vec![nt]);
+        let (from_block, to_block, network) = result.first_metadata().expect("non-empty batch");
+        assert_eq!(from_block, U64::from(5));
+        assert_eq!(to_block, U64::from(15));
+        assert_eq!(network, "anvil");
+    }
+
+    //native_transfer_block_consumer always fires trigger_event with a Block-only batch before firing the
+    // NativeTransfer batch, so first_metadata must
+    // extract cleanly from a TraceResult::Block without panicking
+    #[test]
+    fn first_metadata_trace_block_returns_fields() {
+        let b = TraceResult::Block {
+            block: Box::new(test_block()),
+            tx_information: test_tx_information("polygon"),
+            found_in_request: test_found_in_request(100, 200),
+        };
+        let result = CallbackResult::Trace(vec![b]);
+        let (from_block, to_block, network) = result.first_metadata().expect("non-empty batch");
+        assert_eq!(from_block, U64::from(100));
+        assert_eq!(to_block, U64::from(200));
+        assert_eq!(network, "polygon");
+    }
+
+    #[test]
+    fn first_metadata_empty_event_returns_none() {
+        let result = CallbackResult::Event(vec![]);
+        assert!(result.first_metadata().is_none());
+    }
+
+    #[test]
+    fn first_metadata_empty_trace_returns_none() {
+        let result = CallbackResult::Trace(vec![]);
+        assert!(result.first_metadata().is_none());
     }
 }

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -338,46 +338,29 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
                 return Ok(());
             }
 
-            // TODO
-            // Remove unwrap
-            let (from_block, to_block) = match &results {
-                CallbackResult::Event(event) => (
-                    event.first().unwrap().found_in_request.from_block,
-                    event.first().unwrap().found_in_request.to_block,
-                ),
-                CallbackResult::Trace(event) => {
-                    // Filter to only NativeTransfer events and get the first one
-                    let native_transfer = event
-                        .iter()
-                        .filter_map(|result| match result {
-                            TraceResult::NativeTransfer { found_in_request, .. } => {
-                                Some(found_in_request)
-                            }
-                            TraceResult::Block { .. } => None,
-                        })
-                        .next()
-                        .unwrap();
-                    (native_transfer.from_block, native_transfer.to_block)
-                }
-            };
-
-            let network = match &results {
+            // event_length > 0 check above guarantees at least one entry. Both trace
+            // variants carry the same metadata in found_in_request/tx_information, so
+            // we extract from whichever variant is first without discriminating.
+            let (from_block, to_block, network) = match &results {
                 CallbackResult::Event(event) => {
-                    event.first().unwrap().tx_information.network.clone()
+                    let first = event.first().expect("event_length > 0");
+                    (
+                        first.found_in_request.from_block,
+                        first.found_in_request.to_block,
+                        first.tx_information.network.clone(),
+                    )
                 }
                 CallbackResult::Trace(event) => {
-                    // Filter to only NativeTransfer events and get the first one
-                    event
-                        .iter()
-                        .filter_map(|result| match result {
-                            TraceResult::NativeTransfer { tx_information, .. } => {
-                                Some(&tx_information.network)
-                            }
-                            TraceResult::Block { .. } => None,
-                        })
-                        .next()
-                        .unwrap()
-                        .clone()
+                    let first = event.first().expect("event_length > 0");
+                    let (fir, tx_info) = match first {
+                        TraceResult::NativeTransfer {
+                            found_in_request, tx_information, ..
+                        } => (found_in_request, tx_information),
+                        TraceResult::Block { found_in_request, tx_information, .. } => {
+                            (found_in_request, tx_information)
+                        }
+                    };
+                    (fir.from_block, fir.to_block, tx_info.network.clone())
                 }
             };
 

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -338,31 +338,9 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
                 return Ok(());
             }
 
-            // event_length > 0 check above guarantees at least one entry. Both trace
-            // variants carry the same metadata in found_in_request/tx_information, so
-            // we extract from whichever variant is first without discriminating.
-            let (from_block, to_block, network) = match &results {
-                CallbackResult::Event(event) => {
-                    let first = event.first().expect("event_length > 0");
-                    (
-                        first.found_in_request.from_block,
-                        first.found_in_request.to_block,
-                        first.tx_information.network.clone(),
-                    )
-                }
-                CallbackResult::Trace(event) => {
-                    let first = event.first().expect("event_length > 0");
-                    let (fir, tx_info) = match first {
-                        TraceResult::NativeTransfer {
-                            found_in_request, tx_information, ..
-                        } => (found_in_request, tx_information),
-                        TraceResult::Block { found_in_request, tx_information, .. } => {
-                            (found_in_request, tx_information)
-                        }
-                    };
-                    (fir.from_block, fir.to_block, tx_info.network.clone())
-                }
-            };
+            //guarantees non empty batch
+            let (from_block, to_block, network) =
+                results.first_metadata().expect("event_length > 0 guarantees at least one entry");
 
             let mut indexed_count = 0;
             let mut sql_bulk_data: Vec<Vec<EthereumSqlTypeWrapper>> = Vec::new();

--- a/e2e-tests/src/anvil_setup.rs
+++ b/e2e-tests/src/anvil_setup.rs
@@ -360,6 +360,43 @@ impl AnvilInstance {
         Ok(tx_hashes)
     }
 
+    ///send plain eth transfer
+    pub async fn send_eth_transfer(
+        &self,
+        to: &ethers::types::Address,
+        amount: ethers::types::U256,
+    ) -> Result<String> {
+        use ethers::middleware::MiddlewareBuilder;
+        use ethers::providers::{Http, Middleware, Provider};
+        use ethers::signers::{LocalWallet, Signer};
+        use ethers::types::TransactionRequest;
+
+        let base_provider = Provider::<Http>::try_from(&self.rpc_url)?;
+        let chain_id = base_provider.get_chainid().await?.as_u64();
+
+        let wallet: LocalWallet = ANVIL_DEFAULT_PRIVATE_KEY.parse()?;
+        let wallet = wallet.with_chain_id(chain_id);
+        let signer_address = wallet.address();
+        let provider = base_provider.with_signer(wallet);
+
+        let nonce = provider.get_transaction_count(signer_address, None).await?;
+
+        let tx = TransactionRequest {
+            from: Some(signer_address),
+            to: Some((*to).into()),
+            data: None,
+            gas: Some(21000u64.into()),
+            nonce: Some(nonce),
+            gas_price: Some(20000000000u128.into()),
+            value: Some(amount),
+            chain_id: None,
+        };
+
+        let pending = provider.send_transaction(tx, None).await?;
+        let tx_hash = format!("{:?}", pending.tx_hash()).to_lowercase();
+        Ok(tx_hash)
+    }
+
     /// Get transaction receipt.
     #[allow(dead_code)]
     pub async fn get_receipt(&self, tx_hash: &str) -> Result<TxReceipt> {

--- a/e2e-tests/src/rindexer_client.rs
+++ b/e2e-tests/src/rindexer_client.rs
@@ -422,7 +422,11 @@ impl RindexerInstance {
                 csv: crate::test_suite::CsvConfig { enabled: true },
                 clickhouse: None,
             },
-            native_transfers: crate::test_suite::NativeTransfersConfig { enabled: false },
+            native_transfers: crate::test_suite::NativeTransfersConfig {
+                enabled: false,
+                networks: None,
+                generate_csv: None,
+            },
             contracts: vec![],
         }
     }

--- a/e2e-tests/src/test_suite.rs
+++ b/e2e-tests/src/test_suite.rs
@@ -71,6 +71,19 @@ pub struct CsvConfig {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct NativeTransfersConfig {
     pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub networks: Option<Vec<NativeTransferNetworkDetail>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generate_csv: Option<bool>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct NativeTransferNetworkDetail {
+    pub network: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_block: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_block: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/e2e-tests/src/tests/direct_rpc.rs
+++ b/e2e-tests/src/tests/direct_rpc.rs
@@ -111,7 +111,11 @@ fn build_direct_rpc_config(
             csv: CsvConfig { enabled: true },
             clickhouse: None,
         },
-        native_transfers: NativeTransfersConfig { enabled: false },
+        native_transfers: NativeTransfersConfig {
+            enabled: false,
+            networks: None,
+            generate_csv: None,
+        },
         contracts: vec![ContractConfig {
             name: "ERC20".to_string(),
             details: vec![ContractDetail {

--- a/e2e-tests/src/tests/mod.rs
+++ b/e2e-tests/src/tests/mod.rs
@@ -10,6 +10,7 @@ pub mod health_assertions;
 pub mod historic_indexing;
 pub mod live_indexing;
 pub mod multi_network;
+pub mod native_transfer;
 pub mod postgres_e2e;
 pub mod reorg_e2e;
 pub mod restart_checkpoint;

--- a/e2e-tests/src/tests/multi_network.rs
+++ b/e2e-tests/src/tests/multi_network.rs
@@ -268,7 +268,11 @@ fn build_multi_network_config(
             csv: CsvConfig { enabled: true },
             clickhouse: None,
         },
-        native_transfers: NativeTransfersConfig { enabled: false },
+        native_transfers: NativeTransfersConfig {
+            enabled: false,
+            networks: None,
+            generate_csv: None,
+        },
         contracts: vec![
             ContractConfig {
                 name: "RocketPoolETH".to_string(),

--- a/e2e-tests/src/tests/native_transfer.rs
+++ b/e2e-tests/src/tests/native_transfer.rs
@@ -1,0 +1,197 @@
+use anyhow::{Context, Result};
+use ethers::types::U256;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
+use tracing::info;
+
+use crate::test_suite::{
+    ContractConfig, ContractDetail, CsvConfig, EventConfig, GlobalConfig,
+    NativeTransferNetworkDetail, NativeTransfersConfig, NetworkConfig, RindexerConfig,
+    StorageConfig, TestContext,
+};
+use crate::tests::helpers::{
+    generate_test_address, parse_transfer_csv, produced_csv_path_for, validate_csv_structure,
+};
+use crate::tests::registry::{TestDefinition, TestModule};
+
+pub struct NativeTransferTests;
+
+impl TestModule for NativeTransferTests {
+    fn get_tests() -> Vec<TestDefinition> {
+        vec![TestDefinition::new(
+            "test_native_transfer_csv_no_panic",
+            "Native transfers + no-code CSV: Block-only trace batches must not panic the callback",
+            native_transfer_csv_no_panic_test,
+        )
+        .with_timeout(120)]
+    }
+}
+
+/// Regression test for a panic in the no_code trace callback at
+/// `core/src/indexer/no_code.rs`.
+///
+/// `native_transfer_block_consumer` fires `trigger_event` with a `Vec<TraceResult::Block>`
+/// batch before firing the `Vec<TraceResult::NativeTransfer>` batch. Previously the callback
+/// filtered the incoming batch for `NativeTransfer` entries only and called `.next().unwrap()`
+/// on the result, which panicked on the first Block-only batch.
+///
+/// With the fix, both variants produce the metadata the callback needs, so processing succeeds
+/// and the CSV gets written. This test enables `native_transfers` against a local anvil node
+/// and asserts the native-transfer CSV ends up with one row per plain ETH transfer we sent.
+fn native_transfer_csv_no_panic_test(
+    context: &mut TestContext,
+) -> Pin<Box<dyn Future<Output = Result<()>> + '_>> {
+    Box::pin(async move {
+        info!("Running Native Transfer no-code CSV regression test");
+
+        // A contract is included to get a reliable `100.00% progress` sync signal and to
+        // exercise the trace path alongside a normal event path. The contract deployment
+        // emits a Transfer event in its constructor but does not move ETH, so the native
+        // transfer CSV is unaffected by it.
+        let contract_address = context.deploy_test_contract().await?;
+
+        // Three plain ETH transfers to deterministic recipients, mined explicitly to avoid
+        // relying on anvil's 1s auto-mine timing.
+        let recipients: Vec<ethers::types::Address> = (0..3).map(generate_test_address).collect();
+        let one_eth = U256::from(1_000_000_000_000_000_000u64);
+
+        let mut expected_tx_hashes = Vec::new();
+        for (i, recipient) in recipients.iter().enumerate() {
+            let tx_hash = context.anvil.send_eth_transfer(recipient, one_eth).await?;
+            context.anvil.mine_block().await?;
+            info!("ETH transfer {}: 1 ETH to {:?} (tx={})", i, recipient, tx_hash);
+            expected_tx_hashes.push(tx_hash);
+        }
+
+        let end_block = context.anvil.get_block_number().await?;
+        info!("Chain tip after seeding: block {}", end_block);
+
+        // Bound both the contract and native_transfers with end_block so neither enters
+        // live phase. This keeps the test's scope limited to historical indexing only,
+        // which is where the panic was triggered.
+        let config = RindexerConfig {
+            name: "native_transfer_no_panic".to_string(),
+            project_type: "no-code".to_string(),
+            config: serde_json::json!({}),
+            timestamps: None,
+            networks: vec![NetworkConfig {
+                name: "anvil".to_string(),
+                chain_id: 31337,
+                rpc: context.anvil.rpc_url.clone(),
+            }],
+            global: GlobalConfig { health_port: context.health_port },
+            storage: StorageConfig {
+                postgres: None,
+                csv: CsvConfig { enabled: true },
+                clickhouse: None,
+            },
+            native_transfers: NativeTransfersConfig {
+                enabled: true,
+                networks: Some(vec![NativeTransferNetworkDetail {
+                    network: "anvil".to_string(),
+                    start_block: Some("0".to_string()),
+                    end_block: Some(end_block.to_string()),
+                }]),
+                generate_csv: Some(true),
+            },
+            contracts: vec![ContractConfig {
+                name: "SimpleERC20".to_string(),
+                details: vec![ContractDetail {
+                    network: "anvil".to_string(),
+                    address: contract_address.clone(),
+                    start_block: "0".to_string(),
+                    end_block: Some(end_block.to_string()),
+                }],
+                abi: Some("./abis/SimpleERC20.abi.json".to_string()),
+                reorg_safe_distance: None,
+                include_events: Some(vec![EventConfig { name: "Transfer".to_string() }]),
+                tables: None,
+            }],
+        };
+
+        context.start_rindexer(config).await?;
+
+        // This returns early on process death (catches a panic that kills rindexer) or
+        // when progress hits 100% on any pipeline (contract or native transfer).
+        context.wait_for_sync_completion(30).await?;
+
+        // Contract's 100% progress typically fires before native transfer's, so poll the
+        // native transfer CSV here until it has the expected rows. This also catches the
+        // case where rindexer is still alive but the callback panicked on a spawned task
+        // and the native pipeline never wrote anything.
+        let csv_path = produced_csv_path_for(context, "EvmTraces", "nativetransfer");
+        let expected_rows = recipients.len();
+
+        let start = Instant::now();
+        let poll_timeout = Duration::from_secs(30);
+        loop {
+            if start.elapsed() > poll_timeout {
+                let current = std::fs::read_to_string(&csv_path).ok();
+                return Err(anyhow::anyhow!(
+                    "Timeout waiting for {} native transfer rows at {}. Current content: {:?}",
+                    expected_rows,
+                    csv_path,
+                    current
+                ));
+            }
+            if std::path::Path::new(&csv_path).exists() {
+                if let Ok(content) = std::fs::read_to_string(&csv_path) {
+                    let data_rows = content.lines().count().saturating_sub(1);
+                    if data_rows >= expected_rows {
+                        break;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        let (headers, rows) =
+            parse_transfer_csv(&csv_path).context("Failed to parse native transfer CSV")?;
+
+        validate_csv_structure(&headers, &rows)
+            .context("Native transfer CSV failed structural validation")?;
+
+        if rows.len() != expected_rows {
+            return Err(anyhow::anyhow!(
+                "Expected exactly {} native transfer rows, got {}",
+                expected_rows,
+                rows.len()
+            ));
+        }
+
+        // Each recipient must appear as a `to` address in exactly one row, and each
+        // transaction we sent must appear exactly once. Order-independent checks so
+        // the test is resilient to any minor ordering differences the pipeline might
+        // introduce across variants.
+        let got_to: std::collections::BTreeSet<String> =
+            rows.iter().map(|r| r.to.clone()).collect();
+        let expected_to: std::collections::BTreeSet<String> =
+            recipients.iter().map(|r| format!("0x{}", hex::encode(r.as_bytes()))).collect();
+        if got_to != expected_to {
+            return Err(anyhow::anyhow!(
+                "Row recipients don't match: got {:?}, expected {:?}",
+                got_to,
+                expected_to
+            ));
+        }
+
+        let got_tx: std::collections::BTreeSet<String> =
+            rows.iter().map(|r| r.tx_hash.clone()).collect();
+        let expected_tx: std::collections::BTreeSet<String> =
+            expected_tx_hashes.iter().cloned().collect();
+        if got_tx != expected_tx {
+            return Err(anyhow::anyhow!(
+                "Row tx_hashes don't match: got {:?}, expected {:?}",
+                got_tx,
+                expected_tx
+            ));
+        }
+
+        info!(
+            "Native Transfer CSV regression test PASSED: {} rows, recipients and tx hashes match",
+            rows.len()
+        );
+        Ok(())
+    })
+}

--- a/e2e-tests/src/tests/native_transfer.rs
+++ b/e2e-tests/src/tests/native_transfer.rs
@@ -79,6 +79,7 @@ fn native_transfer_csv_no_panic_test(
                 name: "anvil".to_string(),
                 chain_id: 31337,
                 rpc: context.anvil.rpc_url.clone(),
+                reorg_handling: None,
             }],
             global: GlobalConfig { health_port: context.health_port },
             storage: StorageConfig {
@@ -107,6 +108,7 @@ fn native_transfer_csv_no_panic_test(
                 reorg_safe_distance: None,
                 include_events: Some(vec![EventConfig { name: "Transfer".to_string() }]),
                 tables: None,
+                streams: None,
             }],
         };
 

--- a/e2e-tests/src/tests/registry.rs
+++ b/e2e-tests/src/tests/registry.rs
@@ -77,6 +77,9 @@ impl TestRegistry {
         // Direct RPC
         tests.extend(crate::tests::direct_rpc::DirectRpcTests::get_tests());
 
+        // Native transfers
+        tests.extend(crate::tests::native_transfer::NativeTransferTests::get_tests());
+
         // Reorg handling
         tests.extend(crate::tests::reorg_e2e::ReorgTests::get_tests());
 

--- a/graphql/package-lock.json
+++ b/graphql/package-lock.json
@@ -1216,6 +1216,7 @@
       "resolved": "https://registry.npmjs.org/graphile-build/-/graphile-build-4.14.1.tgz",
       "integrity": "sha512-l/ylyMK0vl5LCOScpTsTedNZUqwBgafXS7RPDW1YiQofeioVtTDMdV9k3zRkXdMKtKqJsvOBvjXn64WGLaLInQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphile/lru": "4.11.0",
         "chalk": "^2.4.2",
@@ -1239,6 +1240,7 @@
       "resolved": "https://registry.npmjs.org/graphile-build-pg/-/graphile-build-pg-4.14.1.tgz",
       "integrity": "sha512-7DIVbcfMU5lXNkGnAeobqm29AvjFYw4/xOlKNQk3NE/mfFDcyPuXYboypmtxzglg1hGXkyONLYnas9vzL+SunQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphile/lru": "4.11.0",
         "chalk": "^2.4.2",
@@ -1364,6 +1366,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz",
       "integrity": "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -3446,6 +3449,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
In no_code.rs line 361, the trace callback filters the incoming batch for TraceResult::NativeTransfer entries and calls .unwrap() on the result

native_transfer_block_consumer always fires trigger_event with a block only batch first before firing the NativeTransfer batch, so the filter produces an empty iterator and the unwrap causes a panic.

This seems to happen on the first block processed whenever native_transfers is enabled with no_code CSV output, making this portion unusable

I came across this bug when trying to verify my own version of a fix proposed in this PR #368 




update:

To add coverage for no_code.rs fix:

- Given that no_code.rs had no_code_callback taking NoCodeCallBackParams, it was difficult writing unit test coverage with this structure because NoCodeCallBackParams is a huge load of stuff that this unit test shouldn't be concerned with

- extracted the code this PR is concerned with into a function first_metadata() so it could be 
unit tested in isolation

- wrote 5 unit tests supporting each outcome:
1. first_metadata_event_returns_fields_from_first_entry (Event)
2. first_metadata_trace_native_transfer_returns_fields (NativeTransfer variant)
3. first_metadata_trace_block_returns_fields (Block variant) <----- this is where the bug was
4. first_metadata_empty_event_returns_none (empty Event input)
5. first_metadata_empty_trace_returns_none (empty Trace input)

