### PR TITLE
fix(ci): Windows release build fails at 'Skip if not a release' step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,8 @@ jobs:
 
       - name: Skip if not a release
         if: steps.check_release.outputs.is_release != 'true'
-        run: echo "Not a release commit — skipping" && exit 0
+        shell: bash
+        run: echo "Not a release commit — skipping"
 
       - name: Checkout release branch
         if: steps.check_release.outputs.is_release == 'true'

--- a/core/src/indexer/cron_scheduler.rs
+++ b/core/src/indexer/cron_scheduler.rs
@@ -1026,7 +1026,7 @@ async fn execute_cron_operations_batch(
         "RPC calls completed: {}/{} successful ({}%)",
         successful_calls,
         total_calls,
-        if total_calls > 0 { (successful_calls * 100) / total_calls } else { 0 }
+        (successful_calls * 100).checked_div(total_calls).unwrap_or(0)
     );
     let mut all_rows: Vec<TableRowData> =
         Vec::with_capacity(blocks.len() * addresses_with_blocks.len());


### PR DESCRIPTION
Fix windows builds that are getting errors on CI