### PR TITLE
feat(reorg): add reorg handling for native transfers

### DIFF
--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -126,7 +126,7 @@ pub async fn handle_add_contract_command(
         let item = &metadata.items[0];
         if item.proxy == 1 {
             if let Some(implementation) = &item.implementation {
-                abi_lookup_address = implementation.to_string().parse().unwrap();
+                abi_lookup_address = implementation.to_string().parse()?;
                 println!(
                     "This contract is a proxy contract. Loading the implementation contract {abi_lookup_address}"
                 );

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/**", "resources/**", "Cargo.toml", "build.rs"]
 tempfile = "3.23"
 mockito = "1.7.0"
 testcontainers = "0.27"
-testcontainers-modules = { version = "0.15", features = ["postgres", "clickhouse"] }
+testcontainers-modules = { version = "0.15", features = ["postgres", "clickhouse", "redis", "rabbitmq", "kafka"] }
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 rust_decimal = { version = "1.39.0", features = ["db-tokio-postgres"] }
 tokio = { version = "1", features = ["test-util"] }

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -293,7 +293,7 @@ impl ABIItem {
         }
 
         // Combine both sets of event names
-        let all_needed_events: std::collections::HashSet<String> =
+        let all_needed_events: HashSet<String> =
             include_event_names.into_iter().chain(table_event_names).collect();
 
         // Filter to only include needed events (keep all non-event items)

--- a/core/src/api/graphql.rs
+++ b/core/src/api/graphql.rs
@@ -74,7 +74,7 @@ fn get_graphql_exe() -> Result<PathBuf, Box<dyn std::error::Error>> {
     // Fall back to embedded binary (for deployed/installed versions)
     const GRAPHQL_BINARY: &[u8] = include_bytes!(env!("RINDEXER_GRAPHQL_EMBED"));
 
-    let temp_dir = std::env::temp_dir();
+    let temp_dir = env::temp_dir();
     let exe_name = if cfg!(windows) {
         format!("rindexer-graphql-{}.exe", std::process::id())
     } else {

--- a/core/src/chat/clients.rs
+++ b/core/src/chat/clients.rs
@@ -213,13 +213,10 @@ impl ChatClients {
                 if let Some(expression) = &event_for.filter_expression {
                     let result = filter_by_expression(expression, event_data);
 
-                    return match result {
-                        Ok(res) => res,
-                        Err(e) => {
-                            tracing::error!("Error evaluating filter expression: {}", e);
-                            false
-                        }
-                    };
+                    return result.unwrap_or_else(|e| {
+                        tracing::error!("Error evaluating filter expression: {}", e);
+                        false
+                    });
                 }
                 if let Some(conditions) = &event_for.conditions {
                     return filter_event_data_by_conditions(event_data, conditions);
@@ -255,13 +252,10 @@ impl ChatClients {
                 if let Some(expression) = &event_for.filter_expression {
                     let result = filter_by_expression(expression, event_data);
 
-                    return match result {
-                        Ok(res) => res,
-                        Err(e) => {
-                            tracing::error!("Error evaluating filter expression: {}", e);
-                            false
-                        }
-                    };
+                    return result.unwrap_or_else(|e| {
+                        tracing::error!("Error evaluating filter expression: {}", e);
+                        false
+                    });
                 }
                 if let Some(conditions) = &event_for.conditions {
                     return filter_event_data_by_conditions(event_data, conditions);
@@ -297,13 +291,10 @@ impl ChatClients {
                 if let Some(expression) = &event_for.filter_expression {
                     let result = filter_by_expression(expression, event_data);
 
-                    return match result {
-                        Ok(res) => res,
-                        Err(e) => {
-                            tracing::error!("Error evaluating filter expression: {}", e);
-                            false
-                        }
-                    };
+                    return result.unwrap_or_else(|e| {
+                        tracing::error!("Error evaluating filter expression: {}", e);
+                        false
+                    });
                 }
                 if let Some(conditions) = &event_for.conditions {
                     return filter_event_data_by_conditions(event_data, conditions);
@@ -336,13 +327,10 @@ impl ChatClients {
                 if let Some(expression) = &event_for.filter_expression {
                     let result = filter_by_expression(expression, event_data);
 
-                    return match result {
-                        Ok(res) => res,
-                        Err(e) => {
-                            tracing::error!("Error evaluating filter expression: {}", e);
-                            false
-                        }
-                    };
+                    return result.unwrap_or_else(|e| {
+                        tracing::error!("Error evaluating filter expression: {}", e);
+                        false
+                    });
                 }
                 if let Some(conditions) = &event_for.conditions {
                     return filter_event_data_by_conditions(event_data, conditions);
@@ -375,13 +363,10 @@ impl ChatClients {
                 if let Some(expression) = &event_for.filter_expression {
                     let result = filter_by_expression(expression, event_data);
 
-                    return match result {
-                        Ok(res) => res,
-                        Err(e) => {
-                            tracing::error!("Error evaluating filter expression: {}", e);
-                            false
-                        }
-                    };
+                    return result.unwrap_or_else(|e| {
+                        tracing::error!("Error evaluating filter expression: {}", e);
+                        false
+                    });
                 }
                 if let Some(conditions) = &event_for.conditions {
                     return filter_event_data_by_conditions(event_data, conditions);
@@ -413,13 +398,10 @@ impl ChatClients {
                 if let Some(expression) = &event_for.filter_expression {
                     let result = filter_by_expression(expression, event_data);
 
-                    return match result {
-                        Ok(res) => res,
-                        Err(e) => {
-                            tracing::error!("Error evaluating filter expression: {}", e);
-                            false
-                        }
-                    };
+                    return result.unwrap_or_else(|e| {
+                        tracing::error!("Error evaluating filter expression: {}", e);
+                        false
+                    });
                 }
                 if let Some(conditions) = &event_for.conditions {
                     return filter_event_data_by_conditions(event_data, conditions);

--- a/core/src/database/sql_type_wrapper.rs
+++ b/core/src/database/sql_type_wrapper.rs
@@ -2495,13 +2495,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "Unsupported")]
     fn test_ch_jsonb_panics() {
-        EthereumSqlTypeWrapper::JSONB(serde_json::json!({"k": "v"})).to_clickhouse_value();
+        EthereumSqlTypeWrapper::JSONB(json!({"k": "v"})).to_clickhouse_value();
     }
 
     #[test]
     #[should_panic(expected = "Unsupported")]
     fn test_ch_uuid_panics() {
-        EthereumSqlTypeWrapper::Uuid(uuid::Uuid::new_v4()).to_clickhouse_value();
+        EthereumSqlTypeWrapper::Uuid(Uuid::new_v4()).to_clickhouse_value();
     }
 
     // =========================================================================

--- a/core/src/event/callback_registry.rs
+++ b/core/src/event/callback_registry.rs
@@ -554,6 +554,219 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    fn sample_notification() -> ReorgNotification {
+        ReorgNotification {
+            network: "ethereum".to_string(),
+            fork_block: 100,
+            detection_block: 105,
+            invalidated_tx_hashes: vec![TxHash::from([0xab; 32])],
+        }
+    }
+
+    // ======================================================================
+    // ReorgNotification clone / field equality
+    // ======================================================================
+
+    #[test]
+    fn test_reorg_notification_clone() {
+        let n = sample_notification();
+        let cloned = n.clone();
+        assert_eq!(cloned.network, n.network);
+        assert_eq!(cloned.fork_block, n.fork_block);
+        assert_eq!(cloned.detection_block, n.detection_block);
+        assert_eq!(cloned.invalidated_tx_hashes, n.invalidated_tx_hashes);
+    }
+
+    // ======================================================================
+    // EventCallbackRegistry::new / default
+    // ======================================================================
+
+    #[test]
+    fn test_event_callback_registry_new_is_empty() {
+        let registry = EventCallbackRegistry::new();
+        assert!(registry.events.is_empty());
+        assert!(registry.on_reorg.is_empty());
+    }
+
+    #[test]
+    fn test_event_callback_registry_default_is_empty() {
+        let registry = EventCallbackRegistry::default();
+        assert!(registry.events.is_empty());
+        assert!(registry.on_reorg.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_event_callback_registry_fire_on_reorg_no_callbacks_noop() {
+        let registry = EventCallbackRegistry::new();
+        // No callbacks registered → must complete without panic/error.
+        registry.fire_on_reorg(sample_notification()).await;
+    }
+
+    #[tokio::test]
+    async fn test_event_callback_registry_fire_on_reorg_single_callback() {
+        let captured: Arc<StdMutex<Option<ReorgNotification>>> = Arc::new(StdMutex::new(None));
+        let captured_clone = Arc::clone(&captured);
+
+        let mut registry = EventCallbackRegistry::new();
+        registry.register_on_reorg(Arc::new(move |notification| {
+            let captured = Arc::clone(&captured_clone);
+            Box::pin(async move {
+                *captured.lock().unwrap() = Some(notification);
+            })
+        }));
+        assert_eq!(registry.on_reorg.len(), 1);
+
+        registry.fire_on_reorg(sample_notification()).await;
+
+        let observed = captured.lock().unwrap().take().expect("callback should have fired");
+        assert_eq!(observed.network, "ethereum");
+        assert_eq!(observed.fork_block, 100);
+        assert_eq!(observed.detection_block, 105);
+        assert_eq!(observed.invalidated_tx_hashes.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_event_callback_registry_fire_on_reorg_multiple_callbacks() {
+        let counter: Arc<StdMutex<u32>> = Arc::new(StdMutex::new(0));
+        let last_network: Arc<StdMutex<Option<String>>> = Arc::new(StdMutex::new(None));
+
+        let mut registry = EventCallbackRegistry::new();
+        for _ in 0..3 {
+            let counter = Arc::clone(&counter);
+            let last_network = Arc::clone(&last_network);
+            registry.register_on_reorg(Arc::new(move |n| {
+                let counter = Arc::clone(&counter);
+                let last_network = Arc::clone(&last_network);
+                Box::pin(async move {
+                    *counter.lock().unwrap() += 1;
+                    *last_network.lock().unwrap() = Some(n.network);
+                })
+            }));
+        }
+        assert_eq!(registry.on_reorg.len(), 3);
+
+        registry.fire_on_reorg(sample_notification()).await;
+
+        assert_eq!(*counter.lock().unwrap(), 3, "all three callbacks must fire");
+        assert_eq!(last_network.lock().unwrap().as_deref(), Some("ethereum"));
+    }
+
+    // ======================================================================
+    // TraceCallbackRegistry::new / default
+    // ======================================================================
+
+    #[test]
+    fn test_trace_callback_registry_new_is_empty() {
+        let registry = TraceCallbackRegistry::new();
+        assert!(registry.events.is_empty());
+        assert!(registry.on_reorg.is_empty());
+    }
+
+    #[test]
+    fn test_trace_callback_registry_default_is_empty() {
+        let registry = TraceCallbackRegistry::default();
+        assert!(registry.events.is_empty());
+        assert!(registry.on_reorg.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_trace_callback_registry_fire_on_reorg_no_callbacks_noop() {
+        let registry = TraceCallbackRegistry::new();
+        registry.fire_on_reorg(sample_notification()).await;
+    }
+
+    #[tokio::test]
+    async fn test_trace_callback_registry_fire_on_reorg_single_callback() {
+        let captured: Arc<StdMutex<Option<ReorgNotification>>> = Arc::new(StdMutex::new(None));
+        let captured_clone = Arc::clone(&captured);
+
+        let mut registry = TraceCallbackRegistry::new();
+        registry.register_on_reorg(Arc::new(move |notification| {
+            let captured = Arc::clone(&captured_clone);
+            Box::pin(async move {
+                *captured.lock().unwrap() = Some(notification);
+            })
+        }));
+        assert_eq!(registry.on_reorg.len(), 1);
+
+        registry.fire_on_reorg(sample_notification()).await;
+
+        let observed = captured.lock().unwrap().take().expect("callback should have fired");
+        assert_eq!(observed.network, "ethereum");
+        assert_eq!(observed.fork_block, 100);
+        assert_eq!(observed.detection_block, 105);
+    }
+
+    #[tokio::test]
+    async fn test_trace_callback_registry_fire_on_reorg_multiple_callbacks() {
+        let counter: Arc<StdMutex<u32>> = Arc::new(StdMutex::new(0));
+
+        let mut registry = TraceCallbackRegistry::new();
+        for _ in 0..3 {
+            let counter = Arc::clone(&counter);
+            registry.register_on_reorg(Arc::new(move |_n| {
+                let counter = Arc::clone(&counter);
+                Box::pin(async move {
+                    *counter.lock().unwrap() += 1;
+                })
+            }));
+        }
+        assert_eq!(registry.on_reorg.len(), 3);
+
+        registry.fire_on_reorg(sample_notification()).await;
+
+        assert_eq!(*counter.lock().unwrap(), 3, "all three callbacks must fire");
+    }
+
+    // ======================================================================
+    // Independence: EventCallbackRegistry and TraceCallbackRegistry have
+    // separate on_reorg lists.
+    // ======================================================================
+
+    #[tokio::test]
+    async fn test_event_and_trace_registries_have_independent_on_reorg() {
+        let event_counter: Arc<StdMutex<u32>> = Arc::new(StdMutex::new(0));
+        let trace_counter: Arc<StdMutex<u32>> = Arc::new(StdMutex::new(0));
+
+        let mut event_registry = EventCallbackRegistry::new();
+        {
+            let c = Arc::clone(&event_counter);
+            event_registry.register_on_reorg(Arc::new(move |_n| {
+                let c = Arc::clone(&c);
+                Box::pin(async move {
+                    *c.lock().unwrap() += 1;
+                })
+            }));
+        }
+
+        let mut trace_registry = TraceCallbackRegistry::new();
+        {
+            let c = Arc::clone(&trace_counter);
+            trace_registry.register_on_reorg(Arc::new(move |_n| {
+                let c = Arc::clone(&c);
+                Box::pin(async move {
+                    *c.lock().unwrap() += 1;
+                })
+            }));
+        }
+
+        // Firing on the event registry must NOT trigger trace callbacks.
+        event_registry.fire_on_reorg(sample_notification()).await;
+        assert_eq!(*event_counter.lock().unwrap(), 1);
+        assert_eq!(*trace_counter.lock().unwrap(), 0);
+
+        // And vice versa.
+        trace_registry.fire_on_reorg(sample_notification()).await;
+        assert_eq!(*event_counter.lock().unwrap(), 1);
+        assert_eq!(*trace_counter.lock().unwrap(), 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
     use alloy::network::AnyRpcBlock;
 
     fn test_tx_information(network: &str) -> TxInformation {

--- a/core/src/event/callback_registry.rs
+++ b/core/src/event/callback_registry.rs
@@ -437,6 +437,8 @@ pub struct TraceCallbackRegistryInformation {
     pub contract_name: String,
     pub trace_information: TraceInformation,
     pub callback: TraceCallbackType,
+    /// Derived/custom tables for this trace event (for reorg cleanup).
+    pub tables: Arc<Vec<TableRuntime>>,
     /// Streams clients for reorg retraction. Shared with the callback params so the
     /// reorg coordinator can publish rollback notifications to the same stream the
     /// native-transfer pipeline writes to.

--- a/core/src/event/callback_registry.rs
+++ b/core/src/event/callback_registry.rs
@@ -437,6 +437,10 @@ pub struct TraceCallbackRegistryInformation {
     pub contract_name: String,
     pub trace_information: TraceInformation,
     pub callback: TraceCallbackType,
+    /// Streams clients for reorg retraction. Shared with the callback params so the
+    /// reorg coordinator can publish rollback notifications to the same stream the
+    /// native-transfer pipeline writes to.
+    pub streams_clients: Arc<Option<StreamsClients>>,
 }
 
 impl TraceCallbackRegistryInformation {

--- a/core/src/event/callback_registry.rs
+++ b/core/src/event/callback_registry.rs
@@ -454,11 +454,12 @@ impl TraceCallbackRegistryInformation {
 #[derive(Clone, Default)]
 pub struct TraceCallbackRegistry {
     pub events: Vec<TraceCallbackRegistryInformation>,
+    pub on_reorg: Vec<OnReorgCallback>,
 }
 
 impl TraceCallbackRegistry {
     pub fn new() -> Self {
-        TraceCallbackRegistry { events: Vec::new() }
+        TraceCallbackRegistry { events: Vec::new(), on_reorg: Vec::new() }
     }
 
     pub fn find_event(&self, id: &String) -> Option<&TraceCallbackRegistryInformation> {
@@ -467,6 +468,16 @@ impl TraceCallbackRegistry {
 
     pub fn register_event(&mut self, event: TraceCallbackRegistryInformation) {
         self.events.push(event);
+    }
+
+    pub fn register_on_reorg(&mut self, callback: OnReorgCallback) {
+        self.on_reorg.push(callback);
+    }
+
+    pub async fn fire_on_reorg(&self, notification: ReorgNotification) {
+        for callback in &self.on_reorg {
+            callback(notification.clone()).await;
+        }
     }
 
     pub async fn trigger_event(&self, id: &String, data: Vec<TraceResult>) -> Result<(), String> {

--- a/core/src/event/callback_registry.rs
+++ b/core/src/event/callback_registry.rs
@@ -554,6 +554,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::network::AnyRpcBlock;
     use std::sync::Mutex as StdMutex;
 
     fn sample_notification() -> ReorgNotification {
@@ -762,12 +763,6 @@ mod tests {
         assert_eq!(*event_counter.lock().unwrap(), 1);
         assert_eq!(*trace_counter.lock().unwrap(), 1);
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy::network::AnyRpcBlock;
 
     fn test_tx_information(network: &str) -> TxInformation {
         TxInformation {

--- a/core/src/event/factory_event_filter_sync.rs
+++ b/core/src/event/factory_event_filter_sync.rs
@@ -478,5 +478,5 @@ pub async fn get_factory_addresses_with_birth_blocks(
         return Ok(values);
     }
 
-    Ok(std::collections::HashMap::new())
+    Ok(HashMap::new())
 }

--- a/core/src/generator/build.rs
+++ b/core/src/generator/build.rs
@@ -567,7 +567,10 @@ serde = {{ version = "1.0", features = ["derive"] }}
                             indexing_details: if enable_indexer {
                                 Some(IndexingDetails {
                                     registry: register_all_handlers(&manifest_path).await,
-                                    trace_registry: TraceCallbackRegistry { events: vec![] },
+                                    trace_registry: TraceCallbackRegistry {
+                                        events: vec![],
+                                        on_reorg: vec![],
+                                    },
                                     event_stream: None,
                                 })
                             } else {

--- a/core/src/generator/build.rs
+++ b/core/src/generator/build.rs
@@ -125,15 +125,14 @@ fn write_indexer_events(
         let abi_string = contract.parse_abi(project_path)?;
 
         let code = format!(
-            r##"
-            use alloy::sol;
+            r##"use alloy::sol;
 
-            sol!(
-                #[sol(rpc, all_derives)]
-                {contract_name},
-                r#"{contract_path}"#
-            );
-            "##,
+sol!(
+    #[sol(rpc, all_derives)]
+    {contract_name},
+    r#"{contract_path}"#
+);
+"##,
             contract_name = abigen_contract_name(&contract),
             contract_path = abi_string,
         );
@@ -174,15 +173,14 @@ fn write_indexer_events(
         let abigen_contract_name = format!("Rindexer{NATIVE_TRANSFER_CONTRACT_NAME}Gen");
 
         let code = format!(
-            r##"
-            use alloy::sol;
+            r##"use alloy::sol;
 
-            sol!(
-                #[sol(rpc, all_derives)]
-                {abigen_contract_name},
-                r#"{abi_string}"#
-            );
-            "##,
+sol!(
+    #[sol(rpc, all_derives)]
+    {abigen_contract_name},
+    r#"{abi_string}"#
+);
+"##,
         );
         let code = Code::new(code);
 

--- a/core/src/generator/database_bindings.rs
+++ b/core/src/generator/database_bindings.rs
@@ -2,44 +2,42 @@ use crate::types::code::Code;
 
 pub fn generate_postgres_code() -> Code {
     Code::new(
-        r#"
-    use std::sync::Arc;
-    use rindexer::PostgresClient;
-    use tokio::sync::OnceCell;
+        r#"use std::sync::Arc;
+use rindexer::PostgresClient;
+use tokio::sync::OnceCell;
 
-    static POSTGRES_CLIENT: OnceCell<Arc<PostgresClient>> = OnceCell::const_new();
+static POSTGRES_CLIENT: OnceCell<Arc<PostgresClient>> = OnceCell::const_new();
 
-    pub async fn get_or_init_postgres_client() -> Arc<PostgresClient> {
-        POSTGRES_CLIENT
-            .get_or_init(|| async {
-                Arc::new(PostgresClient::new().await.expect("Failed to connect to Postgres"))
-            })
-            .await
-            .clone()
-    }
-    "#
+pub async fn get_or_init_postgres_client() -> Arc<PostgresClient> {
+    POSTGRES_CLIENT
+        .get_or_init(|| async {
+            Arc::new(PostgresClient::new().await.expect("Failed to connect to Postgres"))
+        })
+        .await
+        .clone()
+}
+"#
         .to_string(),
     )
 }
 
 pub fn generate_clickhouse_code() -> Code {
     Code::new(
-        r#"
-    use std::sync::Arc;
-    use rindexer::ClickhouseClient;
-    use tokio::sync::OnceCell;
+        r#"use std::sync::Arc;
+use rindexer::ClickhouseClient;
+use tokio::sync::OnceCell;
 
-    static CLICKHOUSE_CLIENT: OnceCell<Arc<ClickhouseClient>> = OnceCell::const_new();
+static CLICKHOUSE_CLIENT: OnceCell<Arc<ClickhouseClient>> = OnceCell::const_new();
 
-    pub async fn get_or_init_clickhouse_client() -> Arc<ClickhouseClient> {
-        CLICKHOUSE_CLIENT
-            .get_or_init(|| async {
-                Arc::new(ClickhouseClient::new().await.expect("Failed to connect to Clickhouse"))
-            })
-            .await
-            .clone()
-    }
-    "#
+pub async fn get_or_init_clickhouse_client() -> Arc<ClickhouseClient> {
+    CLICKHOUSE_CLIENT
+        .get_or_init(|| async {
+            Arc::new(ClickhouseClient::new().await.expect("Failed to connect to Clickhouse"))
+        })
+        .await
+        .clone()
+}
+"#
         .to_string(),
     )
 }

--- a/core/src/generator/trace_bindings.rs
+++ b/core/src/generator/trace_bindings.rs
@@ -647,6 +647,7 @@ impl<TExtensions> {event_type_name}<TExtensions> where TExtensions: 'static + Se
             contract_name: contract_name.to_string(),
             trace_information: trace_information,
             callback,
+            streams_clients: Arc::new(None),
         }});
     }}
 }}

--- a/core/src/generator/trace_bindings.rs
+++ b/core/src/generator/trace_bindings.rs
@@ -647,6 +647,7 @@ impl<TExtensions> {event_type_name}<TExtensions> where TExtensions: 'static + Se
             contract_name: contract_name.to_string(),
             trace_information: trace_information,
             callback,
+            tables: Arc::new(Vec::new()),
             streams_clients: Arc::new(None),
         }});
     }}

--- a/core/src/helpers/mod.rs
+++ b/core/src/helpers/mod.rs
@@ -116,14 +116,14 @@ pub fn to_pascal_case(input: &str) -> String {
 
 fn capitalize_word(word: &str, is_single_word: bool) -> String {
     if word.chars().all(|c| c.is_ascii_uppercase()) {
-        if is_single_word {
+        return if is_single_word {
             // Convert single all-uppercase word to Pascal case
             let mut chars = word.chars();
-            return chars.next().unwrap().to_string() + &chars.as_str().to_lowercase();
+            chars.next().unwrap().to_string() + &chars.as_str().to_lowercase()
         } else {
             // Preserve acronyms in compound words
-            return word.to_string();
-        }
+            word.to_string()
+        };
     }
 
     let mut result = String::with_capacity(word.len());

--- a/core/src/indexer/cron_scheduler.rs
+++ b/core/src/indexer/cron_scheduler.rs
@@ -965,7 +965,7 @@ async fn execute_cron_operations_batch(
                 futures.push(async move {
                     let _permit = sem.acquire().await.unwrap();
 
-                    let timestamp = U256::from(chrono::Utc::now().timestamp() as u64);
+                    let timestamp = U256::from(Utc::now().timestamp() as u64);
                     let tx_metadata = TxMetadata {
                         block_number,
                         block_timestamp: Some(timestamp),
@@ -1042,7 +1042,7 @@ async fn execute_cron_operations_batch(
             if block_number < birth_block {
                 continue;
             }
-            let timestamp = U256::from(chrono::Utc::now().timestamp() as u64);
+            let timestamp = U256::from(Utc::now().timestamp() as u64);
             let tx_metadata = TxMetadata {
                 block_number,
                 block_timestamp: Some(timestamp),
@@ -1240,7 +1240,7 @@ async fn run_live_cron_loop(
             CronSchedule::Interval(duration) => *duration,
             CronSchedule::Cron(cron) => {
                 // Calculate next occurrence from now
-                let now = chrono::Utc::now();
+                let now = Utc::now();
                 match cron.find_next_occurrence(&now, false) {
                     Ok(next) => {
                         let duration = next - now;
@@ -1394,7 +1394,7 @@ async fn execute_cron_operations(
         0
     };
 
-    let now = chrono::Utc::now();
+    let now = Utc::now();
 
     let is_factory = task.factory_config.is_some();
     if is_factory {
@@ -1601,9 +1601,9 @@ async fn extract_cron_value(
 
     // Handle $rindexer_* built-ins
     if let Some(field_name) = value_ref.strip_prefix('$') {
-        match field_name {
+        return match field_name {
             "rindexer_block_number" => {
-                return Some(EthereumSqlTypeWrapper::U64BigInt(tx_metadata.block_number));
+                Some(EthereumSqlTypeWrapper::U64BigInt(tx_metadata.block_number))
             }
             "rindexer_block_timestamp" | "rindexer_timestamp" => {
                 if let Some(ts) = tx_metadata.block_timestamp {
@@ -1611,29 +1611,23 @@ async fn extract_cron_value(
                         return Some(EthereumSqlTypeWrapper::DateTime(dt.with_timezone(&Utc)));
                     }
                 }
-                return None;
+                None
             }
             "rindexer_tx_hash" => {
-                return Some(EthereumSqlTypeWrapper::StringChar(format!(
-                    "{:?}",
-                    tx_metadata.tx_hash
-                )));
+                Some(EthereumSqlTypeWrapper::StringChar(format!("{:?}", tx_metadata.tx_hash)))
             }
             "rindexer_block_hash" => {
-                return Some(EthereumSqlTypeWrapper::StringChar(format!(
-                    "{:?}",
-                    tx_metadata.block_hash
-                )));
+                Some(EthereumSqlTypeWrapper::StringChar(format!("{:?}", tx_metadata.block_hash)))
             }
             "rindexer_contract_address" => {
-                return Some(EthereumSqlTypeWrapper::Address(tx_metadata.contract_address));
+                Some(EthereumSqlTypeWrapper::Address(tx_metadata.contract_address))
             }
             _ => {
                 // Unknown $ reference - this shouldn't happen after validation
                 warn!("Unknown cron value reference: {}", value_ref);
-                return None;
+                None
             }
-        }
+        };
     }
 
     // Handle literal values
@@ -1664,9 +1658,9 @@ fn extract_cron_value_sync(
 
     // Handle $rindexer_* built-ins
     if let Some(field_name) = value_ref.strip_prefix('$') {
-        match field_name {
+        return match field_name {
             "rindexer_block_number" => {
-                return Some(EthereumSqlTypeWrapper::U64BigInt(tx_metadata.block_number));
+                Some(EthereumSqlTypeWrapper::U64BigInt(tx_metadata.block_number))
             }
             "rindexer_block_timestamp" | "rindexer_timestamp" => {
                 if let Some(ts) = tx_metadata.block_timestamp {
@@ -1674,28 +1668,22 @@ fn extract_cron_value_sync(
                         return Some(EthereumSqlTypeWrapper::DateTime(dt.with_timezone(&Utc)));
                     }
                 }
-                return None;
+                None
             }
             "rindexer_tx_hash" => {
-                return Some(EthereumSqlTypeWrapper::StringChar(format!(
-                    "{:?}",
-                    tx_metadata.tx_hash
-                )));
+                Some(EthereumSqlTypeWrapper::StringChar(format!("{:?}", tx_metadata.tx_hash)))
             }
             "rindexer_block_hash" => {
-                return Some(EthereumSqlTypeWrapper::StringChar(format!(
-                    "{:?}",
-                    tx_metadata.block_hash
-                )));
+                Some(EthereumSqlTypeWrapper::StringChar(format!("{:?}", tx_metadata.block_hash)))
             }
             "rindexer_contract_address" => {
-                return Some(EthereumSqlTypeWrapper::Address(tx_metadata.contract_address));
+                Some(EthereumSqlTypeWrapper::Address(tx_metadata.contract_address))
             }
             _ => {
                 // Unknown $ reference
-                return None;
+                None
             }
-        }
+        };
     }
 
     // Handle literal values

--- a/core/src/indexer/dependency.rs
+++ b/core/src/indexer/dependency.rs
@@ -3,6 +3,8 @@ use std::{
     sync::Arc,
 };
 
+use tokio::sync::Mutex;
+
 use crate::{
     database::postgres::relationship::Relationship,
     event::{config::EventProcessingConfig, contract_setup::ContractEventMapping},
@@ -306,7 +308,7 @@ pub struct ContractEventsDependenciesConfig {
     pub event_dependencies: EventDependencies,
     pub events_config: Vec<Arc<EventProcessingConfig>>,
     /// Per-network reorg coordinators for live indexing reorg protection.
-    pub reorg_coordinators: HashMap<String, ReorgCoordinator>,
+    pub reorg_coordinators: HashMap<String, Arc<Mutex<ReorgCoordinator>>>,
 }
 
 impl ContractEventsDependenciesConfig {

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1172,10 +1172,11 @@ async fn live_indexing_stream(
             // rewind, derived table rollback, window update) when available.
             if let Some(coordinator) = reorg_coordinator.as_ref() {
                 let detection_point = fork_block + reth_reorg.depth;
-                // Mutex held across reorg handling (DB rollback, stream publishes).
-                // On a real reorg this blocks the other indexing path for the
-                // duration of handle_reorg, which is acceptable for isolation.
-                // If latency becomes a concern, move handle_reorg out of the hot path.
+                // Mutex held across reorg handling (DB rollback, stream publishes,
+                // user on_reorg callback firing). On a real reorg this blocks the
+                // other indexing path for the duration of handle_reorg, which is
+                // acceptable for isolation. If latency becomes a concern, move
+                // handle_reorg out of the hot path.
                 let mut guard = coordinator.lock().await;
                 match guard.on_exex_reorg(detection_point, fork_block) {
                     Ok(task) => {
@@ -1260,10 +1261,11 @@ async fn live_indexing_stream(
                             trace_registry,
                             streams_clients: streams_clients.as_ref().as_ref(),
                         };
-                        // Mutex held across reorg handling (DB rollback, stream publishes).
-                        // On a real reorg this blocks the other indexing path for the
-                        // duration of handle_reorg, which is acceptable for isolation.
-                        // If latency becomes a concern, move handle_reorg out of the hot path.
+                        // Mutex held across reorg handling (DB rollback, stream publishes,
+                        // user on_reorg callback firing). On a real reorg this blocks the
+                        // other indexing path for the duration of handle_reorg, which is
+                        // acceptable for isolation. If latency becomes a concern, move
+                        // handle_reorg out of the hot path.
                         let mut guard = coordinator.lock().await;
                         match detect_and_handle_reorg(
                             &mut guard,
@@ -1449,11 +1451,12 @@ async fn live_indexing_stream(
                                             // the coordinator is not configured.
                                             if let Some(coordinator) = reorg_coordinator.as_ref() {
                                                 // Mutex held across reorg handling (DB rollback,
-                                                // stream publishes). On a real reorg this blocks
-                                                // the other indexing path for the duration of
-                                                // handle_reorg, which is acceptable for isolation.
-                                                // If latency becomes a concern, move handle_reorg
-                                                // out of the hot path.
+                                                // stream publishes, user on_reorg callback
+                                                // firing). On a real reorg this blocks the other
+                                                // indexing path for the duration of handle_reorg,
+                                                // which is acceptable for isolation. If latency
+                                                // becomes a concern, move handle_reorg out of the
+                                                // hot path.
                                                 let mut guard = coordinator.lock().await;
                                                 match guard
                                                     .try_create_reorg_task_for_block_range(

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1168,11 +1168,12 @@ async fn live_indexing_stream(
             // rewind, derived table rollback, window update) when available.
             if let Some(coordinator) = reorg_coordinator.as_ref() {
                 let detection_point = fork_block + reth_reorg.depth;
-                // Mutex held across reorg handling (DB rollback, stream publishes,
-                // user on_reorg callback firing). On a real reorg this blocks the
-                // other indexing path for the duration of handle_reorg, which is
-                // acceptable for isolation. If latency becomes a concern, move
-                // handle_reorg out of the hot path.
+                // Mutex held across reorg handling (DB rollback, stream
+                // publishes in parallel, user on_reorg callback firing). On a
+                // real reorg this blocks the other indexing path for the
+                // duration of handle_reorg, which is acceptable for isolation.
+                // If latency becomes a concern, move handle_reorg out of the
+                // hot path.
                 let mut guard = coordinator.lock().await;
                 match guard.on_exex_reorg(detection_point, fork_block) {
                     Ok(task) => {
@@ -1255,11 +1256,13 @@ async fn live_indexing_stream(
                             registry: Some(registry),
                             trace_registry,
                         };
-                        // Mutex held across reorg handling (DB rollback, stream publishes,
-                        // user on_reorg callback firing). On a real reorg this blocks the
-                        // other indexing path for the duration of handle_reorg, which is
-                        // acceptable for isolation. If latency becomes a concern, move
-                        // handle_reorg out of the hot path.
+                        // Mutex held across reorg handling (DB rollback,
+                        // stream publishes in parallel, user on_reorg callback
+                        // firing). On a real reorg this blocks the other
+                        // indexing path for the duration of handle_reorg,
+                        // which is acceptable for isolation. If latency
+                        // becomes a concern, move handle_reorg out of the hot
+                        // path.
                         let mut guard = coordinator.lock().await;
                         match detect_and_handle_reorg(
                             &mut guard,
@@ -1445,12 +1448,12 @@ async fn live_indexing_stream(
                                             // the coordinator is not configured.
                                             if let Some(coordinator) = reorg_coordinator.as_ref() {
                                                 // Mutex held across reorg handling (DB rollback,
-                                                // stream publishes, user on_reorg callback
-                                                // firing). On a real reorg this blocks the other
-                                                // indexing path for the duration of handle_reorg,
-                                                // which is acceptable for isolation. If latency
-                                                // becomes a concern, move handle_reorg out of the
-                                                // hot path.
+                                                // stream publishes in parallel, user on_reorg
+                                                // callback firing). On a real reorg this blocks
+                                                // the other indexing path for the duration of
+                                                // handle_reorg, which is acceptable for
+                                                // isolation. If latency becomes a concern, move
+                                                // handle_reorg out of the hot path.
                                                 let mut guard = coordinator.lock().await;
                                                 match guard
                                                     .try_create_reorg_task_for_block_range(

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1455,11 +1455,10 @@ async fn live_indexing_stream(
                                                 // isolation. If latency becomes a concern, move
                                                 // handle_reorg out of the hot path.
                                                 let mut guard = coordinator.lock().await;
-                                                match guard
-                                                    .try_create_reorg_task_for_block_range(
-                                                        min_removed_block,
-                                                        to_block.to::<u64>(),
-                                                    ) {
+                                                match guard.try_create_reorg_task_for_block_range(
+                                                    min_removed_block,
+                                                    to_block.to::<u64>(),
+                                                ) {
                                                     Ok(task) => {
                                                         let reorg_ctx = ReorgContext {
                                                             postgres: postgres.as_deref(),

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -27,6 +27,7 @@ use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{error::Error, str::FromStr, sync::Arc, time::Duration};
+use tokio::sync::Mutex;
 use tokio::{sync::mpsc, time::Instant};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
@@ -61,7 +62,7 @@ pub struct FetchLogsResult {
 pub fn fetch_logs_stream(
     config: Arc<EventProcessingConfig>,
     force_no_live_indexing: bool,
-    reorg_coordinator: Option<ReorgCoordinator>,
+    reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
 ) -> impl tokio_stream::Stream<Item = Result<FetchLogsResult, Box<dyn Error + Send>>> + Send + Unpin
 {
     // If the sink is slower than the producer it can lead to unbounded memory growth and
@@ -1107,7 +1108,7 @@ async fn live_indexing_stream(
     disable_logs_bloom_checks: bool,
     original_max_limit: Option<U64>,
     cancel_token: CancellationToken,
-    mut reorg_coordinator: Option<ReorgCoordinator>,
+    reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
     postgres: Option<Arc<PostgresClient>>,
     clickhouse: Option<Arc<ClickhouseClient>>,
     streams_clients: Arc<Option<StreamsClients>>,
@@ -1165,9 +1166,10 @@ async fn live_indexing_stream(
 
             // Route through coordinator for full recovery (event deletion, checkpoint
             // rewind, derived table rollback, window update) when available.
-            if let Some(ref mut coordinator) = reorg_coordinator {
+            if let Some(coordinator) = reorg_coordinator.as_ref() {
                 let detection_point = fork_block + reth_reorg.depth;
-                match coordinator.on_exex_reorg(detection_point, fork_block) {
+                let mut guard = coordinator.lock().await;
+                match guard.on_exex_reorg(detection_point, fork_block) {
                     Ok(task) => {
                         let reorg_ctx = ReorgContext {
                             postgres: postgres.as_deref(),
@@ -1175,7 +1177,7 @@ async fn live_indexing_stream(
                             registry: Some(registry),
                             streams_clients: streams_clients.as_ref().as_ref(),
                         };
-                        if let Err(e) = coordinator.handle_reorg(task, &reorg_ctx).await {
+                        if let Err(e) = guard.handle_reorg(task, &reorg_ctx).await {
                             error!("{} - Failed to handle ExEx reorg: {:?}", info_log_name, e);
                         }
                     }
@@ -1236,7 +1238,7 @@ async fn live_indexing_stream(
                     }
 
                     // Reorg detection via coordinator (parent hash validation)
-                    if let Some(ref mut coordinator) = reorg_coordinator {
+                    if let Some(coordinator) = reorg_coordinator.as_ref() {
                         let log_prefix = format!(
                             "{} - {}",
                             info_log_name,
@@ -1248,8 +1250,9 @@ async fn live_indexing_stream(
                             registry: Some(registry),
                             streams_clients: streams_clients.as_ref().as_ref(),
                         };
+                        let mut guard = coordinator.lock().await;
                         match detect_and_handle_reorg(
-                            coordinator,
+                            &mut guard,
                             latest_block.header.number,
                             latest_block.header.hash,
                             latest_block.header.parent_hash,
@@ -1430,8 +1433,9 @@ async fn live_indexing_stream(
                                             // (event deletion, checkpoint rewind, window update).
                                             // Fall back to sending ReorgInfo through the stream when
                                             // the coordinator is not configured.
-                                            if let Some(ref mut coordinator) = reorg_coordinator {
-                                                match coordinator
+                                            if let Some(coordinator) = reorg_coordinator.as_ref() {
+                                                let mut guard = coordinator.lock().await;
+                                                match guard
                                                     .try_create_reorg_task_for_block_range(
                                                         min_removed_block,
                                                         to_block.to::<u64>(),
@@ -1445,7 +1449,7 @@ async fn live_indexing_stream(
                                                                 .as_ref()
                                                                 .as_ref(),
                                                         };
-                                                        if let Err(e) = coordinator
+                                                        if let Err(e) = guard
                                                             .handle_reorg(task, &reorg_ctx)
                                                             .await
                                                         {

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1168,6 +1168,10 @@ async fn live_indexing_stream(
             // rewind, derived table rollback, window update) when available.
             if let Some(coordinator) = reorg_coordinator.as_ref() {
                 let detection_point = fork_block + reth_reorg.depth;
+                // Mutex held across reorg handling (DB rollback, stream publishes).
+                // On a real reorg this blocks the other indexing path for the
+                // duration of handle_reorg, which is acceptable for isolation.
+                // If latency becomes a concern, move handle_reorg out of the hot path.
                 let mut guard = coordinator.lock().await;
                 match guard.on_exex_reorg(detection_point, fork_block) {
                     Ok(task) => {
@@ -1250,6 +1254,10 @@ async fn live_indexing_stream(
                             registry: Some(registry),
                             streams_clients: streams_clients.as_ref().as_ref(),
                         };
+                        // Mutex held across reorg handling (DB rollback, stream publishes).
+                        // On a real reorg this blocks the other indexing path for the
+                        // duration of handle_reorg, which is acceptable for isolation.
+                        // If latency becomes a concern, move handle_reorg out of the hot path.
                         let mut guard = coordinator.lock().await;
                         match detect_and_handle_reorg(
                             &mut guard,
@@ -1434,6 +1442,12 @@ async fn live_indexing_stream(
                                             // Fall back to sending ReorgInfo through the stream when
                                             // the coordinator is not configured.
                                             if let Some(coordinator) = reorg_coordinator.as_ref() {
+                                                // Mutex held across reorg handling (DB rollback,
+                                                // stream publishes). On a real reorg this blocks
+                                                // the other indexing path for the duration of
+                                                // handle_reorg, which is acceptable for isolation.
+                                                // If latency becomes a concern, move handle_reorg
+                                                // out of the hot path.
                                                 let mut guard = coordinator.lock().await;
                                                 match guard
                                                     .try_create_reorg_task_for_block_range(

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1,7 +1,7 @@
 use crate::adaptive_concurrency::{AdaptiveConcurrency, ADAPTIVE_CONCURRENCY};
 use crate::blockclock::BlockClock;
 use crate::database::clickhouse::client::ClickhouseClient;
-use crate::event::callback_registry::EventCallbackRegistry;
+use crate::event::callback_registry::{EventCallbackRegistry, TraceCallbackRegistry};
 use crate::helpers::{halved_block_number, is_relevant_block};
 use crate::indexer::heartbeat::{HeartbeatAction, HeartbeatTracker};
 use crate::indexer::reorg::{
@@ -63,6 +63,7 @@ pub fn fetch_logs_stream(
     config: Arc<EventProcessingConfig>,
     force_no_live_indexing: bool,
     reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
+    trace_registry: Option<Arc<TraceCallbackRegistry>>,
 ) -> impl tokio_stream::Stream<Item = Result<FetchLogsResult, Box<dyn Error + Send>>> + Send + Unpin
 {
     // If the sink is slower than the producer it can lead to unbounded memory growth and
@@ -244,6 +245,7 @@ pub fn fetch_logs_stream(
                         config.clickhouse(),
                         config.streams_clients(),
                         &registry,
+                        trace_registry.as_deref(),
                     )
                     .await;
                 }
@@ -349,6 +351,7 @@ pub fn fetch_logs_stream(
                 config.clickhouse(),
                 config.streams_clients(),
                 &registry,
+                trace_registry.as_deref(),
             )
             .await;
         }
@@ -1113,6 +1116,7 @@ async fn live_indexing_stream(
     clickhouse: Option<Arc<ClickhouseClient>>,
     streams_clients: Arc<Option<StreamsClients>>,
     registry: &EventCallbackRegistry,
+    trace_registry: Option<&TraceCallbackRegistry>,
 ) {
     let mut last_seen_block_number = last_seen_block_number;
     let mut log_response_to_large_to_block: Option<U64> = None;
@@ -1179,6 +1183,7 @@ async fn live_indexing_stream(
                             postgres: postgres.as_deref(),
                             clickhouse: clickhouse.as_ref(),
                             registry: Some(registry),
+                            trace_registry,
                             streams_clients: streams_clients.as_ref().as_ref(),
                         };
                         if let Err(e) = guard.handle_reorg(task, &reorg_ctx).await {
@@ -1252,6 +1257,7 @@ async fn live_indexing_stream(
                             postgres: postgres.as_deref(),
                             clickhouse: clickhouse.as_ref(),
                             registry: Some(registry),
+                            trace_registry,
                             streams_clients: streams_clients.as_ref().as_ref(),
                         };
                         // Mutex held across reorg handling (DB rollback, stream publishes).
@@ -1459,6 +1465,7 @@ async fn live_indexing_stream(
                                                             postgres: postgres.as_deref(),
                                                             clickhouse: clickhouse.as_ref(),
                                                             registry: Some(registry),
+                                                            trace_registry,
                                                             streams_clients: streams_clients
                                                                 .as_ref()
                                                                 .as_ref(),

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -8,7 +8,6 @@ use crate::indexer::reorg::{
     detect_and_handle_reorg, reorg_safe_distance_for_chain, ReorgContext, ReorgCoordinator,
 };
 use crate::metrics::indexing as metrics;
-use crate::streams::StreamsClients;
 use crate::PostgresClient;
 use crate::{
     event::{config::EventProcessingConfig, RindexerEventFilter},
@@ -243,7 +242,6 @@ pub fn fetch_logs_stream(
                         reorg_coordinator,
                         config.postgres(),
                         config.clickhouse(),
-                        config.streams_clients(),
                         &registry,
                         trace_registry.as_deref(),
                     )
@@ -349,7 +347,6 @@ pub fn fetch_logs_stream(
                 reorg_coordinator,
                 config.postgres(),
                 config.clickhouse(),
-                config.streams_clients(),
                 &registry,
                 trace_registry.as_deref(),
             )
@@ -1114,7 +1111,6 @@ async fn live_indexing_stream(
     reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
     postgres: Option<Arc<PostgresClient>>,
     clickhouse: Option<Arc<ClickhouseClient>>,
-    streams_clients: Arc<Option<StreamsClients>>,
     registry: &EventCallbackRegistry,
     trace_registry: Option<&TraceCallbackRegistry>,
 ) {
@@ -1185,7 +1181,6 @@ async fn live_indexing_stream(
                             clickhouse: clickhouse.as_ref(),
                             registry: Some(registry),
                             trace_registry,
-                            streams_clients: streams_clients.as_ref().as_ref(),
                         };
                         if let Err(e) = guard.handle_reorg(task, &reorg_ctx).await {
                             error!("{} - Failed to handle ExEx reorg: {:?}", info_log_name, e);
@@ -1259,7 +1254,6 @@ async fn live_indexing_stream(
                             clickhouse: clickhouse.as_ref(),
                             registry: Some(registry),
                             trace_registry,
-                            streams_clients: streams_clients.as_ref().as_ref(),
                         };
                         // Mutex held across reorg handling (DB rollback, stream publishes,
                         // user on_reorg callback firing). On a real reorg this blocks the
@@ -1469,9 +1463,6 @@ async fn live_indexing_stream(
                                                             clickhouse: clickhouse.as_ref(),
                                                             registry: Some(registry),
                                                             trace_registry,
-                                                            streams_clients: streams_clients
-                                                                .as_ref()
-                                                                .as_ref(),
                                                         };
                                                         if let Err(e) = guard
                                                             .handle_reorg(task, &reorg_ctx)

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -172,10 +172,10 @@ pub(crate) async fn native_transfer_detect_reorg_in_range(
         return NativeTransferReorgOutcome::Failed;
     }
 
-    // Mutex held across reorg handling (DB rollback, stream publishes). On a real
-    // reorg this blocks the other indexing path for the duration of handle_reorg,
-    // which is acceptable for isolation. If latency becomes a concern, move
-    // handle_reorg out of the hot path.
+    // Mutex held across reorg handling (DB rollback, stream publishes, user
+    // on_reorg callback firing). On a real reorg this blocks the other indexing
+    // path for the duration of handle_reorg, which is acceptable for isolation.
+    // If latency becomes a concern, move handle_reorg out of the hot path.
     let mut guard = coordinator.lock().await;
     let ctx = ReorgContext {
         postgres,

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -8,13 +8,17 @@ use alloy::{
 };
 use futures::future::try_join_all;
 use serde::Serialize;
+use tokio::sync::Mutex;
 use tokio::{sync::mpsc, time::sleep};
 use tracing::{debug, error, info, warn};
 
 use tokio_util::sync::CancellationToken;
 
+use crate::database::clickhouse::client::ClickhouseClient;
+use crate::indexer::reorg::{detect_and_handle_reorg, ReorgContext, ReorgCoordinator};
 use crate::is_running;
 use crate::provider::RECOMMENDED_RPC_CHUNK_SIZE;
+use crate::streams::StreamsClients;
 use crate::PostgresClient;
 use crate::{
     event::{
@@ -99,6 +103,101 @@ async fn push_range(block_tx: &mpsc::Sender<U64>, last: U64, latest: U64) {
     }
 }
 
+/// Result of a reorg check over a pending block range.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum NativeTransferReorgOutcome {
+    /// No coordinator configured; range can be emitted as-is.
+    NoCoordinator,
+    /// All blocks in the range are canonical. Safe to emit.
+    Canonical,
+    /// A reorg was handled. `rewind_to` is the new cursor: the next fetch
+    /// should start at `rewind_to + 1`.
+    Rewound { rewind_to: u64 },
+    /// Detection or rollback failed. Caller should back off and retry.
+    Failed,
+}
+
+/// Walk the next contiguous block range `from..=to` against the coordinator,
+/// feeding each canonical block's `(number, hash, parent_hash)` through
+/// `detect_and_handle_reorg`. The first reorg detected rewinds the cursor.
+///
+/// Extracted from `native_transfer_block_fetch` to keep the hot loop readable
+/// and to provide a unit-testable seam for reorg rewind behaviour.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn native_transfer_detect_reorg_in_range(
+    provider: &dyn ChainProvider,
+    coordinator: Option<&Arc<Mutex<ReorgCoordinator>>>,
+    postgres: Option<&PostgresClient>,
+    clickhouse: Option<&Arc<ClickhouseClient>>,
+    streams_clients: Option<&StreamsClients>,
+    network: &str,
+    from_block: u64,
+    to_block: u64,
+) -> NativeTransferReorgOutcome {
+    let Some(coordinator) = coordinator else {
+        return NativeTransferReorgOutcome::NoCoordinator;
+    };
+
+    let block_numbers: Vec<U64> = (from_block..=to_block).map(U64::from).collect();
+    let blocks = match provider.get_block_by_number_batch(&block_numbers, false).await {
+        Ok(b) => b,
+        Err(e) => {
+            error!(
+                network,
+                from_block,
+                to_block,
+                error = %e,
+                "Native transfer reorg pre-check: block header fetch failed",
+            );
+            return NativeTransferReorgOutcome::Failed;
+        }
+    };
+
+    let mut guard = coordinator.lock().await;
+    // TODO(Task 4): ReorgContext.registry expects &EventCallbackRegistry; native
+    // transfers use a TraceCallbackRegistry. Task 4 will add `trace_registry` to
+    // ReorgContext so the `on_reorg` callback can fire for NT-only reorgs.
+    let ctx = ReorgContext { postgres, clickhouse, registry: None, streams_clients };
+
+    for block in blocks {
+        let number = block.header.number;
+        let hash = block.header.hash;
+        let parent_hash = block.header.parent_hash;
+        match detect_and_handle_reorg(
+            &mut guard,
+            number,
+            hash,
+            parent_hash,
+            "NativeTransfers",
+            &ctx,
+        )
+        .await
+        {
+            Ok(Some(fork_point)) => {
+                warn!(
+                    network,
+                    fork_point,
+                    detection_block = number,
+                    "Rewinding native transfer fetch to fork point",
+                );
+                return NativeTransferReorgOutcome::Rewound { rewind_to: fork_point };
+            }
+            Ok(None) => {}
+            Err(e) => {
+                error!(
+                    network,
+                    block = number,
+                    error = ?e,
+                    "Native transfer reorg detection failed",
+                );
+                return NativeTransferReorgOutcome::Failed;
+            }
+        }
+    }
+
+    NativeTransferReorgOutcome::Canonical
+}
+
 /// Block publisher.
 ///
 /// This is a long-running process designed to accept a [`Sender`] handle and publish blocks
@@ -115,15 +214,13 @@ pub async fn native_transfer_block_fetch(
     indexing_distance_from_head: U64,
     network: String,
     cancel_token: CancellationToken,
-    _postgres: Option<Arc<PostgresClient>>,
+    postgres: Option<Arc<PostgresClient>>,
     _indexer_name: String,
+    reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
+    clickhouse: Option<Arc<ClickhouseClient>>,
+    streams_clients: Arc<Option<StreamsClients>>,
 ) -> Result<(), ProcessEventError> {
     let mut last_seen_block = start_block;
-
-    // TODO: Native transfer tables are registered in the network's ReorgCoordinator (start.rs)
-    // for rollback during reorg recovery. Detection is driven by the contract event
-    // coordinator on the same network. Standalone native-transfer reorg detection is
-    // not yet implemented.
 
     loop {
         if !is_running() || cancel_token.is_cancelled() {
@@ -144,10 +241,40 @@ pub async fn native_transfer_block_fetch(
                     let to_block = end_block.map(|end| block.min(end)).unwrap_or(block);
                     let from_block = block.min(last_seen_block + U64::from(1));
 
-                    debug!("Pushing trace blocks {} - {}", from_block, to_block);
+                    // Reorg detection runs on the fetch side so every block - even those
+                    // with zero native transfers - feeds the coordinator's window, keeping
+                    // it contiguous.
+                    let outcome = native_transfer_detect_reorg_in_range(
+                        publisher.as_ref(),
+                        reorg_coordinator.as_ref(),
+                        postgres.as_deref(),
+                        clickhouse.as_ref(),
+                        streams_clients.as_ref().as_ref(),
+                        &network,
+                        from_block.to::<u64>(),
+                        to_block.to::<u64>(),
+                    )
+                    .await;
 
-                    push_range(&block_tx, from_block, to_block).await;
-                    last_seen_block = to_block;
+                    match outcome {
+                        NativeTransferReorgOutcome::Canonical
+                        | NativeTransferReorgOutcome::NoCoordinator => {
+                            debug!("Pushing trace blocks {} - {}", from_block, to_block);
+                            push_range(&block_tx, from_block, to_block).await;
+                            last_seen_block = to_block;
+                        }
+                        NativeTransferReorgOutcome::Rewound { rewind_to } => {
+                            // Re-fetch from fork_point + 1 next iteration so the now-canonical
+                            // traces are re-emitted.
+                            last_seen_block = U64::from(rewind_to);
+                            continue;
+                        }
+                        NativeTransferReorgOutcome::Failed => {
+                            // Mirror contract-event backoff: pause before retrying.
+                            sleep(Duration::from_secs(2)).await;
+                            continue;
+                        }
+                    }
                 }
 
                 if end_block.is_some() && block > end_block.expect("must have block") {
@@ -732,5 +859,156 @@ mod tests {
         assert_eq!(contracts.len(), 13);
         // 0x8007 is intentionally missing (not a system contract used in transfers)
         assert!(!contracts.contains(&"0x0000000000000000000000000000000000008007".parse().unwrap()));
+    }
+
+    // ----------------------------------------------------------------------
+    // Reorg rewind behaviour
+    // ----------------------------------------------------------------------
+
+    /// Build a block with a fixed parent hash (no transactions). Used to simulate
+    /// canonical vs. reorged chains for the coordinator.
+    fn make_block_with_parent(
+        block_number: u64,
+        block_hash: alloy::primitives::B256,
+        parent_hash: alloy::primitives::B256,
+    ) -> alloy::network::AnyRpcBlock {
+        use alloy::network::{AnyHeader, AnyRpcHeader};
+        use alloy::rpc::types::{Block, BlockTransactions};
+
+        alloy::network::AnyRpcBlock::new(
+            Block::new(
+                AnyRpcHeader::from_sealed(
+                    AnyHeader { number: block_number, parent_hash, ..Default::default() }
+                        .seal(block_hash),
+                ),
+                BlockTransactions::Full(vec![]),
+            )
+            .into(),
+        )
+    }
+
+    fn b256(n: u8) -> alloy::primitives::B256 {
+        let mut bytes = [0u8; 32];
+        bytes[31] = n;
+        alloy::primitives::B256::from(bytes)
+    }
+
+    fn make_test_coordinator(
+        network: &str,
+        window_blocks: &[(u64, u8, u8)],
+        provider: Arc<dyn ChainProvider>,
+    ) -> Arc<Mutex<ReorgCoordinator>> {
+        use crate::indexer::reorg::{BlockChainWindow, ReorgBlockHashPersistence};
+
+        let mut window = BlockChainWindow::try_new(100).unwrap();
+        for &(num, h, p) in window_blocks {
+            window.insert(num, b256(h), b256(p));
+        }
+
+        let persistence = Arc::new(ReorgBlockHashPersistence::new(None, None));
+        let coord = ReorgCoordinator::new(
+            network.to_string(),
+            window,
+            persistence,
+            provider,
+            vec![],
+            vec![],
+        )
+        .unwrap();
+        Arc::new(Mutex::new(coord))
+    }
+
+    #[tokio::test]
+    async fn native_transfer_detects_no_reorg_on_canonical_chain() {
+        // Window has blocks 10, 11. Provider returns canonical 12, 13 whose
+        // parent_hashes chain back to the window. Expect `Canonical`.
+        let canonical_12 = make_block_with_parent(12, b256(12), b256(11));
+        let canonical_13 = make_block_with_parent(13, b256(13), b256(12));
+        let provider: Arc<dyn ChainProvider> = Arc::new(
+            MockChainProvider::new(1).with_blocks(vec![canonical_12, canonical_13]),
+        );
+
+        let coordinator =
+            make_test_coordinator("ethereum", &[(10, 10, 9), (11, 11, 10)], provider.clone());
+
+        let outcome = native_transfer_detect_reorg_in_range(
+            provider.as_ref(),
+            Some(&coordinator),
+            None,
+            None,
+            None,
+            "ethereum",
+            12,
+            13,
+        )
+        .await;
+
+        assert_eq!(outcome, NativeTransferReorgOutcome::Canonical);
+    }
+
+    #[tokio::test]
+    async fn native_transfer_rewinds_to_fork_point_on_reorg() {
+        // Window has block 11 with hash=11, parent=10 (pre-reorg state).
+        // Canonical chain now says block 11 has hash=0xFE / parent=10 (reorged).
+        // Fetch range 12..=12 with canonical block 12 whose parent_hash=0xFE
+        // does NOT match the window's stored hash of block 11 → reorg.
+        //
+        // The coordinator then fetches missing blocks from the provider to locate
+        // the fork point; we expose canonical 11 so find_fork_point can succeed.
+        let canonical_11 = make_block_with_parent(11, b256(0xFE), b256(10));
+        let canonical_12 = make_block_with_parent(12, b256(12), b256(0xFE));
+        let provider: Arc<dyn ChainProvider> = Arc::new(
+            MockChainProvider::new(1).with_blocks(vec![canonical_11, canonical_12]),
+        );
+
+        let coordinator =
+            make_test_coordinator("ethereum", &[(10, 10, 9), (11, 11, 10)], provider.clone());
+
+        let outcome = native_transfer_detect_reorg_in_range(
+            provider.as_ref(),
+            Some(&coordinator),
+            None,
+            None,
+            None,
+            "ethereum",
+            12,
+            12,
+        )
+        .await;
+
+        // Coordinator's find_fork_point compares the window's entries against
+        // canonical hashes. With window blocks [10, 11] and canonical [11@0xFE, 12@12],
+        // no canonical hash matches any window entry → fork_point falls back to the
+        // oldest window block (10). The caller will re-fetch from 11 onwards.
+        match outcome {
+            NativeTransferReorgOutcome::Rewound { rewind_to } => {
+                assert!(
+                    rewind_to <= 11,
+                    "fork_point {rewind_to} must rewind to at least block 11"
+                );
+            }
+            other => panic!("expected Rewound, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn native_transfer_no_coordinator_short_circuits() {
+        // Without a coordinator configured, the helper must return NoCoordinator
+        // so the caller emits the range as-is.
+        let provider: Arc<dyn ChainProvider> = Arc::new(MockChainProvider::new(1));
+
+        let outcome = native_transfer_detect_reorg_in_range(
+            provider.as_ref(),
+            None,
+            None,
+            None,
+            None,
+            "ethereum",
+            12,
+            13,
+        )
+        .await;
+
+        assert_eq!(outcome, NativeTransferReorgOutcome::NoCoordinator);
     }
 }

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -170,10 +170,11 @@ pub(crate) async fn native_transfer_detect_reorg_in_range(
         return NativeTransferReorgOutcome::Failed;
     }
 
-    // Mutex held across reorg handling (DB rollback, stream publishes, user
-    // on_reorg callback firing). On a real reorg this blocks the other indexing
-    // path for the duration of handle_reorg, which is acceptable for isolation.
-    // If latency becomes a concern, move handle_reorg out of the hot path.
+    // Mutex held across reorg handling (DB rollback, stream publishes in
+    // parallel, user on_reorg callback firing). On a real reorg this blocks
+    // the other indexing path for the duration of handle_reorg, which is
+    // acceptable for isolation. If latency becomes a concern, move
+    // handle_reorg out of the hot path.
     let mut guard = coordinator.lock().await;
     let ctx = ReorgContext {
         postgres,

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -255,10 +255,66 @@ pub async fn native_transfer_block_fetch(
             break Ok(());
         }
 
+        // Pace the poll loop so the per-poll tip reorg check below doesn't spin
+        // the CPU when the chain tip is idle. Mirrors the
+        // `target_iteration_duration` used in the contract-event fetch loop.
+        sleep(Duration::from_millis(200)).await;
+
         let latest_block = publisher.get_latest_block().await;
 
         match latest_block {
             Ok(Some(latest_block)) => {
+                // Per-poll tip reorg check: mirrors the contract-event path in
+                // `fetch_logs.rs`. Runs on every iteration — even when no blocks
+                // advanced — so we catch reorgs that rewrite the tip without
+                // moving the block number (e.g. Anvil `anvil_reorg(depth)` that
+                // keeps or lowers the tip height).
+                if let Some(coordinator) = reorg_coordinator.as_ref() {
+                    let tip_number = latest_block.header.number;
+                    let tip_hash = latest_block.header.hash;
+                    let tip_parent = latest_block.header.parent_hash;
+                    let mut guard = coordinator.lock().await;
+                    let ctx = ReorgContext {
+                        postgres: postgres.as_deref(),
+                        clickhouse: clickhouse.as_ref(),
+                        registry: None,
+                        trace_registry: Some(trace_registry.as_ref()),
+                        streams_clients: streams_clients.as_ref().as_ref(),
+                    };
+                    match detect_and_handle_reorg(
+                        &mut guard,
+                        tip_number,
+                        tip_hash,
+                        tip_parent,
+                        "NativeTransfers",
+                        &ctx,
+                    )
+                    .await
+                    {
+                        Ok(Some(fork_point)) => {
+                            drop(guard);
+                            warn!(
+                                network = %network,
+                                fork_point,
+                                "Native transfer tip reorg - rewinding fetch cursor",
+                            );
+                            last_seen_block = U64::from(fork_point.saturating_sub(1));
+                            continue;
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            drop(guard);
+                            error!(
+                                network = %network,
+                                error = ?e,
+                                "Native transfer tip reorg detection failed",
+                            );
+                            sleep(Duration::from_secs(2)).await;
+                            continue;
+                        }
+                    }
+                }
+
                 let block = U64::from(latest_block.header.number);
 
                 // Always trim back to the safe indexing threshold (which is zero if disabled)

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -820,7 +820,7 @@ mod tests {
             postgres: None,
             csv_details: None,
             registry: Arc::new(TraceCallbackRegistry::new()),
-            method: crate::manifest::native_transfer::TraceProcessingMethod::TraceBlock,
+            method: TraceProcessingMethod::TraceBlock,
             stream_last_synced_block_file_path: None,
             cancel_token: CancellationToken::new(),
         })
@@ -849,7 +849,7 @@ mod tests {
             gas_limit: 21_000,
             to: TxKind::Call(to),
             value,
-            input: alloy::primitives::Bytes::new(),
+            input: Bytes::new(),
         };
 
         // Dummy sig and hash — we only need the fields, not cryptographic validity.

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -22,7 +22,7 @@ use crate::streams::StreamsClients;
 use crate::PostgresClient;
 use crate::{
     event::{
-        callback_registry::{TraceResult, TxInformation},
+        callback_registry::{TraceCallbackRegistry, TraceResult, TxInformation},
         config::TraceProcessingConfig,
     },
     indexer::{
@@ -131,6 +131,7 @@ pub(crate) async fn native_transfer_detect_reorg_in_range(
     postgres: Option<&PostgresClient>,
     clickhouse: Option<&Arc<ClickhouseClient>>,
     streams_clients: Option<&StreamsClients>,
+    trace_registry: Option<&TraceCallbackRegistry>,
     network: &str,
     from_block: u64,
     to_block: u64,
@@ -176,10 +177,13 @@ pub(crate) async fn native_transfer_detect_reorg_in_range(
     // which is acceptable for isolation. If latency becomes a concern, move
     // handle_reorg out of the hot path.
     let mut guard = coordinator.lock().await;
-    // TODO(Task 4): ReorgContext.registry expects &EventCallbackRegistry; native
-    // transfers use a TraceCallbackRegistry. Task 4 will add `trace_registry` to
-    // ReorgContext so the `on_reorg` callback can fire for NT-only reorgs.
-    let ctx = ReorgContext { postgres, clickhouse, registry: None, streams_clients };
+    let ctx = ReorgContext {
+        postgres,
+        clickhouse,
+        registry: None,
+        trace_registry,
+        streams_clients,
+    };
 
     for block in blocks {
         let number = block.header.number;
@@ -241,6 +245,7 @@ pub async fn native_transfer_block_fetch(
     reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
     clickhouse: Option<Arc<ClickhouseClient>>,
     streams_clients: Arc<Option<StreamsClients>>,
+    trace_registry: Arc<TraceCallbackRegistry>,
 ) -> Result<(), ProcessEventError> {
     let mut last_seen_block = start_block;
 
@@ -272,6 +277,7 @@ pub async fn native_transfer_block_fetch(
                         postgres.as_deref(),
                         clickhouse.as_ref(),
                         streams_clients.as_ref().as_ref(),
+                        Some(trace_registry.as_ref()),
                         &network,
                         from_block.to::<u64>(),
                         to_block.to::<u64>(),
@@ -962,6 +968,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             "ethereum",
             12,
             13,
@@ -992,6 +999,7 @@ mod tests {
         let outcome = native_transfer_detect_reorg_in_range(
             provider.as_ref(),
             Some(&coordinator),
+            None,
             None,
             None,
             None,
@@ -1052,6 +1060,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             "ethereum",
             10,
             12,
@@ -1073,6 +1082,7 @@ mod tests {
 
         let outcome = native_transfer_detect_reorg_in_range(
             provider.as_ref(),
+            None,
             None,
             None,
             None,

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -18,7 +18,6 @@ use crate::database::clickhouse::client::ClickhouseClient;
 use crate::indexer::reorg::{detect_and_handle_reorg, ReorgContext, ReorgCoordinator};
 use crate::is_running;
 use crate::provider::RECOMMENDED_RPC_CHUNK_SIZE;
-use crate::streams::StreamsClients;
 use crate::PostgresClient;
 use crate::{
     event::{
@@ -130,7 +129,6 @@ pub(crate) async fn native_transfer_detect_reorg_in_range(
     coordinator: Option<&Arc<Mutex<ReorgCoordinator>>>,
     postgres: Option<&PostgresClient>,
     clickhouse: Option<&Arc<ClickhouseClient>>,
-    streams_clients: Option<&StreamsClients>,
     trace_registry: Option<&TraceCallbackRegistry>,
     network: &str,
     from_block: u64,
@@ -182,7 +180,6 @@ pub(crate) async fn native_transfer_detect_reorg_in_range(
         clickhouse,
         registry: None,
         trace_registry,
-        streams_clients,
     };
 
     for block in blocks {
@@ -244,7 +241,6 @@ pub async fn native_transfer_block_fetch(
     _indexer_name: String,
     reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
     clickhouse: Option<Arc<ClickhouseClient>>,
-    streams_clients: Arc<Option<StreamsClients>>,
     trace_registry: Arc<TraceCallbackRegistry>,
 ) -> Result<(), ProcessEventError> {
     let mut last_seen_block = start_block;
@@ -279,7 +275,6 @@ pub async fn native_transfer_block_fetch(
                         clickhouse: clickhouse.as_ref(),
                         registry: None,
                         trace_registry: Some(trace_registry.as_ref()),
-                        streams_clients: streams_clients.as_ref().as_ref(),
                     };
                     match detect_and_handle_reorg(
                         &mut guard,
@@ -332,7 +327,6 @@ pub async fn native_transfer_block_fetch(
                         reorg_coordinator.as_ref(),
                         postgres.as_deref(),
                         clickhouse.as_ref(),
-                        streams_clients.as_ref().as_ref(),
                         Some(trace_registry.as_ref()),
                         &network,
                         from_block.to::<u64>(),
@@ -1000,6 +994,7 @@ mod tests {
             provider,
             vec![],
             vec![],
+            vec![],
         )
         .unwrap();
         Arc::new(Mutex::new(coord))
@@ -1021,7 +1016,6 @@ mod tests {
         let outcome = native_transfer_detect_reorg_in_range(
             provider.as_ref(),
             Some(&coordinator),
-            None,
             None,
             None,
             None,
@@ -1055,7 +1049,6 @@ mod tests {
         let outcome = native_transfer_detect_reorg_in_range(
             provider.as_ref(),
             Some(&coordinator),
-            None,
             None,
             None,
             None,
@@ -1116,7 +1109,6 @@ mod tests {
             None,
             None,
             None,
-            None,
             "ethereum",
             10,
             12,
@@ -1138,7 +1130,6 @@ mod tests {
 
         let outcome = native_transfer_detect_reorg_in_range(
             provider.as_ref(),
-            None,
             None,
             None,
             None,

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -110,8 +110,9 @@ pub(crate) enum NativeTransferReorgOutcome {
     NoCoordinator,
     /// All blocks in the range are canonical. Safe to emit.
     Canonical,
-    /// A reorg was handled. `rewind_to` is the new cursor: the next fetch
-    /// should start at `rewind_to + 1`.
+    /// A reorg was handled. `rewind_to` is the first canonical block to re-fetch
+    /// (inclusive) — the caller rewinds `last_seen_block` to `rewind_to - 1` so
+    /// the next iteration's `from_block` equals `rewind_to`.
     Rewound { rewind_to: u64 },
     /// Detection or rollback failed. Caller should back off and retry.
     Failed,
@@ -153,6 +154,27 @@ pub(crate) async fn native_transfer_detect_reorg_in_range(
         }
     };
 
+    // Guard against short reads (RPC lag, chain-tip reorg). Advancing the caller's
+    // cursor on a partial batch would leave a silent gap: blocks requested but not
+    // returned would never be fed to the coordinator, and their native-transfer
+    // rows would never be emitted. Treat as a transient failure so the caller
+    // backs off and retries the same range.
+    if blocks.len() != block_numbers.len() {
+        warn!(
+            network,
+            from_block,
+            to_block,
+            requested = block_numbers.len(),
+            received = blocks.len(),
+            "Native transfer reorg pre-check: short read from provider, retrying",
+        );
+        return NativeTransferReorgOutcome::Failed;
+    }
+
+    // Mutex held across reorg handling (DB rollback, stream publishes). On a real
+    // reorg this blocks the other indexing path for the duration of handle_reorg,
+    // which is acceptable for isolation. If latency becomes a concern, move
+    // handle_reorg out of the hot path.
     let mut guard = coordinator.lock().await;
     // TODO(Task 4): ReorgContext.registry expects &EventCallbackRegistry; native
     // transfers use a TraceCallbackRegistry. Task 4 will add `trace_registry` to
@@ -264,9 +286,12 @@ pub async fn native_transfer_block_fetch(
                             last_seen_block = to_block;
                         }
                         NativeTransferReorgOutcome::Rewound { rewind_to } => {
-                            // Re-fetch from fork_point + 1 next iteration so the now-canonical
-                            // traces are re-emitted.
-                            last_seen_block = U64::from(rewind_to);
+                            // `rewind_to` is the first canonical block to re-fetch (inclusive).
+                            // Subtract 1 from the cursor so the next iteration computes
+                            // `from_block = last_seen_block + 1 = rewind_to`, matching the
+                            // coordinator's rollback which deletes rows with
+                            // `block_number >= fork_point`.
+                            last_seen_block = U64::from(rewind_to.saturating_sub(1));
                             continue;
                         }
                         NativeTransferReorgOutcome::Failed => {
@@ -979,16 +1004,65 @@ mod tests {
         // Coordinator's find_fork_point compares the window's entries against
         // canonical hashes. With window blocks [10, 11] and canonical [11@0xFE, 12@12],
         // no canonical hash matches any window entry → fork_point falls back to the
-        // oldest window block (10). The caller will re-fetch from 11 onwards.
-        match outcome {
-            NativeTransferReorgOutcome::Rewound { rewind_to } => {
-                assert!(
-                    rewind_to <= 11,
-                    "fork_point {rewind_to} must rewind to at least block 11"
-                );
-            }
+        // oldest window block (10).
+        //
+        // Helper contract: `rewind_to` IS the first canonical block to re-fetch
+        // (inclusive) — equal to `fork_point`.
+        let rewind_to = match outcome {
+            NativeTransferReorgOutcome::Rewound { rewind_to } => rewind_to,
             other => panic!("expected Rewound, got {other:?}"),
-        }
+        };
+        assert_eq!(
+            rewind_to, 10,
+            "helper must return rewind_to == fork_point (the first canonical block to re-fetch)"
+        );
+
+        // Caller contract: applying `last_seen_block = rewind_to - 1` makes the
+        // next iteration's `from_block = last_seen_block + 1 = rewind_to = fork_point`,
+        // so block `fork_point` is NOT skipped. This mirrors the contract-event
+        // path at fetch_logs.rs where `last_seen_block_number = fork_point - 1`.
+        let last_seen_block_after_rewind = U64::from(rewind_to.saturating_sub(1));
+        let next_from_block = last_seen_block_after_rewind + U64::from(1);
+        assert_eq!(
+            next_from_block,
+            U64::from(rewind_to),
+            "caller rewind must set next from_block to fork_point (inclusive)"
+        );
+    }
+
+    #[tokio::test]
+    async fn native_transfer_short_read_returns_failed() {
+        // Provider registered with blocks [10, 11] but caller requests [10, 11, 12].
+        // The helper must detect the short read and return Failed, so the caller
+        // backs off and retries the same range instead of silently advancing
+        // `last_seen_block` past block 12.
+        let canonical_10 = make_block_with_parent(10, b256(10), b256(9));
+        let canonical_11 = make_block_with_parent(11, b256(11), b256(10));
+        let provider: Arc<dyn ChainProvider> = Arc::new(
+            MockChainProvider::new(1).with_blocks(vec![canonical_10, canonical_11]),
+        );
+
+        // Coordinator with an empty window so validation would otherwise succeed
+        // — we want to isolate the short-read check.
+        let coordinator = make_test_coordinator("ethereum", &[], provider.clone());
+
+        let outcome = native_transfer_detect_reorg_in_range(
+            provider.as_ref(),
+            Some(&coordinator),
+            None,
+            None,
+            None,
+            "ethereum",
+            10,
+            12,
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            NativeTransferReorgOutcome::Failed,
+            "short read (2 blocks returned when 3 requested) must yield Failed",
+        );
     }
 
     #[tokio::test]

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -176,12 +176,7 @@ pub(crate) async fn native_transfer_detect_reorg_in_range(
     // acceptable for isolation. If latency becomes a concern, move
     // handle_reorg out of the hot path.
     let mut guard = coordinator.lock().await;
-    let ctx = ReorgContext {
-        postgres,
-        clickhouse,
-        registry: None,
-        trace_registry,
-    };
+    let ctx = ReorgContext { postgres, clickhouse, registry: None, trace_registry };
 
     for block in blocks {
         let number = block.header.number;
@@ -1007,9 +1002,8 @@ mod tests {
         // parent_hashes chain back to the window. Expect `Canonical`.
         let canonical_12 = make_block_with_parent(12, b256(12), b256(11));
         let canonical_13 = make_block_with_parent(13, b256(13), b256(12));
-        let provider: Arc<dyn ChainProvider> = Arc::new(
-            MockChainProvider::new(1).with_blocks(vec![canonical_12, canonical_13]),
-        );
+        let provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(1).with_blocks(vec![canonical_12, canonical_13]));
 
         let coordinator =
             make_test_coordinator("ethereum", &[(10, 10, 9), (11, 11, 10)], provider.clone());
@@ -1040,9 +1034,8 @@ mod tests {
         // the fork point; we expose canonical 11 so find_fork_point can succeed.
         let canonical_11 = make_block_with_parent(11, b256(0xFE), b256(10));
         let canonical_12 = make_block_with_parent(12, b256(12), b256(0xFE));
-        let provider: Arc<dyn ChainProvider> = Arc::new(
-            MockChainProvider::new(1).with_blocks(vec![canonical_11, canonical_12]),
-        );
+        let provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(1).with_blocks(vec![canonical_11, canonical_12]));
 
         let coordinator =
             make_test_coordinator("ethereum", &[(10, 10, 9), (11, 11, 10)], provider.clone());
@@ -1096,9 +1089,8 @@ mod tests {
         // `last_seen_block` past block 12.
         let canonical_10 = make_block_with_parent(10, b256(10), b256(9));
         let canonical_11 = make_block_with_parent(11, b256(11), b256(10));
-        let provider: Arc<dyn ChainProvider> = Arc::new(
-            MockChainProvider::new(1).with_blocks(vec![canonical_10, canonical_11]),
-        );
+        let provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(1).with_blocks(vec![canonical_10, canonical_11]));
 
         // Coordinator with an empty window so validation would otherwise succeed
         // — we want to isolate the short-read check.

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -343,6 +343,45 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
             let (from_block, to_block, network) =
                 results.first_metadata().expect("event_length > 0 guarantees at least one entry");
 
+            // Determine block range and network.
+            // For Trace results, NativeTransfer entries carry the batch metadata; if
+            // a batch has only Block entries (no-op blocks), there's nothing for this
+            // callback to process, so short-circuit.
+            let batch_meta = match &results {
+                CallbackResult::Event(event) => {
+                    let first = event.first().expect("event_length > 0 verified above");
+                    Some((
+                        first.found_in_request.from_block,
+                        first.found_in_request.to_block,
+                        first.tx_information.network.clone(),
+                    ))
+                }
+                CallbackResult::Trace(event) => event.iter().find_map(|result| match result {
+                    TraceResult::NativeTransfer { found_in_request, tx_information, .. } => {
+                        Some((
+                            found_in_request.from_block,
+                            found_in_request.to_block,
+                            tx_information.network.clone(),
+                        ))
+                    }
+                    TraceResult::Block { .. } => None,
+                }),
+            };
+
+            let (from_block, to_block, network) = match batch_meta {
+                Some(meta) => meta,
+                None => {
+                    debug!(
+                        "{} {}: {} - {}",
+                        params.indexer_name,
+                        params.contract_name,
+                        params.event_info.name,
+                        "NO NATIVE TRANSFER EVENTS IN TRACE BATCH"
+                    );
+                    return Ok(());
+                }
+            };
+
             let mut indexed_count = 0;
             let mut sql_bulk_data: Vec<Vec<EthereumSqlTypeWrapper>> = Vec::new();
             let mut sql_bulk_column_types: Vec<PgType> = Vec::new();

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -239,8 +239,7 @@ pub async fn setup_no_code(
                 &network_providers,
             )
             .await?;
-            let trace_registry =
-                TraceCallbackRegistry { events: trace_events, on_reorg: vec![] };
+            let trace_registry = TraceCallbackRegistry { events: trace_events, on_reorg: vec![] };
 
             if manifest.has_enabled_native_transfers() {
                 info!(
@@ -383,13 +382,11 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
                     ))
                 }
                 CallbackResult::Trace(event) => event.iter().find_map(|result| match result {
-                    TraceResult::NativeTransfer { found_in_request, tx_information, .. } => {
-                        Some((
-                            found_in_request.from_block,
-                            found_in_request.to_block,
-                            tx_information.network.clone(),
-                        ))
-                    }
+                    TraceResult::NativeTransfer { found_in_request, tx_information, .. } => Some((
+                        found_in_request.from_block,
+                        found_in_request.to_block,
+                        tx_information.network.clone(),
+                    )),
                     TraceResult::Block { .. } => None,
                 }),
             };
@@ -1245,11 +1242,8 @@ storage:
         let table = &tables[0];
         assert_eq!(table.name, "balances");
 
-        let account = table
-            .columns
-            .iter()
-            .find(|c| c.name == "account")
-            .expect("account column present");
+        let account =
+            table.columns.iter().find(|c| c.name == "account").expect("account column present");
         assert_eq!(account.resolved_type(), &ColumnType::Address);
 
         let total_sent = table

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -365,7 +365,7 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
             }
 
             //guarantees non empty batch
-            let (from_block, to_block, network) =
+            let (_from_block, _to_block, _network) =
                 results.first_metadata().expect("event_length > 0 guarantees at least one entry");
 
             // Determine block range and network.

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -1022,6 +1022,19 @@ pub async fn process_trace_events(
         let trace_information =
             TraceInformation::create(manifest.native_transfers.clone(), network_providers)?;
 
+        let nt_tables: Vec<TableRuntime> = manifest
+            .native_transfers
+            .tables
+            .as_ref()
+            .map(|tables| {
+                tables
+                    .iter()
+                    .map(|table| TableRuntime::new(table.clone(), &manifest.name, &contract_name))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let nt_tables_arc = Arc::new(nt_tables);
+
         let mut csv: Option<Arc<AsyncCsvAppender>> = None;
         if contract.generate_csv.unwrap_or(true) && manifest.storage.csv_enabled() {
             let csv_path =
@@ -1088,8 +1101,8 @@ pub async fn process_trace_events(
             sql_column_names,
             streams_clients: Arc::clone(&streams_arc),
             chat_clients: Arc::new(chat_clients),
-            tables: Arc::new(Vec::new()), // Native transfers don't support custom tables
-            store_raw_events: true,       // Native transfers always store raw events
+            tables: nt_tables_arc.clone(),
+            store_raw_events: true, // Native transfers always store raw events
             providers,
             constants: Arc::new(manifest.constants.clone()),
             multicall_addresses,
@@ -1102,6 +1115,7 @@ pub async fn process_trace_events(
             contract_name: contract_name.clone(),
             trace_information: trace_information.clone(),
             callback: no_code_callback(callback_params).trace_callback,
+            tables: nt_tables_arc,
             streams_clients: streams_arc,
         };
 

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -1050,6 +1050,7 @@ pub async fn process_trace_events(
         } else {
             None
         };
+        let streams_arc = Arc::new(streams_client);
 
         let chat_clients = if let Some(chats) = &contract.chat {
             Some(ChatClients::new(chats.clone()).await)
@@ -1085,7 +1086,7 @@ pub async fn process_trace_events(
             clickhouse: clickhouse.clone(),
             sql_event_table_name,
             sql_column_names,
-            streams_clients: Arc::new(streams_client),
+            streams_clients: Arc::clone(&streams_arc),
             chat_clients: Arc::new(chat_clients),
             tables: Arc::new(Vec::new()), // Native transfers don't support custom tables
             store_raw_events: true,       // Native transfers always store raw events
@@ -1101,6 +1102,7 @@ pub async fn process_trace_events(
             contract_name: contract_name.clone(),
             trace_information: trace_information.clone(),
             callback: no_code_callback(callback_params).trace_callback,
+            streams_clients: streams_arc,
         };
 
         events.push(event);

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -21,7 +21,7 @@ use crate::database::generate::generate_event_table_full_name;
 use crate::database::sql_type_wrapper::{
     map_ethereum_wrapper_to_json, map_log_params_to_ethereum_wrapper, EthereumSqlTypeWrapper,
 };
-use crate::manifest::contract::Contract;
+use crate::manifest::contract::{Contract, Table};
 use crate::manifest::core::Constants;
 use crate::provider::ChainProvider;
 use crate::{
@@ -100,33 +100,59 @@ pub fn resolve_table_column_types(
             Ok(items) => items,
             Err(e) => return Err(SetupNoCodeError::ProcessIndexersError(e.into())),
         };
-        let event_infos = match ABIItem::extract_event_names_and_signatures_from_abi(abi_items) {
-            Ok(infos) => infos,
-            Err(e) => return Err(SetupNoCodeError::ProcessIndexersError(e.into())),
-        };
-
-        // Build event ABI types map
-        let event_abi_types: HashMap<String, HashMap<String, String>> = event_infos
-            .iter()
-            .map(|event_info| {
-                let column_types: HashMap<String, String> = event_info
-                    .inputs
-                    .iter()
-                    .map(|input| (input.name.clone(), input.type_.clone()))
-                    .collect();
-                (event_info.name.clone(), column_types)
-            })
-            .collect();
+        let event_abi_types = build_event_abi_types(abi_items)?;
 
         // Resolve column types in custom tables
         if let Some(tables) = &mut contract.tables {
-            for table in tables.iter_mut() {
-                if let Err(e) = table.resolve_column_types(&event_abi_types) {
-                    return Err(SetupNoCodeError::ProcessIndexersError(
-                        ProcessIndexersError::TableColumnTypeResolutionError(e),
-                    ));
-                }
-            }
+            resolve_tables_against_abi(tables, &event_abi_types)?;
+        }
+    }
+
+    // Resolve column types for native-transfer custom tables against the synthetic
+    // NativeTransfer ABI so they reach `get_column_type()` fully resolved.
+    if manifest.has_enabled_native_transfers() {
+        if let Some(tables) = manifest.native_transfers.tables.as_mut() {
+            let abi_items: Vec<ABIItem> = serde_json::from_str(NATIVE_TRANSFER_ABI)
+                .map_err(|e| SetupNoCodeError::ProcessIndexersError(e.into()))?;
+            let event_abi_types = build_event_abi_types(abi_items)?;
+            resolve_tables_against_abi(tables, &event_abi_types)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Build an `event_name -> field_name -> solidity_type` map from a list of ABI items.
+#[allow(clippy::result_large_err)]
+fn build_event_abi_types(
+    abi_items: Vec<ABIItem>,
+) -> Result<HashMap<String, HashMap<String, String>>, SetupNoCodeError> {
+    let event_infos = ABIItem::extract_event_names_and_signatures_from_abi(abi_items)
+        .map_err(|e| SetupNoCodeError::ProcessIndexersError(e.into()))?;
+
+    Ok(event_infos
+        .iter()
+        .map(|event_info| {
+            let column_types: HashMap<String, String> = event_info
+                .inputs
+                .iter()
+                .map(|input| (input.name.clone(), input.type_.clone()))
+                .collect();
+            (event_info.name.clone(), column_types)
+        })
+        .collect())
+}
+
+#[allow(clippy::result_large_err)]
+fn resolve_tables_against_abi(
+    tables: &mut [Table],
+    event_abi_types: &HashMap<String, HashMap<String, String>>,
+) -> Result<(), SetupNoCodeError> {
+    for table in tables.iter_mut() {
+        if let Err(e) = table.resolve_column_types(event_abi_types) {
+            return Err(SetupNoCodeError::ProcessIndexersError(
+                ProcessIndexersError::TableColumnTypeResolutionError(e),
+            ));
         }
     }
     Ok(())
@@ -1163,4 +1189,74 @@ pub async fn process_trace_events(
     }
 
     Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::contract::ColumnType;
+    use std::path::PathBuf;
+
+    const NT_TABLES_YAML: &str = r#"
+name: test-indexer
+project_type: no-code
+networks:
+  - name: ethereum
+    chain_id: 1
+    rpc: https://eth.rpc.example.com
+native_transfers:
+  enabled: true
+  tables:
+    - name: balances
+      columns:
+        - name: account
+        - name: total_sent
+      events:
+        - event: NativeTransfer
+          operations:
+            - type: upsert
+              where:
+                account: "$from"
+              set:
+                - column: total_sent
+                  action: add
+                  value: "$value"
+contracts: []
+storage:
+  postgres:
+    enabled: true
+"#;
+
+    #[test]
+    fn resolve_table_column_types_resolves_native_transfer_tables() {
+        let mut manifest: Manifest =
+            serde_yaml::from_str(NT_TABLES_YAML).expect("parse manifest yaml");
+
+        // Any path is fine — contracts vector is empty, so no ABI file is read.
+        resolve_table_column_types(&PathBuf::from("/tmp"), &mut manifest)
+            .expect("native-transfer table columns resolve against synthetic ABI");
+
+        let tables = manifest
+            .native_transfers
+            .tables
+            .as_ref()
+            .expect("native_transfers.tables retained after resolution");
+        assert_eq!(tables.len(), 1);
+        let table = &tables[0];
+        assert_eq!(table.name, "balances");
+
+        let account = table
+            .columns
+            .iter()
+            .find(|c| c.name == "account")
+            .expect("account column present");
+        assert_eq!(account.resolved_type(), &ColumnType::Address);
+
+        let total_sent = table
+            .columns
+            .iter()
+            .find(|c| c.name == "total_sent")
+            .expect("total_sent column present");
+        assert_eq!(total_sent.resolved_type(), &ColumnType::Uint256);
+    }
 }

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -213,7 +213,8 @@ pub async fn setup_no_code(
                 &network_providers,
             )
             .await?;
-            let trace_registry = TraceCallbackRegistry { events: trace_events };
+            let trace_registry =
+                TraceCallbackRegistry { events: trace_events, on_reorg: vec![] };
 
             if manifest.has_enabled_native_transfers() {
                 info!(

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -52,7 +52,7 @@ pub enum ProcessEventError {
 /// This function returns immediately without waiting for the indexing to complete.
 pub async fn process_non_blocking_event(
     config: EventProcessingConfig,
-    reorg_coordinator: Option<ReorgCoordinator>,
+    reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
 ) -> Result<(), ProcessEventError> {
     debug!("{} - Processing non blocking event", config.info_log_name());
 
@@ -82,7 +82,7 @@ async fn process_event_logs(
     config: Arc<EventProcessingConfig>,
     force_no_live_indexing: bool,
     block_until_indexed: bool,
-    reorg_coordinator: Option<ReorgCoordinator>,
+    reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
 ) -> Result<(), Box<ProviderError>> {
     // The concurrency with which we can call the trigger. If the indexer is running in-order
     // we can only call one at a time, otherwise we can call multiple in parallel based on what is
@@ -310,7 +310,7 @@ pub struct OrderedLiveIndexingDetails {
 async fn process_contract_events_with_dependencies(
     dependencies: EventDependencies,
     events_processing_config: Arc<Vec<Arc<EventProcessingConfig>>>,
-    mut reorg_coordinators: HashMap<String, ReorgCoordinator>,
+    mut reorg_coordinators: HashMap<String, Arc<Mutex<ReorgCoordinator>>>,
 ) -> Result<(), ProcessContractEventsWithDependenciesError> {
     let mut stack = vec![dependencies.tree];
 
@@ -420,7 +420,7 @@ pub struct EventDependenciesIndexingConfig {
     pub network: String,
     pub cached_provider: Arc<dyn ChainProvider>,
     pub events: Vec<(Arc<EventProcessingConfig>, RindexerEventFilter)>,
-    pub reorg_coordinator: Option<ReorgCoordinator>,
+    pub reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
 }
 
 // TODO - this is a similar to live_indexing_stream but has to be a bit different we should merge
@@ -469,8 +469,7 @@ async fn live_indexing_for_contract_event_dependencies(
     // Use the first event's cancel_token -- all events in this generation share the same token.
     let generation_cancel = events.first().map(|(config, _)| config.cancel_token().clone());
 
-    // Reorg coordinator is mutated in-place during the loop
-    let mut reorg_coordinator = reorg_coordinator;
+    let reorg_coordinator = reorg_coordinator;
 
     let (pg_client, ch_client, streams_clients, event_registry) = events
         .first()
@@ -513,7 +512,7 @@ async fn live_indexing_for_contract_event_dependencies(
         };
 
         // Reorg detection: validate parent hash via coordinator
-        if let Some(ref mut coordinator) = reorg_coordinator {
+        if let Some(coordinator) = reorg_coordinator.as_ref() {
             let log_prefix = format!("{} - {}", network, IndexingEventProgressStatus::live_log());
             let reorg_ctx = ReorgContext {
                 postgres: pg_client.as_deref(),
@@ -521,8 +520,9 @@ async fn live_indexing_for_contract_event_dependencies(
                 registry: Some(&event_registry),
                 streams_clients: streams_clients.as_ref().as_ref(),
             };
+            let mut guard = coordinator.lock().await;
             match detect_and_handle_reorg(
-                coordinator,
+                &mut guard,
                 latest_block.header.number,
                 latest_block.header.hash,
                 latest_block.header.parent_hash,

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -21,8 +21,9 @@ use crate::metrics::indexing as metrics;
 use crate::provider::ChainProvider;
 use crate::{
     event::{
-        callback_registry::EventResult, config::EventProcessingConfig, BuildRindexerFilterError,
-        RindexerEventFilter,
+        callback_registry::{EventResult, TraceCallbackRegistry},
+        config::EventProcessingConfig,
+        BuildRindexerFilterError, RindexerEventFilter,
     },
     indexer::{
         dependency::{ContractEventsDependenciesConfig, EventDependencies},
@@ -53,10 +54,11 @@ pub enum ProcessEventError {
 pub async fn process_non_blocking_event(
     config: EventProcessingConfig,
     reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
+    trace_registry: Option<Arc<TraceCallbackRegistry>>,
 ) -> Result<(), ProcessEventError> {
     debug!("{} - Processing non blocking event", config.info_log_name());
 
-    process_event_logs(Arc::new(config), false, false, reorg_coordinator).await?;
+    process_event_logs(Arc::new(config), false, false, reorg_coordinator, trace_registry).await?;
 
     Ok(())
 }
@@ -70,7 +72,7 @@ pub async fn process_blocking_event_historical_data(
 
     // Historical data processing does not use reorg coordinator — reorgs are only
     // handled during live indexing.
-    process_event_logs(config, true, true, None).await?;
+    process_event_logs(config, true, true, None, None).await?;
 
     Ok(())
 }
@@ -83,6 +85,7 @@ async fn process_event_logs(
     force_no_live_indexing: bool,
     block_until_indexed: bool,
     reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
+    trace_registry: Option<Arc<TraceCallbackRegistry>>,
 ) -> Result<(), Box<ProviderError>> {
     // The concurrency with which we can call the trigger. If the indexer is running in-order
     // we can only call one at a time, otherwise we can call multiple in parallel based on what is
@@ -98,8 +101,12 @@ async fn process_event_logs(
 
     let callback_permits = Arc::new(Semaphore::new(callback_concurrency));
 
-    let mut logs_stream =
-        fetch_logs_stream(Arc::clone(&config), force_no_live_indexing, reorg_coordinator);
+    let mut logs_stream = fetch_logs_stream(
+        Arc::clone(&config),
+        force_no_live_indexing,
+        reorg_coordinator,
+        trace_registry,
+    );
     // Drain inline so handles don't accumulate during infinite live indexing.
     let mut in_flight: FuturesUnordered<JoinHandle<()>> = FuturesUnordered::new();
     let mut pending_error: Option<Box<dyn std::error::Error + Send>> = None;
@@ -256,16 +263,19 @@ pub enum ProcessContractsEventsWithDependenciesError {
 
 pub async fn process_contracts_events_with_dependencies(
     contracts_events_config: Vec<ContractEventsDependenciesConfig>,
+    trace_registry: Arc<TraceCallbackRegistry>,
 ) -> Result<(), ProcessContractsEventsWithDependenciesError> {
     let mut handles: Vec<JoinHandle<Result<(), ProcessContractEventsWithDependenciesError>>> =
         Vec::new();
 
     for contract_events in contracts_events_config {
+        let trace_registry = Arc::clone(&trace_registry);
         let handle = tokio::spawn(async move {
             process_contract_events_with_dependencies(
                 contract_events.event_dependencies,
                 Arc::new(contract_events.events_config),
                 contract_events.reorg_coordinators,
+                trace_registry,
             )
             .await
         });
@@ -311,6 +321,7 @@ async fn process_contract_events_with_dependencies(
     dependencies: EventDependencies,
     events_processing_config: Arc<Vec<Arc<EventProcessingConfig>>>,
     mut reorg_coordinators: HashMap<String, Arc<Mutex<ReorgCoordinator>>>,
+    trace_registry: Arc<TraceCallbackRegistry>,
 ) -> Result<(), ProcessContractEventsWithDependenciesError> {
     let mut stack = vec![dependencies.tree];
 
@@ -353,6 +364,7 @@ async fn process_contract_events_with_dependencies(
                                     cached_provider: network_contract.cached_provider.clone(),
                                     events: Vec::new(),
                                     reorg_coordinator: None,
+                                    trace_registry: None,
                                 });
 
                             let rindexer_event_filter =
@@ -406,6 +418,12 @@ async fn process_contract_events_with_dependencies(
         }
     }
 
+    // Share the trace registry so contract-event reorg detection also fires any
+    // `on_reorg` callbacks registered on the trace path.
+    for config in live_indexing_events.values_mut() {
+        config.trace_registry = Some(Arc::clone(&trace_registry));
+    }
+
     let live_indexing_tasks = live_indexing_events
         .drain()
         .map(|(_, config)| tokio::spawn(live_indexing_for_contract_event_dependencies(config)))
@@ -421,6 +439,9 @@ pub struct EventDependenciesIndexingConfig {
     pub cached_provider: Arc<dyn ChainProvider>,
     pub events: Vec<(Arc<EventProcessingConfig>, RindexerEventFilter)>,
     pub reorg_coordinator: Option<Arc<Mutex<ReorgCoordinator>>>,
+    /// Trace registry so `on_reorg` callbacks registered on the trace path also
+    /// fire when a reorg is detected by the contract-event pipeline.
+    pub trace_registry: Option<Arc<TraceCallbackRegistry>>,
 }
 
 // TODO - this is a similar to live_indexing_stream but has to be a bit different we should merge
@@ -432,6 +453,7 @@ async fn live_indexing_for_contract_event_dependencies(
         events,
         network,
         reorg_coordinator,
+        trace_registry,
     }: EventDependenciesIndexingConfig,
 ) {
     debug!(
@@ -518,6 +540,7 @@ async fn live_indexing_for_contract_event_dependencies(
                 postgres: pg_client.as_deref(),
                 clickhouse: ch_client.as_ref(),
                 registry: Some(&event_registry),
+                trace_registry: trace_registry.as_deref(),
                 streams_clients: streams_clients.as_ref().as_ref(),
             };
             // Mutex held across reorg handling (DB rollback, stream publishes).

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -520,6 +520,10 @@ async fn live_indexing_for_contract_event_dependencies(
                 registry: Some(&event_registry),
                 streams_clients: streams_clients.as_ref().as_ref(),
             };
+            // Mutex held across reorg handling (DB rollback, stream publishes).
+            // On a real reorg this blocks the other indexing path for the
+            // duration of handle_reorg, which is acceptable for isolation.
+            // If latency becomes a concern, move handle_reorg out of the hot path.
             let mut guard = coordinator.lock().await;
             match detect_and_handle_reorg(
                 &mut guard,

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -540,11 +540,11 @@ async fn live_indexing_for_contract_event_dependencies(
                 registry: Some(&event_registry),
                 trace_registry: trace_registry.as_deref(),
             };
-            // Mutex held across reorg handling (DB rollback, stream publishes,
-            // user on_reorg callback firing). On a real reorg this blocks the
-            // other indexing path for the duration of handle_reorg, which is
-            // acceptable for isolation. If latency becomes a concern, move
-            // handle_reorg out of the hot path.
+            // Mutex held across reorg handling (DB rollback, stream publishes
+            // in parallel, user on_reorg callback firing). On a real reorg
+            // this blocks the other indexing path for the duration of
+            // handle_reorg, which is acceptable for isolation. If latency
+            // becomes a concern, move handle_reorg out of the hot path.
             let mut guard = coordinator.lock().await;
             match detect_and_handle_reorg(
                 &mut guard,

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -543,10 +543,11 @@ async fn live_indexing_for_contract_event_dependencies(
                 trace_registry: trace_registry.as_deref(),
                 streams_clients: streams_clients.as_ref().as_ref(),
             };
-            // Mutex held across reorg handling (DB rollback, stream publishes).
-            // On a real reorg this blocks the other indexing path for the
-            // duration of handle_reorg, which is acceptable for isolation.
-            // If latency becomes a concern, move handle_reorg out of the hot path.
+            // Mutex held across reorg handling (DB rollback, stream publishes,
+            // user on_reorg callback firing). On a real reorg this blocks the
+            // other indexing path for the duration of handle_reorg, which is
+            // acceptable for isolation. If latency becomes a concern, move
+            // handle_reorg out of the hot path.
             let mut guard = coordinator.lock().await;
             match detect_and_handle_reorg(
                 &mut guard,

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -493,11 +493,9 @@ async fn live_indexing_for_contract_event_dependencies(
 
     let reorg_coordinator = reorg_coordinator;
 
-    let (pg_client, ch_client, streams_clients, event_registry) = events
+    let (pg_client, ch_client, event_registry) = events
         .first()
-        .map(|(config, _)| {
-            (config.postgres(), config.clickhouse(), config.streams_clients(), config.registry())
-        })
+        .map(|(config, _)| (config.postgres(), config.clickhouse(), config.registry()))
         .expect("live_indexing_for_contract_event_dependencies called with no events");
 
     loop {
@@ -541,7 +539,6 @@ async fn live_indexing_for_contract_event_dependencies(
                 clickhouse: ch_client.as_ref(),
                 registry: Some(&event_registry),
                 trace_registry: trace_registry.as_deref(),
-                streams_clients: streams_clients.as_ref().as_ref(),
             };
             // Mutex held across reorg handling (DB rollback, stream publishes,
             // user on_reorg callback firing). On a real reorg this blocks the

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -8,6 +8,7 @@ use tracing::{info, warn};
 use crate::event::callback_registry::ReorgNotification;
 use crate::metrics::indexing as metrics;
 use crate::provider::ChainProvider;
+use crate::streams::StreamsClients;
 
 use super::persistence::ReorgBlockHashPersistence;
 use super::task::{DerivedTableInfo, EventTableInfo, ReorgTask};
@@ -25,6 +26,14 @@ pub struct ReorgCoordinator {
     provider: Option<Arc<dyn ChainProvider>>,
     event_tables: Vec<EventTableInfo>,
     derived_tables: Vec<DerivedTableInfo>,
+    /// All `StreamsClients` configured for this network across every indexing
+    /// pipeline (contract events + native transfers). When a reorg is handled
+    /// we fan the retraction notification across all of them so consumers
+    /// receive it regardless of which pipeline detected the reorg first.
+    /// The outer `Arc<Option<...>>` matches the registry-side ownership; only
+    /// entries whose inner `Option` is `Some` are iterated. The caller is
+    /// expected to pre-filter out `None`-valued entries at construction time.
+    streams_clients: Vec<Arc<Option<StreamsClients>>>,
     blocks_since_flush: u64,
 }
 
@@ -36,6 +45,7 @@ impl ReorgCoordinator {
         provider: Arc<dyn ChainProvider>,
         event_tables: Vec<EventTableInfo>,
         derived_tables: Vec<DerivedTableInfo>,
+        streams_clients: Vec<Arc<Option<StreamsClients>>>,
     ) -> anyhow::Result<Self> {
         super::validate_sql_value(&network, "network name")?;
         Ok(Self {
@@ -45,6 +55,7 @@ impl ReorgCoordinator {
             provider: Some(provider),
             event_tables,
             derived_tables,
+            streams_clients,
             blocks_since_flush: 0,
         })
     }
@@ -376,17 +387,17 @@ impl ReorgCoordinator {
             }
         }
 
-        // Publish reorg retraction through instant-mode streams (fire-and-forget)
-        if let Some(clients) = ctx.streams_clients {
+        // Publish reorg retraction through every configured stream on the network
+        // so notifications reach consumers regardless of which indexing pipeline
+        // (contract events vs native transfers) detected the reorg first.
+        for clients_arc in &self.streams_clients {
+            let Some(clients) = clients_arc.as_ref().as_ref() else {
+                continue;
+            };
             let network = reorg_task.network.clone();
             let fork_point = reorg_task.fork_point;
             let depth = reorg_task.detection_point.saturating_sub(reorg_task.fork_point) + 1;
             let tx_hashes = affected_tx_hashes.clone();
-
-            // stream_reorg requires &self so we need a pointer; StreamsClients is not
-            // Clone, but the callers always have it behind Arc<Option<StreamsClients>>.
-            // Since we only have a reference here, we cannot move it into a spawn.
-            // Keep the await inline (the method is fast — it just publishes to queues).
             if let Err(e) = clients
                 .stream_reorg(
                     &network,
@@ -476,6 +487,7 @@ mod tests {
             provider: None,
             event_tables: vec![],
             derived_tables: vec![],
+            streams_clients: vec![],
             blocks_since_flush: 0,
         }
     }
@@ -616,7 +628,6 @@ mod tests {
             clickhouse: None,
             registry: Some(&registry),
             trace_registry: None,
-            streams_clients: None,
         };
 
         coordinator.handle_reorg(task, &ctx).await.unwrap();
@@ -661,7 +672,6 @@ mod tests {
             clickhouse: None,
             registry: None,
             trace_registry: Some(&trace_registry),
-            streams_clients: None,
         };
 
         coordinator.handle_reorg(task, &ctx).await.unwrap();
@@ -727,6 +737,7 @@ mod tests {
                     journal_columns: vec![],
                 },
             ],
+            streams_clients: vec![],
             blocks_since_flush: 0,
         };
 
@@ -755,6 +766,7 @@ mod tests {
                 rollback_ops: vec![],
                 journal_columns: vec![],
             }],
+            streams_clients: vec![],
             blocks_since_flush: 0,
         };
 
@@ -782,6 +794,7 @@ mod tests {
             )
             .unwrap()],
             derived_tables: vec![],
+            streams_clients: vec![],
             blocks_since_flush: 0,
         };
 

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -387,7 +387,10 @@ impl ReorgCoordinator {
             // Clone, but the callers always have it behind Arc<Option<StreamsClients>>.
             // Since we only have a reference here, we cannot move it into a spawn.
             // Keep the await inline (the method is fast — it just publishes to queues).
-            if let Err(e) = clients.stream_reorg(&network, fork_point, depth, &tx_hashes).await {
+            if let Err(e) = clients
+                .stream_reorg(&network, fork_point, depth, &tx_hashes, &result.affected_tables)
+                .await
+            {
                 tracing::error!(
                     network = %network,
                     fork_point,
@@ -766,6 +769,9 @@ mod tests {
                 "schema".to_string(),
                 "table".to_string(),
                 "schema_table".to_string(),
+                "test_indexer".to_string(),
+                "TestContract".to_string(),
+                "TestEvent".to_string(),
             )
             .unwrap()],
             derived_tables: vec![],

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -390,25 +390,45 @@ impl ReorgCoordinator {
         // Publish reorg retraction through every configured stream on the network
         // so notifications reach consumers regardless of which indexing pipeline
         // (contract events vs native transfers) detected the reorg first.
-        for clients_arc in &self.streams_clients {
-            let Some(clients) = clients_arc.as_ref().as_ref() else {
-                continue;
-            };
-            let network = reorg_task.network.clone();
-            let fork_point = reorg_task.fork_point;
-            let depth = reorg_task.detection_point.saturating_sub(reorg_task.fork_point) + 1;
+        //
+        // Fan out in parallel: with N streams configured at ~RTT each, serial
+        // awaits stack to N*RTT of stall blocking both indexing pipelines. Cheap
+        // Arc clones snapshot the stream set so each future owns its inputs.
+        let streams_snapshot: Vec<Arc<Option<StreamsClients>>> =
+            self.streams_clients.iter().map(Arc::clone).collect();
+        let network = reorg_task.network.clone();
+        let fork_point = reorg_task.fork_point;
+        let depth = reorg_task.detection_point.saturating_sub(reorg_task.fork_point) + 1;
+        let events_deleted = result.events_deleted;
+        let affected_tables = result.affected_tables.clone();
+
+        let futures = streams_snapshot.into_iter().filter_map(|clients_arc| {
+            // Skip slots whose inner `Option` is `None`.
+            clients_arc.as_ref().as_ref()?;
+            let network = network.clone();
             let tx_hashes = affected_tx_hashes.clone();
-            if let Err(e) = clients
-                .stream_reorg(
-                    &network,
-                    fork_point,
-                    depth,
-                    result.events_deleted,
-                    &tx_hashes,
-                    &result.affected_tables,
-                )
-                .await
-            {
+            let affected_tables = affected_tables.clone();
+            Some(async move {
+                let clients = clients_arc
+                    .as_ref()
+                    .as_ref()
+                    .expect("filter_map above ensures Some");
+                clients
+                    .stream_reorg(
+                        &network,
+                        fork_point,
+                        depth,
+                        events_deleted,
+                        &tx_hashes,
+                        &affected_tables,
+                    )
+                    .await
+            })
+        });
+
+        let results = futures::future::join_all(futures).await;
+        for res in results {
+            if let Err(e) = res {
                 tracing::error!(
                     network = %network,
                     fork_point,

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -409,10 +409,7 @@ impl ReorgCoordinator {
             let tx_hashes = affected_tx_hashes.clone();
             let affected_tables = affected_tables.clone();
             Some(async move {
-                let clients = clients_arc
-                    .as_ref()
-                    .as_ref()
-                    .expect("filter_map above ensures Some");
+                let clients = clients_arc.as_ref().as_ref().expect("filter_map above ensures Some");
                 clients
                     .stream_reorg(
                         &network,
@@ -696,8 +693,11 @@ mod tests {
 
         coordinator.handle_reorg(task, &ctx).await.unwrap();
 
-        let notification =
-            captured.lock().unwrap().take().expect("trace_registry on_reorg callback was not fired");
+        let notification = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("trace_registry on_reorg callback was not fired");
         assert_eq!(notification.network, "test");
         assert_eq!(notification.fork_block, 11);
         assert_eq!(notification.detection_block, 12);

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -388,7 +388,14 @@ impl ReorgCoordinator {
             // Since we only have a reference here, we cannot move it into a spawn.
             // Keep the await inline (the method is fast — it just publishes to queues).
             if let Err(e) = clients
-                .stream_reorg(&network, fork_point, depth, &tx_hashes, &result.affected_tables)
+                .stream_reorg(
+                    &network,
+                    fork_point,
+                    depth,
+                    result.events_deleted,
+                    &tx_hashes,
+                    &result.affected_tables,
+                )
                 .await
             {
                 tracing::error!(

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -491,6 +491,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_on_new_block_idempotent_for_same_hash() {
+        // Simulate two concurrent detectors (contract events + native transfers)
+        // calling on_new_block with identical (number, hash, parent_hash) after the
+        // Mutex serializes them. The second call must be idempotent — the window
+        // already contains the block with a matching hash, so validation passes
+        // and no reorg is reported.
+        let window = make_window_with_blocks(&[(10, 10, 9), (11, 11, 10)]);
+        let mut coordinator = make_coordinator(window);
+
+        // First call inserts block 12.
+        let first = coordinator.on_new_block(12, hash(12), hash(11)).await.unwrap();
+        assert!(first.is_none(), "first insert should be clean");
+        assert!(coordinator.window.get(12).is_some(), "block 12 should be in window");
+
+        // Second call with the SAME (number, hash, parent_hash) must not panic or
+        // fabricate a reorg. The window's `validate_parent` sees matching parent
+        // hash on block 11 and the insert is a no-op overwrite.
+        let second = coordinator.on_new_block(12, hash(12), hash(11)).await.unwrap();
+        assert!(second.is_none(), "second identical insert must be idempotent");
+        assert!(coordinator.window.get(12).is_some(), "block 12 still in window");
+    }
+
+    #[tokio::test]
     async fn test_on_new_block_reorg_detected() {
         // Build a window with blocks 10, 11, 12
         let window = make_window_with_blocks(&[(10, 10, 9), (11, 11, 10), (12, 12, 11)]);

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -361,14 +361,19 @@ impl ReorgCoordinator {
         let affected_tx_hashes: Vec<B256> =
             result.affected_tx_hashes.iter().filter_map(|h| B256::from_str(h).ok()).collect();
 
-        if let Some(registry) = ctx.registry {
+        if ctx.registry.is_some() || ctx.trace_registry.is_some() {
             let notification = ReorgNotification {
                 network: reorg_task.network.clone(),
                 fork_block: reorg_task.fork_point,
                 detection_block: reorg_task.detection_point,
                 invalidated_tx_hashes: affected_tx_hashes.clone(),
             };
-            registry.fire_on_reorg(notification).await;
+            if let Some(registry) = ctx.registry {
+                registry.fire_on_reorg(notification.clone()).await;
+            }
+            if let Some(trace_registry) = ctx.trace_registry {
+                trace_registry.fire_on_reorg(notification).await;
+            }
         }
 
         // Publish reorg retraction through instant-mode streams (fire-and-forget)
@@ -600,6 +605,7 @@ mod tests {
             postgres: None,
             clickhouse: None,
             registry: Some(&registry),
+            trace_registry: None,
             streams_clients: None,
         };
 
@@ -611,6 +617,80 @@ mod tests {
         assert_eq!(notification.fork_block, 11);
         assert_eq!(notification.detection_block, 12);
         assert!(notification.invalidated_tx_hashes.is_empty(), "no PG → no affected hashes");
+    }
+
+    #[tokio::test]
+    async fn test_handle_reorg_fires_on_reorg_callback_on_trace_registry() {
+        use crate::event::callback_registry::{ReorgNotification, TraceCallbackRegistry};
+        use std::sync::Mutex;
+
+        let window = make_window_with_blocks(&[(10, 10, 9), (11, 11, 10), (12, 12, 11)]);
+        let mut coordinator = make_coordinator(window);
+
+        let task = ReorgTask {
+            network: "test".to_string(),
+            fork_point: 11,
+            detection_point: 12,
+            event_tables: vec![],
+            derived_tables: vec![],
+            canonical_blocks: vec![],
+        };
+
+        let captured: Arc<Mutex<Option<ReorgNotification>>> = Arc::new(Mutex::new(None));
+        let captured_clone = Arc::clone(&captured);
+        let mut trace_registry = TraceCallbackRegistry::new();
+        trace_registry.register_on_reorg(Arc::new(move |notification| {
+            let captured = Arc::clone(&captured_clone);
+            Box::pin(async move {
+                *captured.lock().unwrap() = Some(notification);
+            })
+        }));
+
+        let ctx = ReorgContext {
+            postgres: None,
+            clickhouse: None,
+            registry: None,
+            trace_registry: Some(&trace_registry),
+            streams_clients: None,
+        };
+
+        coordinator.handle_reorg(task, &ctx).await.unwrap();
+
+        let notification =
+            captured.lock().unwrap().take().expect("trace_registry on_reorg callback was not fired");
+        assert_eq!(notification.network, "test");
+        assert_eq!(notification.fork_block, 11);
+        assert_eq!(notification.detection_block, 12);
+        assert!(notification.invalidated_tx_hashes.is_empty(), "no PG → no affected hashes");
+    }
+
+    #[tokio::test]
+    async fn test_trace_registry_fire_on_reorg_direct() {
+        use crate::event::callback_registry::{ReorgNotification, TraceCallbackRegistry};
+        use std::sync::Mutex;
+
+        let captured: Arc<Mutex<Option<ReorgNotification>>> = Arc::new(Mutex::new(None));
+        let captured_clone = Arc::clone(&captured);
+        let mut trace_registry = TraceCallbackRegistry::new();
+        trace_registry.register_on_reorg(Arc::new(move |notification| {
+            let captured = Arc::clone(&captured_clone);
+            Box::pin(async move {
+                *captured.lock().unwrap() = Some(notification);
+            })
+        }));
+
+        let notification = ReorgNotification {
+            network: "test".to_string(),
+            fork_block: 11,
+            detection_block: 12,
+            invalidated_tx_hashes: vec![],
+        };
+        trace_registry.fire_on_reorg(notification).await;
+
+        let observed = captured.lock().unwrap().take().expect("callback was not fired");
+        assert_eq!(observed.network, "test");
+        assert_eq!(observed.fork_block, 11);
+        assert_eq!(observed.detection_block, 12);
     }
 
     #[test]

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -514,6 +514,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_on_new_block_concurrent_same_block_through_arc_mutex() {
+        // Regression test for the shared-coordinator wiring (contract events +
+        // native transfers observe the same tip via Arc<Mutex<ReorgCoordinator>>).
+        // Spawn two tokio tasks that both race to call `on_new_block(12, 12, 11)`.
+        // The Mutex must serialize them; the second caller sees the block already
+        // in the window with a matching hash → validation passes → Ok(None).
+        use tokio::sync::Mutex as AsyncMutex;
+
+        let window = make_window_with_blocks(&[(10, 10, 9), (11, 11, 10)]);
+        let coordinator = Arc::new(AsyncMutex::new(make_coordinator(window)));
+
+        let c1 = Arc::clone(&coordinator);
+        let c2 = Arc::clone(&coordinator);
+
+        let h1 = tokio::spawn(async move {
+            let mut guard = c1.lock().await;
+            guard.on_new_block(12, hash(12), hash(11)).await
+        });
+        let h2 = tokio::spawn(async move {
+            let mut guard = c2.lock().await;
+            guard.on_new_block(12, hash(12), hash(11)).await
+        });
+
+        let r1 = h1.await.expect("task 1 panicked").expect("task 1 returned Err");
+        let r2 = h2.await.expect("task 2 panicked").expect("task 2 returned Err");
+
+        assert!(r1.is_none(), "first caller must see no reorg");
+        assert!(r2.is_none(), "second caller must see no reorg (idempotent)");
+
+        let guard = coordinator.lock().await;
+        assert!(guard.window.get(12).is_some(), "block 12 should remain in the window");
+    }
+
+    #[tokio::test]
     async fn test_on_new_block_reorg_detected() {
         // Build a window with blocks 10, 11, 12
         let window = make_window_with_blocks(&[(10, 10, 9), (11, 11, 10), (12, 12, 11)]);

--- a/core/src/indexer/reorg/mod.rs
+++ b/core/src/indexer/reorg/mod.rs
@@ -15,7 +15,6 @@ use crate::event::callback_registry::{EventCallbackRegistry, TraceCallbackRegist
 use crate::indexer::fetch_logs::ReorgInfo;
 use crate::metrics::indexing as metrics;
 use crate::notifications::ChainStateNotification;
-use crate::streams::StreamsClients;
 
 pub use coordinator::ReorgCoordinator;
 pub use persistence::ReorgBlockHashPersistence;
@@ -76,14 +75,15 @@ pub fn validate_sql_value(value: &str, kind: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Bundles the optional DB clients, callback registry, and streams clients
-/// that reorg recovery needs, avoiding parameter sprawl.
+/// Bundles the optional DB clients and callback registries that reorg recovery
+/// needs, avoiding parameter sprawl. Stream-retraction fan-out lives on the
+/// `ReorgCoordinator` itself so a single detection covers every pipeline on
+/// the network.
 pub struct ReorgContext<'a> {
     pub postgres: Option<&'a PostgresClient>,
     pub clickhouse: Option<&'a Arc<ClickhouseClient>>,
     pub registry: Option<&'a EventCallbackRegistry>,
     pub trace_registry: Option<&'a TraceCallbackRegistry>,
-    pub streams_clients: Option<&'a StreamsClients>,
 }
 
 /// Returns `Some(fork_point)` if a reorg was detected and handled (caller should rewind and `continue`),

--- a/core/src/indexer/reorg/mod.rs
+++ b/core/src/indexer/reorg/mod.rs
@@ -20,8 +20,8 @@ use crate::streams::StreamsClients;
 pub use coordinator::ReorgCoordinator;
 pub use persistence::ReorgBlockHashPersistence;
 pub use task::{
-    DerivedColumnJournal, DerivedColumnRollback, DerivedTableInfo, DerivedTableRollbackOp,
-    EventTableInfo,
+    AffectedTable, DerivedColumnJournal, DerivedColumnRollback, DerivedTableInfo,
+    DerivedTableRollbackOp, EventTableInfo,
 };
 pub use window::BlockChainWindow;
 

--- a/core/src/indexer/reorg/mod.rs
+++ b/core/src/indexer/reorg/mod.rs
@@ -11,7 +11,7 @@ use tracing::{debug, warn};
 
 use crate::database::clickhouse::client::ClickhouseClient;
 use crate::database::postgres::client::PostgresClient;
-use crate::event::callback_registry::EventCallbackRegistry;
+use crate::event::callback_registry::{EventCallbackRegistry, TraceCallbackRegistry};
 use crate::indexer::fetch_logs::ReorgInfo;
 use crate::metrics::indexing as metrics;
 use crate::notifications::ChainStateNotification;
@@ -82,6 +82,7 @@ pub struct ReorgContext<'a> {
     pub postgres: Option<&'a PostgresClient>,
     pub clickhouse: Option<&'a Arc<ClickhouseClient>>,
     pub registry: Option<&'a EventCallbackRegistry>,
+    pub trace_registry: Option<&'a TraceCallbackRegistry>,
     pub streams_clients: Option<&'a StreamsClients>,
 }
 

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -1094,12 +1094,8 @@ mod tests {
 
     #[test]
     fn test_derived_column_journal_happy_path_empty_where_columns() {
-        let jc = DerivedColumnJournal::try_new(
-            "max_trade".to_string(),
-            SetAction::Max,
-            vec![],
-        )
-        .expect("empty where_columns is allowed");
+        let jc = DerivedColumnJournal::try_new("max_trade".to_string(), SetAction::Max, vec![])
+            .expect("empty where_columns is allowed");
         assert_eq!(jc.derived_column, "max_trade");
         assert!(matches!(jc.action, SetAction::Max));
         assert!(jc.where_columns.is_empty());
@@ -1118,11 +1114,7 @@ mod tests {
 
     #[test]
     fn test_derived_column_journal_rejects_sql_injection() {
-        let err = DerivedColumnJournal::try_new(
-            "bad'--".to_string(),
-            SetAction::Set,
-            vec![],
-        );
+        let err = DerivedColumnJournal::try_new("bad'--".to_string(), SetAction::Set, vec![]);
         assert!(err.is_err(), "derived_column with SQL injection must be rejected");
 
         let err = DerivedColumnJournal::try_new(
@@ -1164,13 +1156,8 @@ mod tests {
 
     #[test]
     fn test_derived_table_info_happy_path_empty_ops() {
-        let dt = DerivedTableInfo::try_new(
-            "myschema.balances".to_string(),
-            false,
-            vec![],
-            vec![],
-        )
-        .expect("valid name should construct");
+        let dt = DerivedTableInfo::try_new("myschema.balances".to_string(), false, vec![], vec![])
+            .expect("valid name should construct");
         assert_eq!(dt.full_table_name, "myschema.balances");
         assert!(!dt.cross_chain);
         assert!(dt.rollback_ops.is_empty());
@@ -1191,13 +1178,8 @@ mod tests {
             None,
         )
         .unwrap();
-        let dt = DerivedTableInfo::try_new(
-            "myschema.balances".to_string(),
-            true,
-            vec![op],
-            vec![],
-        )
-        .expect("valid with one rollback op should construct");
+        let dt = DerivedTableInfo::try_new("myschema.balances".to_string(), true, vec![op], vec![])
+            .expect("valid with one rollback op should construct");
         assert_eq!(dt.full_table_name, "myschema.balances");
         assert!(dt.cross_chain);
         assert_eq!(dt.rollback_ops.len(), 1);

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -936,3 +936,270 @@ impl ReorgTask {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ======================================================================
+    // EventTableInfo::try_new
+    // ======================================================================
+
+    #[test]
+    fn test_event_table_info_try_new_happy_path() {
+        let info = EventTableInfo::try_new(
+            "my_schema".to_string(),
+            "transfer".to_string(),
+            "my_schema_transfer".to_string(),
+            "my_indexer".to_string(),
+            "USDC".to_string(),
+            "Transfer".to_string(),
+        )
+        .expect("valid identifiers should construct");
+        assert_eq!(info.schema, "my_schema");
+        assert_eq!(info.table_name, "transfer");
+        assert_eq!(info.full_name, "my_schema.transfer");
+        assert_eq!(info.checkpoint_table, "my_schema_transfer");
+        assert_eq!(info.indexer_name, "my_indexer");
+        assert_eq!(info.contract_name, "USDC");
+        assert_eq!(info.event_name, "Transfer");
+    }
+
+    #[test]
+    fn test_event_table_info_rejects_sql_injection_in_schema() {
+        let err = EventTableInfo::try_new(
+            "schema'; DROP".to_string(),
+            "transfer".to_string(),
+            "schema_transfer".to_string(),
+            "idx".to_string(),
+            "USDC".to_string(),
+            "Transfer".to_string(),
+        );
+        assert!(err.is_err(), "schema with SQL injection chars must be rejected");
+    }
+
+    #[test]
+    fn test_event_table_info_rejects_sql_injection_in_table_name() {
+        let err = EventTableInfo::try_new(
+            "schema".to_string(),
+            "transfer; DROP TABLE".to_string(),
+            "schema_transfer".to_string(),
+            "idx".to_string(),
+            "USDC".to_string(),
+            "Transfer".to_string(),
+        );
+        assert!(err.is_err(), "table name with SQL injection chars must be rejected");
+    }
+
+    #[test]
+    fn test_event_table_info_rejects_sql_injection_in_checkpoint_table() {
+        let err = EventTableInfo::try_new(
+            "schema".to_string(),
+            "transfer".to_string(),
+            "check'--".to_string(),
+            "idx".to_string(),
+            "USDC".to_string(),
+            "Transfer".to_string(),
+        );
+        assert!(err.is_err(), "checkpoint table with SQL injection chars must be rejected");
+    }
+
+    #[test]
+    fn test_event_table_info_does_not_validate_metadata_fields() {
+        // indexer/contract/event are metadata for stream payload — they must
+        // accept arbitrary strings (hyphens, spaces, etc.).
+        let info = EventTableInfo::try_new(
+            "schema".to_string(),
+            "transfer".to_string(),
+            "schema_transfer".to_string(),
+            "my-indexer-with-hyphens".to_string(),
+            "Contract With Spaces".to_string(),
+            "Event Name; DROP".to_string(),
+        )
+        .expect("metadata fields must not be SQL-validated");
+        assert_eq!(info.indexer_name, "my-indexer-with-hyphens");
+        assert_eq!(info.contract_name, "Contract With Spaces");
+        assert_eq!(info.event_name, "Event Name; DROP");
+    }
+
+    // ======================================================================
+    // AffectedTable construction + JSON shape
+    // ======================================================================
+
+    #[test]
+    fn test_affected_table_struct_and_json_shape() {
+        let at = AffectedTable {
+            schema: "s1".to_string(),
+            table_name: "t1".to_string(),
+            rows_deleted: 0,
+            indexer_name: "idx".to_string(),
+            contract_name: "USDC".to_string(),
+            event_name: "NativeTransfer".to_string(),
+        };
+        // The struct is used inside stream payloads; mirror the JSON shape
+        // that downstream consumers rely on (field-by-field).
+        let json = serde_json::json!({
+            "schema": at.schema,
+            "table_name": at.table_name,
+            "rows_deleted": at.rows_deleted,
+            "indexer_name": at.indexer_name,
+            "contract_name": at.contract_name,
+            "event_name": at.event_name,
+        });
+        assert_eq!(json["schema"], "s1");
+        assert_eq!(json["table_name"], "t1");
+        assert_eq!(json["rows_deleted"], 0);
+        assert_eq!(json["indexer_name"], "idx");
+        assert_eq!(json["contract_name"], "USDC");
+        assert_eq!(json["event_name"], "NativeTransfer");
+    }
+
+    // ======================================================================
+    // DerivedColumnRollback::try_new
+    // ======================================================================
+
+    #[test]
+    fn test_derived_column_rollback_happy_path() {
+        let rb = DerivedColumnRollback::try_new(
+            "balance".to_string(),
+            "value".to_string(),
+            SetAction::Add,
+        )
+        .expect("valid columns should construct");
+        assert_eq!(rb.derived_column, "balance");
+        assert_eq!(rb.event_column, "value");
+        assert!(matches!(rb.action, SetAction::Add));
+    }
+
+    #[test]
+    fn test_derived_column_rollback_rejects_sql_injection() {
+        let err = DerivedColumnRollback::try_new(
+            "balance'; DROP".to_string(),
+            "value".to_string(),
+            SetAction::Add,
+        );
+        assert!(err.is_err(), "derived_column with SQL injection must be rejected");
+
+        let err = DerivedColumnRollback::try_new(
+            "balance".to_string(),
+            "value--".to_string(),
+            SetAction::Add,
+        );
+        assert!(err.is_err(), "event_column with SQL injection must be rejected");
+    }
+
+    // ======================================================================
+    // DerivedColumnJournal::try_new
+    // ======================================================================
+
+    #[test]
+    fn test_derived_column_journal_happy_path_empty_where_columns() {
+        let jc = DerivedColumnJournal::try_new(
+            "max_trade".to_string(),
+            SetAction::Max,
+            vec![],
+        )
+        .expect("empty where_columns is allowed");
+        assert_eq!(jc.derived_column, "max_trade");
+        assert!(matches!(jc.action, SetAction::Max));
+        assert!(jc.where_columns.is_empty());
+    }
+
+    #[test]
+    fn test_derived_column_journal_multiple_where_columns() {
+        let jc = DerivedColumnJournal::try_new(
+            "latest".to_string(),
+            SetAction::Set,
+            vec!["user".to_string(), "token".to_string()],
+        )
+        .expect("multiple valid where_columns should be accepted");
+        assert_eq!(jc.where_columns, vec!["user".to_string(), "token".to_string()]);
+    }
+
+    #[test]
+    fn test_derived_column_journal_rejects_sql_injection() {
+        let err = DerivedColumnJournal::try_new(
+            "bad'--".to_string(),
+            SetAction::Set,
+            vec![],
+        );
+        assert!(err.is_err(), "derived_column with SQL injection must be rejected");
+
+        let err = DerivedColumnJournal::try_new(
+            "latest".to_string(),
+            SetAction::Set,
+            vec!["good".to_string(), "bad; DROP".to_string()],
+        );
+        assert!(err.is_err(), "where_columns entry with SQL injection must be rejected");
+    }
+
+    // ======================================================================
+    // DerivedTableRollbackOp::try_new
+    // ======================================================================
+
+    #[test]
+    fn test_derived_table_rollback_op_happy_path() {
+        let columns = vec![DerivedColumnRollback::try_new(
+            "balance".to_string(),
+            "value".to_string(),
+            SetAction::Add,
+        )
+        .unwrap()];
+        let op = DerivedTableRollbackOp::try_new(
+            "myschema.transfer".to_string(),
+            vec![("user".to_string(), "from_addr".to_string())],
+            columns,
+            None,
+        )
+        .expect("valid op should construct");
+        assert_eq!(op.event_table, "myschema.transfer");
+        assert_eq!(op.where_columns.len(), 1);
+        assert_eq!(op.columns.len(), 1);
+        assert!(op.condition.is_none());
+    }
+
+    // ======================================================================
+    // DerivedTableInfo::try_new
+    // ======================================================================
+
+    #[test]
+    fn test_derived_table_info_happy_path_empty_ops() {
+        let dt = DerivedTableInfo::try_new(
+            "myschema.balances".to_string(),
+            false,
+            vec![],
+            vec![],
+        )
+        .expect("valid name should construct");
+        assert_eq!(dt.full_table_name, "myschema.balances");
+        assert!(!dt.cross_chain);
+        assert!(dt.rollback_ops.is_empty());
+        assert!(dt.journal_columns.is_empty());
+    }
+
+    #[test]
+    fn test_derived_table_info_happy_path_with_one_op() {
+        let op = DerivedTableRollbackOp::try_new(
+            "myschema.transfer".to_string(),
+            vec![("user".to_string(), "from_addr".to_string())],
+            vec![DerivedColumnRollback::try_new(
+                "balance".to_string(),
+                "value".to_string(),
+                SetAction::Subtract,
+            )
+            .unwrap()],
+            None,
+        )
+        .unwrap();
+        let dt = DerivedTableInfo::try_new(
+            "myschema.balances".to_string(),
+            true,
+            vec![op],
+            vec![],
+        )
+        .expect("valid with one rollback op should construct");
+        assert_eq!(dt.full_table_name, "myschema.balances");
+        assert!(dt.cross_chain);
+        assert_eq!(dt.rollback_ops.len(), 1);
+    }
+}

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -20,6 +20,12 @@ pub struct EventTableInfo {
     pub full_name: String,
     /// Checkpoint table name in rindexer_internal (without schema prefix)
     pub checkpoint_table: String,
+    /// Indexer name for stream-payload metadata (not used in SQL).
+    pub indexer_name: String,
+    /// Contract name for stream-payload metadata (not used in SQL).
+    pub contract_name: String,
+    /// Event name for stream-payload metadata (not used in SQL).
+    pub event_name: String,
 }
 
 impl EventTableInfo {
@@ -27,13 +33,47 @@ impl EventTableInfo {
         schema: String,
         table_name: String,
         checkpoint_table: String,
+        indexer_name: String,
+        contract_name: String,
+        event_name: String,
     ) -> anyhow::Result<Self> {
         super::validate_sql_identifier(&schema, "event table schema")?;
         super::validate_sql_identifier(&table_name, "event table name")?;
         super::validate_sql_identifier(&checkpoint_table, "checkpoint table name")?;
+        // indexer/contract/event names are metadata for the stream payload,
+        // not used in SQL, so no SQL validation needed.
         let full_name = format!("{}.{}", schema, table_name);
-        Ok(Self { schema, table_name, full_name, checkpoint_table })
+        Ok(Self {
+            schema,
+            table_name,
+            full_name,
+            checkpoint_table,
+            indexer_name,
+            contract_name,
+            event_name,
+        })
     }
+}
+
+/// Per-table summary emitted to downstream consumers in the `__rindexer_reorg`
+/// stream payload. Tells consumers which source event tables were invalidated
+/// so they can act programmatically.
+#[derive(Clone, Debug)]
+pub struct AffectedTable {
+    pub schema: String,
+    pub table_name: String,
+    /// TODO(future): per-table counts are not available from the DB layer today;
+    /// the total is on `ReorgTaskResult.events_deleted`. Set to 0 until a
+    /// cheap per-table tally is added.
+    pub rows_deleted: u64,
+    /// TODO(future): thread event selector through `EventTableInfo` so this
+    /// can be populated for contract events. Native transfers and derived
+    /// tables will remain `None`.
+    pub event_signature_hash: Option<B256>,
+    pub indexer_name: String,
+    pub contract_name: String,
+    /// "NativeTransfer" for native-transfer tables.
+    pub event_name: String,
 }
 
 /// Describes how to reverse one column's accumulation during reorg.
@@ -167,6 +207,10 @@ pub struct ReorgTaskResult {
     pub events_deleted: u64,
     pub duration_secs: f64,
     pub affected_tx_hashes: Vec<String>,
+    /// Per-table summary of which source event tables were rolled back.
+    /// Derived tables are intentionally NOT included — this is about source
+    /// event tables downstream consumers may need to know about.
+    pub affected_tables: Vec<AffectedTable>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -870,10 +914,31 @@ impl ReorgTask {
             "Reorg task completed"
         );
 
+        // Build the per-table summary for downstream stream consumers. Only
+        // source event tables that were rolled back appear here — derived
+        // tables are intentionally excluded.
+        let affected_tables: Vec<AffectedTable> = self
+            .event_tables
+            .iter()
+            .map(|t| AffectedTable {
+                schema: t.schema.clone(),
+                table_name: t.table_name.clone(),
+                // TODO(future): per-table counts from DB layer; total is on
+                // `events_deleted`.
+                rows_deleted: 0,
+                // TODO(future): thread event selector through `EventTableInfo`.
+                event_signature_hash: None,
+                indexer_name: t.indexer_name.clone(),
+                contract_name: t.contract_name.clone(),
+                event_name: t.event_name.clone(),
+            })
+            .collect();
+
         Ok(ReorgTaskResult {
             events_deleted: total_deleted,
             duration_secs: duration,
             affected_tx_hashes,
+            affected_tables,
         })
     }
 }

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -66,10 +66,6 @@ pub struct AffectedTable {
     /// the total is on `ReorgTaskResult.events_deleted`. Set to 0 until a
     /// cheap per-table tally is added.
     pub rows_deleted: u64,
-    /// TODO(future): thread event selector through `EventTableInfo` so this
-    /// can be populated for contract events. Native transfers and derived
-    /// tables will remain `None`.
-    pub event_signature_hash: Option<B256>,
     pub indexer_name: String,
     pub contract_name: String,
     /// "NativeTransfer" for native-transfer tables.
@@ -926,8 +922,6 @@ impl ReorgTask {
                 // TODO(future): per-table counts from DB layer; total is on
                 // `events_deleted`.
                 rows_deleted: 0,
-                // TODO(future): thread event selector through `EventTableInfo`.
-                event_signature_hash: None,
                 indexer_name: t.indexer_name.clone(),
                 contract_name: t.contract_name.clone(),
                 event_name: t.event_name.clone(),

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -302,6 +302,52 @@ async fn start_indexing_traces(
     Ok(non_blocking_process_events)
 }
 
+/// Find a provider for a network, falling back to the trace registry so that
+/// native-transfer-only networks (which have no entry in `registry.events`) still
+/// resolve to their configured provider.
+fn find_provider_for_network(
+    registry: &EventCallbackRegistry,
+    trace_registry: &TraceCallbackRegistry,
+    network_name: &str,
+) -> Option<Arc<dyn ChainProvider>> {
+    registry
+        .events
+        .iter()
+        .flat_map(|e| e.contract.details.iter())
+        .find(|nc| nc.network == network_name)
+        .map(|nc| nc.cached_provider.clone())
+        .or_else(|| {
+            trace_registry
+                .events
+                .iter()
+                .flat_map(|e| e.trace_information.details.iter())
+                .find(|nd| nd.network == network_name)
+                .map(|nd| nd.cached_provider.clone())
+        })
+}
+
+/// Find streams clients for a network, falling back to the trace registry so that
+/// native-transfer-only networks still publish startup-rollback notifications to
+/// their configured stream.
+fn find_streams_clients_for_network(
+    registry: &EventCallbackRegistry,
+    trace_registry: &TraceCallbackRegistry,
+    network_name: &str,
+) -> Option<Arc<Option<crate::streams::StreamsClients>>> {
+    registry
+        .events
+        .iter()
+        .find(|e| e.contract.details.iter().any(|d| d.network == network_name))
+        .map(|e| e.streams_clients.clone())
+        .or_else(|| {
+            trace_registry
+                .events
+                .iter()
+                .find(|e| e.trace_information.details.iter().any(|d| d.network == network_name))
+                .map(|e| e.streams_clients.clone())
+        })
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn start_indexing_contract_events(
     manifest: &Manifest,
@@ -310,6 +356,7 @@ async fn start_indexing_contract_events(
     clickhouse: Option<Arc<ClickhouseClient>>,
     indexer: &Indexer,
     registry: Arc<EventCallbackRegistry>,
+    trace_registry: Arc<TraceCallbackRegistry>,
     dependencies: &[ContractEventDependencies],
     no_live_indexing_forced: bool,
     cancel_token: CancellationToken,
@@ -586,13 +633,10 @@ async fn start_indexing_contract_events(
             }
         };
 
-        // Get a provider for this network from any registry event targeting it
-        let provider = registry
-            .events
-            .iter()
-            .flat_map(|e| e.contract.details.iter())
-            .find(|nc| nc.network == *network_name)
-            .map(|nc| nc.cached_provider.clone());
+        // Get a provider for this network from any registry event targeting it.
+        // Native-transfer-only networks have no entry in `registry.events`, so fall back
+        // to `trace_registry.events[].trace_information.details` for those providers.
+        let provider = find_provider_for_network(&registry, &trace_registry, network_name);
 
         if let Some(provider) = provider {
             let derived_tables =
@@ -606,12 +650,11 @@ async fn start_indexing_contract_events(
                 derived_tables,
             )?;
 
-            // Get streams_clients for this network (if any event has one)
-            let startup_streams_clients = registry
-                .events
-                .iter()
-                .find(|e| e.contract.details.iter().any(|d| d.network == *network_name))
-                .map(|e| e.streams_clients.clone());
+            // Get streams_clients for this network (if any event has one). Fall back to
+            // the trace registry so native-transfer-only networks still publish
+            // startup-rollback notifications to their configured stream.
+            let startup_streams_clients =
+                find_streams_clients_for_network(&registry, &trace_registry, network_name);
 
             // Run startup validation
             match coordinator.validate_on_startup().await {
@@ -885,12 +928,22 @@ async fn start_indexing_contract_events(
                     }
                 };
 
-                // Get a provider from any dependency event config for this network
+                // Get a provider from any dependency event config for this network.
+                // Fall back to the trace registry so native-transfer-only networks still
+                // have a provider available when this branch is reached.
                 let provider = dependency_event_processing_configs
                     .iter()
                     .flat_map(|dep| dep.events_config.iter())
                     .find(|e| e.network_contract().network == *network_name)
-                    .map(|e| e.network_contract().cached_provider.clone());
+                    .map(|e| e.network_contract().cached_provider.clone())
+                    .or_else(|| {
+                        trace_registry
+                            .events
+                            .iter()
+                            .flat_map(|e| e.trace_information.details.iter())
+                            .find(|nd| nd.network == *network_name)
+                            .map(|nd| nd.cached_provider.clone())
+                    });
 
                 if let Some(provider) = provider {
                     let derived_tables =
@@ -904,12 +957,25 @@ async fn start_indexing_contract_events(
                         derived_tables,
                     )?;
 
-                    // Get streams_clients for this network from dependency events
+                    // Get streams_clients for this network from dependency events, with a
+                    // fall back to the trace registry for native-transfer-only networks.
                     let dep_streams_clients = dependency_event_processing_configs
                         .iter()
                         .flat_map(|dep| dep.events_config.iter())
                         .find(|e| e.network_contract().network == *network_name)
-                        .map(|e| e.streams_clients());
+                        .map(|e| e.streams_clients())
+                        .or_else(|| {
+                            trace_registry
+                                .events
+                                .iter()
+                                .find(|e| {
+                                    e.trace_information
+                                        .details
+                                        .iter()
+                                        .any(|d| d.network == *network_name)
+                                })
+                                .map(|e| e.streams_clients.clone())
+                        });
 
                     match coordinator.validate_on_startup().await {
                         Ok(Some(startup_task)) => {
@@ -1068,6 +1134,7 @@ async fn start_indexing(
             clickhouse.clone(),
             &indexer,
             registry.clone(),
+            trace_registry.clone(),
             dependencies,
             no_live_indexing_forced,
             cancel_token.clone(),
@@ -1500,5 +1567,104 @@ mod tests {
         );
         assert_eq!(end, U64::from(1000));
         assert_eq!(distance, U64::ZERO);
+    }
+
+    // --- Provider / streams_clients lookup tests ---
+    //
+    // These cover the fallback from `registry.events` → `trace_registry.events` for
+    // native-transfer-only networks (Task 1, Step 2 verification).
+
+    use crate::event::callback_registry::{
+        TraceCallbackRegistry, TraceCallbackRegistryInformation,
+    };
+    use crate::event::contract_setup::{NetworkTrace, TraceInformation};
+    use crate::manifest::native_transfer::TraceProcessingMethod;
+    use crate::provider::ChainProvider;
+    use futures::future::{BoxFuture, FutureExt};
+
+    fn trace_registry_with_network(
+        network: &str,
+        provider: Arc<dyn ChainProvider>,
+    ) -> TraceCallbackRegistry {
+        let noop_callback: Arc<
+            dyn Fn(
+                    Vec<crate::event::callback_registry::TraceResult>,
+                ) -> BoxFuture<
+                    'static,
+                    crate::event::callback_registry::EventCallbackResult<()>,
+                > + Send
+                + Sync,
+        > = Arc::new(|_| async { Ok(()) }.boxed());
+
+        let trace_info = TraceInformation {
+            name: "NativeTransfer".to_string(),
+            details: vec![NetworkTrace {
+                id: "anvil-trace".to_string(),
+                network: network.to_string(),
+                cached_provider: provider,
+                start_block: None,
+                end_block: None,
+                method: TraceProcessingMethod::EthGetBlockByNumber,
+            }],
+            reorg_safe_distance: None,
+        };
+
+        let info = TraceCallbackRegistryInformation {
+            id: "test-id".to_string(),
+            indexer_name: "test_indexer".to_string(),
+            event_name: "NativeTransfer".to_string(),
+            contract_name: "EvmTraces".to_string(),
+            trace_information: trace_info,
+            callback: noop_callback,
+            streams_clients: Arc::new(None),
+        };
+
+        TraceCallbackRegistry { events: vec![info] }
+    }
+
+    #[test]
+    fn provider_lookup_falls_back_to_trace_registry() {
+        // Network "anvil" has no contract events but IS present as a native-transfer
+        // target. The provider lookup must resolve to the trace registry's provider.
+        let mock_provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(31337).with_block_number(100));
+        let empty_registry = EventCallbackRegistry::new();
+        let trace_registry = trace_registry_with_network("anvil", mock_provider.clone());
+
+        let found = find_provider_for_network(&empty_registry, &trace_registry, "anvil");
+
+        assert!(found.is_some(), "expected provider to be found via trace registry fallback");
+        // Identity check: same Arc instance (contract/trace chain provider is the same pointer).
+        assert!(Arc::ptr_eq(&found.unwrap(), &mock_provider));
+    }
+
+    #[test]
+    fn provider_lookup_returns_none_for_unknown_network() {
+        // Network "mainnet" is not present in either registry → None.
+        let mock_provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(31337).with_block_number(100));
+        let empty_registry = EventCallbackRegistry::new();
+        let trace_registry = trace_registry_with_network("anvil", mock_provider);
+
+        let found = find_provider_for_network(&empty_registry, &trace_registry, "mainnet");
+
+        assert!(found.is_none(), "expected no provider for unknown network");
+    }
+
+    #[test]
+    fn streams_clients_lookup_falls_back_to_trace_registry() {
+        // Native-transfer-only network: streams_clients must fall back to the trace
+        // registry so the coordinator still fires startup-rollback notifications.
+        let mock_provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(31337).with_block_number(100));
+        let empty_registry = EventCallbackRegistry::new();
+        let trace_registry = trace_registry_with_network("anvil", mock_provider);
+
+        let found = find_streams_clients_for_network(&empty_registry, &trace_registry, "anvil");
+
+        // The fixture uses `Arc::new(None)` — we just need to confirm the fallback
+        // path is exercised and returns Some(Arc<Option<...>>) instead of None.
+        assert!(found.is_some(), "expected streams_clients fallback to trace registry");
+        assert!(found.unwrap().is_none(), "fixture carries Arc::new(None) for streams_clients");
     }
 }

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -191,9 +191,15 @@ async fn start_indexing_traces(
     cancel_token: CancellationToken,
     progress: Arc<IndexingEventsProgressState>,
     network_coordinators: &HashMap<String, Arc<Mutex<ReorgCoordinator>>>,
+    no_live_indexing_forced: bool,
 ) -> Result<Vec<JoinHandle<Result<(), ProcessEventError>>>, StartIndexingError> {
     if !manifest.native_transfers.enabled {
         info!("Native transfer indexing disabled!");
+        return Ok(vec![]);
+    }
+
+    if no_live_indexing_forced {
+        info!("Native transfer indexing skipped in historical-only pass (no end_block semantic)");
         return Ok(vec![]);
     }
 
@@ -1201,6 +1207,7 @@ async fn start_indexing(
         cancel_token.clone(),
         progress.clone(),
         &network_coordinators,
+        no_live_indexing_forced,
     )
     .await?;
 

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -353,6 +353,115 @@ fn reorg_ctx_streams(
     startup_streams_clients.as_ref().and_then(|a| a.as_ref().as_ref())
 }
 
+/// Build derived-table rollback + journal entries for an event's tables and merge
+/// them into `accumulator` keyed by `network`. Shared between contract events and
+/// native-transfer trace events so both sources contribute to reorg rollback.
+fn build_derived_tables_for_event(
+    event_name: &str,
+    indexer_name: &str,
+    contract_name: &str,
+    network: &str,
+    tables: &[crate::indexer::tables::TableRuntime],
+    accumulator: &mut HashMap<String, Vec<DerivedTableInfo>>,
+) -> anyhow::Result<()> {
+    let schema = generate_indexer_contract_schema_name(indexer_name, contract_name);
+    let event_table_full = format!("{}.{}", schema, camel_to_snake(event_name));
+
+    for tr in tables.iter() {
+        let derived = accumulator.entry(network.to_string()).or_default();
+
+        let event_table_name = event_table_full.clone();
+        let mut rollback_ops: Vec<DerivedTableRollbackOp> = Vec::new();
+        let mut journal_columns: Vec<DerivedColumnJournal> = Vec::new();
+
+        for table_event in &tr.table.events {
+            if table_event.event != event_name {
+                continue;
+            }
+            for operation in &table_event.operations {
+                use crate::manifest::contract::OperationType;
+                if !matches!(
+                    operation.operation_type,
+                    OperationType::Upsert | OperationType::Update
+                ) {
+                    continue;
+                }
+
+                let mut where_columns: Vec<(String, String)> = operation
+                    .where_clause
+                    .iter()
+                    .filter_map(|(col, val)| {
+                        val.strip_prefix('$').map(|field| (col.clone(), camel_to_snake(field)))
+                    })
+                    .collect();
+                where_columns.sort_by(|a, b| a.0.cmp(&b.0));
+
+                let where_col_names: Vec<String> =
+                    where_columns.iter().map(|(col, _)| col.clone()).collect();
+
+                let columns: Vec<DerivedColumnRollback> = operation
+                    .set
+                    .iter()
+                    .filter(|set_col| {
+                        set_col.action.reverse().is_some() && set_col.event_field_name().is_some()
+                    })
+                    .map(|set_col| {
+                        DerivedColumnRollback::try_new(
+                            set_col.column.clone(),
+                            camel_to_snake(set_col.event_field_name().unwrap()),
+                            set_col.action.clone(),
+                        )
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+
+                // Collect non-reversible columns for journal-based recalculation
+                for set_col in &operation.set {
+                    if set_col.action.reverse().is_some() {
+                        continue; // handled by rollback_ops
+                    }
+                    if !journal_columns.iter().any(|jc| jc.derived_column == set_col.column) {
+                        journal_columns.push(DerivedColumnJournal::try_new(
+                            set_col.column.clone(),
+                            set_col.action.clone(),
+                            where_col_names.clone(),
+                        )?);
+                    }
+                }
+
+                if !columns.is_empty() {
+                    rollback_ops.push(DerivedTableRollbackOp::try_new(
+                        event_table_name.clone(),
+                        where_columns,
+                        columns,
+                        operation.condition().map(String::from),
+                    )?);
+                }
+            }
+        }
+
+        // Merge into existing entry or create a new one
+        if let Some(existing) =
+            derived.iter_mut().find(|d| d.full_table_name == tr.full_table_name)
+        {
+            existing.rollback_ops.extend(rollback_ops);
+            for jc in journal_columns {
+                if !existing.journal_columns.iter().any(|e| e.derived_column == jc.derived_column) {
+                    existing.journal_columns.push(jc);
+                }
+            }
+        } else {
+            derived.push(DerivedTableInfo::try_new(
+                tr.full_table_name.clone(),
+                tr.table.cross_chain,
+                rollback_ops,
+                journal_columns,
+            )?);
+        }
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn start_indexing_contract_events(
     manifest: &Manifest,
@@ -473,113 +582,20 @@ async fn start_indexing_contract_events(
             let schema =
                 generate_indexer_contract_schema_name(&event.indexer_name, &event.contract.name);
             let table_name = camel_to_snake(&event.event_name);
-            let event_table_full = format!("{}.{}", schema, table_name);
             let checkpoint_table = generate_internal_event_table_name(&schema, &event.event_name);
             network_event_tables
                 .entry(network_contract.network.clone())
                 .or_default()
                 .push(EventTableInfo::try_new(schema, table_name, checkpoint_table)?);
 
-            for tr in event.tables.iter() {
-                let derived =
-                    network_derived_tables.entry(network_contract.network.clone()).or_default();
-
-                // Build rollback_ops from table event mappings that reference this event
-                let event_table_name = event_table_full.clone();
-                let mut rollback_ops: Vec<DerivedTableRollbackOp> = Vec::new();
-                let mut journal_columns: Vec<DerivedColumnJournal> = Vec::new();
-
-                for table_event in &tr.table.events {
-                    if table_event.event != event.event_name {
-                        continue;
-                    }
-                    for operation in &table_event.operations {
-                        use crate::manifest::contract::OperationType;
-                        if !matches!(
-                            operation.operation_type,
-                            OperationType::Upsert | OperationType::Update
-                        ) {
-                            continue;
-                        }
-
-                        let mut where_columns: Vec<(String, String)> = operation
-                            .where_clause
-                            .iter()
-                            .filter_map(|(col, val)| {
-                                val.strip_prefix('$')
-                                    .map(|field| (col.clone(), camel_to_snake(field)))
-                            })
-                            .collect();
-                        where_columns.sort_by(|a, b| a.0.cmp(&b.0));
-
-                        let where_col_names: Vec<String> =
-                            where_columns.iter().map(|(col, _)| col.clone()).collect();
-
-                        let columns: Vec<DerivedColumnRollback> = operation
-                            .set
-                            .iter()
-                            .filter(|set_col| {
-                                set_col.action.reverse().is_some()
-                                    && set_col.event_field_name().is_some()
-                            })
-                            .map(|set_col| {
-                                DerivedColumnRollback::try_new(
-                                    set_col.column.clone(),
-                                    camel_to_snake(set_col.event_field_name().unwrap()),
-                                    set_col.action.clone(),
-                                )
-                            })
-                            .collect::<anyhow::Result<Vec<_>>>()?;
-
-                        // Collect non-reversible columns for journal-based recalculation
-                        for set_col in &operation.set {
-                            if set_col.action.reverse().is_some() {
-                                continue; // handled by rollback_ops
-                            }
-                            if !journal_columns.iter().any(|jc| jc.derived_column == set_col.column)
-                            {
-                                journal_columns.push(DerivedColumnJournal::try_new(
-                                    set_col.column.clone(),
-                                    set_col.action.clone(),
-                                    where_col_names.clone(),
-                                )?);
-                            }
-                        }
-
-                        if !columns.is_empty() {
-                            rollback_ops.push(DerivedTableRollbackOp::try_new(
-                                event_table_name.clone(),
-                                where_columns,
-                                columns,
-                                operation.condition().map(String::from),
-                            )?);
-                        }
-                    }
-                }
-
-                // Merge into existing entry or create a new one
-                if let Some(existing) =
-                    derived.iter_mut().find(|d| d.full_table_name == tr.full_table_name)
-                {
-                    existing.rollback_ops.extend(rollback_ops);
-                    for jc in journal_columns {
-                        if !existing
-                            .journal_columns
-                            .iter()
-                            .any(|e| e.derived_column == jc.derived_column)
-                        {
-                            existing.journal_columns.push(jc);
-                        }
-                    }
-                } else {
-                    derived.push(DerivedTableInfo::try_new(
-                        tr.full_table_name.clone(),
-                        tr.table.cross_chain,
-                        rollback_ops,
-                        journal_columns,
-                    )?);
-                }
-            }
+            build_derived_tables_for_event(
+                &event.event_name,
+                &event.indexer_name,
+                &event.contract.name,
+                &network_contract.network,
+                &event.tables,
+                &mut network_derived_tables,
+            )?;
         }
     }
 
@@ -599,6 +615,21 @@ async fn start_indexing_contract_events(
                     .entry(nt_detail.network.clone())
                     .or_default()
                     .push(EventTableInfo::try_new(schema, table_name, checkpoint_table)?);
+            }
+        }
+
+        // Mirror the contract-events pass for native-transfer derived tables: every
+        // trace event contributes rollback ops for each configured network.
+        for trace_event in trace_registry.events.iter() {
+            for network_detail in trace_event.trace_information.details.iter() {
+                build_derived_tables_for_event(
+                    &trace_event.event_name,
+                    &trace_event.indexer_name,
+                    &trace_event.contract_name,
+                    &network_detail.network,
+                    &trace_event.tables,
+                    &mut network_derived_tables,
+                )?;
             }
         }
     }
@@ -1624,6 +1655,7 @@ mod tests {
             contract_name: "EvmTraces".to_string(),
             trace_information: trace_info,
             callback: noop_callback,
+            tables: Arc::new(Vec::new()),
             streams_clients: Arc::new(None),
         };
 
@@ -1707,5 +1739,103 @@ mod tests {
         let none_inner: Option<Arc<Option<crate::streams::StreamsClients>>> =
             Some(Arc::new(None));
         assert!(reorg_ctx_streams(&none_inner).is_none());
+    }
+
+    // --- Derived-table rollback build tests ---
+    //
+    // Verifies that `build_derived_tables_for_event` is symmetric for contract
+    // events and native-transfer trace events: both sources populate
+    // `network_derived_tables` with rollback ops that target their respective
+    // source table.
+
+    #[test]
+    fn build_derived_tables_for_native_transfer_populates_accumulator() {
+        use crate::indexer::tables::TableRuntime;
+        use crate::manifest::contract::{
+            OperationType, SetAction, SetColumn, Table, TableColumn, TableEventMapping,
+            TableOperation,
+        };
+
+        // Minimal derived table: one upsert op keyed by `account` that adds
+        // `$value` to `total_sent` when a NativeTransfer event fires.
+        let table = Table {
+            name: "balances".to_string(),
+            global: false,
+            cross_chain: false,
+            columns: vec![
+                TableColumn {
+                    name: "account".to_string(),
+                    column_type: None,
+                    nullable: false,
+                    default: None,
+                },
+                TableColumn {
+                    name: "total_sent".to_string(),
+                    column_type: None,
+                    nullable: false,
+                    default: None,
+                },
+            ],
+            events: vec![TableEventMapping {
+                event: "NativeTransfer".to_string(),
+                iterate: Vec::new(),
+                operations: vec![TableOperation {
+                    operation_type: OperationType::Upsert,
+                    where_clause: {
+                        let mut m = HashMap::new();
+                        m.insert("account".to_string(), "$from".to_string());
+                        m
+                    },
+                    if_condition: None,
+                    filter: None,
+                    set: vec![SetColumn {
+                        column: "total_sent".to_string(),
+                        action: SetAction::Add,
+                        value: Some("$value".to_string()),
+                    }],
+                }],
+            }],
+            cron: None,
+            timestamp: false,
+            database: None,
+        };
+
+        let runtime =
+            TableRuntime::new(table, "test_indexer", NATIVE_TRANSFER_CONTRACT_NAME);
+        let tables = vec![runtime];
+
+        let mut accumulator: HashMap<String, Vec<DerivedTableInfo>> = HashMap::new();
+        build_derived_tables_for_event(
+            "NativeTransfer",
+            "test_indexer",
+            NATIVE_TRANSFER_CONTRACT_NAME,
+            "anvil",
+            &tables,
+            &mut accumulator,
+        )
+        .expect("build_derived_tables_for_event should succeed");
+
+        let anvil_entries =
+            accumulator.get("anvil").expect("accumulator should contain anvil entry");
+        assert_eq!(anvil_entries.len(), 1, "one derived table expected");
+
+        let entry = &anvil_entries[0];
+        assert!(
+            entry.full_table_name.ends_with("balances"),
+            "full_table_name should end with derived table name, got: {}",
+            entry.full_table_name,
+        );
+        assert_eq!(
+            entry.rollback_ops.len(),
+            1,
+            "one rollback op expected for the upsert-with-add column",
+        );
+        let op = &entry.rollback_ops[0];
+        assert!(
+            op.event_table.contains("native_transfer"),
+            "rollback op should target the native_transfer source table, got: {}",
+            op.event_table,
+        );
+        assert!(entry.journal_columns.is_empty(), "no non-reversible columns in this fixture");
     }
 }

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -749,12 +749,11 @@ async fn start_indexing_contract_events(
                 }
             }
 
-            // Only keep coordinators for live indexing; in the historical-only pass
-            // they served their purpose (startup validation) and can be dropped.
-            if !no_live_indexing_forced {
-                network_coordinators
-                    .insert(network_name.clone(), Arc::new(Mutex::new(coordinator)));
-            }
+            // Keep the coordinator in the map so non-blocking tasks (contract events
+            // and native-transfer fetchers) can share it. Historical-only runs still
+            // work — the map is scoped to this function and dropped when it returns.
+            network_coordinators
+                .insert(network_name.clone(), Arc::new(Mutex::new(coordinator)));
         }
     }
 

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -753,10 +753,13 @@ async fn start_indexing_contract_events(
             }
 
             // Keep the coordinator in the map so non-blocking tasks (contract events
-            // and native-transfer fetchers) can share it. Historical-only runs still
-            // work — the map is scoped to this function and dropped when it returns.
-            network_coordinators
-                .insert(network_name.clone(), Arc::new(Mutex::new(coordinator)));
+            // and native-transfer fetchers) can share it during live indexing. In a
+            // pure historical pass the coordinator served its purpose (startup
+            // validation) and can be dropped.
+            if !no_live_indexing_forced {
+                network_coordinators
+                    .insert(network_name.clone(), Arc::new(Mutex::new(coordinator)));
+            }
         }
     }
 

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -302,50 +302,43 @@ async fn start_indexing_traces(
     Ok(non_blocking_process_events)
 }
 
-/// Find a provider for a network, falling back to the trace registry so that
-/// native-transfer-only networks (which have no entry in `registry.events`) still
-/// resolve to their configured provider.
-fn find_provider_for_network(
-    registry: &EventCallbackRegistry,
+/// Find a provider for a network in the trace registry. Used as a fallback when
+/// the primary lookup (either `registry.events` or `dependency_event_processing_configs`)
+/// has no entry for the network — native-transfer-only networks live only in the
+/// trace registry.
+fn find_provider_in_trace_registry(
     trace_registry: &TraceCallbackRegistry,
     network_name: &str,
 ) -> Option<Arc<dyn ChainProvider>> {
-    registry
+    trace_registry
         .events
         .iter()
-        .flat_map(|e| e.contract.details.iter())
-        .find(|nc| nc.network == network_name)
-        .map(|nc| nc.cached_provider.clone())
-        .or_else(|| {
-            trace_registry
-                .events
-                .iter()
-                .flat_map(|e| e.trace_information.details.iter())
-                .find(|nd| nd.network == network_name)
-                .map(|nd| nd.cached_provider.clone())
-        })
+        .flat_map(|e| e.trace_information.details.iter())
+        .find(|nd| nd.network == network_name)
+        .map(|nd| nd.cached_provider.clone())
 }
 
-/// Find streams clients for a network, falling back to the trace registry so that
-/// native-transfer-only networks still publish startup-rollback notifications to
-/// their configured stream.
-fn find_streams_clients_for_network(
-    registry: &EventCallbackRegistry,
+/// Find streams clients for a network in the trace registry. Used as a fallback
+/// when the primary lookup has no entry so native-transfer-only networks still
+/// publish startup-rollback notifications to their configured stream.
+fn find_streams_clients_in_trace_registry(
     trace_registry: &TraceCallbackRegistry,
     network_name: &str,
 ) -> Option<Arc<Option<crate::streams::StreamsClients>>> {
-    registry
+    trace_registry
         .events
         .iter()
-        .find(|e| e.contract.details.iter().any(|d| d.network == network_name))
+        .find(|e| e.trace_information.details.iter().any(|d| d.network == network_name))
         .map(|e| e.streams_clients.clone())
-        .or_else(|| {
-            trace_registry
-                .events
-                .iter()
-                .find(|e| e.trace_information.details.iter().any(|d| d.network == network_name))
-                .map(|e| e.streams_clients.clone())
-        })
+}
+
+/// Extract the concrete `StreamsClients` reference from the layered
+/// `Option<Arc<Option<StreamsClients>>>` wrapper that `ReorgContext.streams_clients`
+/// expects. Returns `None` if there is no outer `Arc` or if the `Arc` contains `None`.
+fn reorg_ctx_streams(
+    startup_streams_clients: &Option<Arc<Option<crate::streams::StreamsClients>>>,
+) -> Option<&crate::streams::StreamsClients> {
+    startup_streams_clients.as_ref().and_then(|a| a.as_ref().as_ref())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -635,8 +628,14 @@ async fn start_indexing_contract_events(
 
         // Get a provider for this network from any registry event targeting it.
         // Native-transfer-only networks have no entry in `registry.events`, so fall back
-        // to `trace_registry.events[].trace_information.details` for those providers.
-        let provider = find_provider_for_network(&registry, &trace_registry, network_name);
+        // to the trace registry for those providers.
+        let provider = registry
+            .events
+            .iter()
+            .flat_map(|e| e.contract.details.iter())
+            .find(|nc| &nc.network == network_name)
+            .map(|nc| nc.cached_provider.clone())
+            .or_else(|| find_provider_in_trace_registry(&trace_registry, network_name));
 
         if let Some(provider) = provider {
             let derived_tables =
@@ -653,8 +652,12 @@ async fn start_indexing_contract_events(
             // Get streams_clients for this network (if any event has one). Fall back to
             // the trace registry so native-transfer-only networks still publish
             // startup-rollback notifications to their configured stream.
-            let startup_streams_clients =
-                find_streams_clients_for_network(&registry, &trace_registry, network_name);
+            let startup_streams_clients = registry
+                .events
+                .iter()
+                .find(|e| e.contract.details.iter().any(|d| &d.network == network_name))
+                .map(|e| e.streams_clients.clone())
+                .or_else(|| find_streams_clients_in_trace_registry(&trace_registry, network_name));
 
             // Run startup validation
             match coordinator.validate_on_startup().await {
@@ -669,9 +672,7 @@ async fn start_indexing_contract_events(
                         postgres: postgres.as_deref(),
                         clickhouse: clickhouse.as_ref(),
                         registry: Some(&registry),
-                        streams_clients: startup_streams_clients
-                            .as_ref()
-                            .and_then(|a| a.as_ref().as_ref()),
+                        streams_clients: reorg_ctx_streams(&startup_streams_clients),
                     };
                     if let Err(e) = coordinator.handle_reorg(startup_task, &reorg_ctx).await {
                         error!(
@@ -936,14 +937,7 @@ async fn start_indexing_contract_events(
                     .flat_map(|dep| dep.events_config.iter())
                     .find(|e| e.network_contract().network == *network_name)
                     .map(|e| e.network_contract().cached_provider.clone())
-                    .or_else(|| {
-                        trace_registry
-                            .events
-                            .iter()
-                            .flat_map(|e| e.trace_information.details.iter())
-                            .find(|nd| nd.network == *network_name)
-                            .map(|nd| nd.cached_provider.clone())
-                    });
+                    .or_else(|| find_provider_in_trace_registry(&trace_registry, network_name));
 
                 if let Some(provider) = provider {
                     let derived_tables =
@@ -965,16 +959,7 @@ async fn start_indexing_contract_events(
                         .find(|e| e.network_contract().network == *network_name)
                         .map(|e| e.streams_clients())
                         .or_else(|| {
-                            trace_registry
-                                .events
-                                .iter()
-                                .find(|e| {
-                                    e.trace_information
-                                        .details
-                                        .iter()
-                                        .any(|d| d.network == *network_name)
-                                })
-                                .map(|e| e.streams_clients.clone())
+                            find_streams_clients_in_trace_registry(&trace_registry, network_name)
                         });
 
                     match coordinator.validate_on_startup().await {
@@ -989,9 +974,7 @@ async fn start_indexing_contract_events(
                                 postgres: postgres.as_deref(),
                                 clickhouse: clickhouse.as_ref(),
                                 registry: Some(&registry),
-                                streams_clients: dep_streams_clients
-                                    .as_ref()
-                                    .and_then(|a| a.as_ref().as_ref()),
+                                streams_clients: reorg_ctx_streams(&dep_streams_clients),
                             };
                             if let Err(e) = coordinator.handle_reorg(startup_task, &reorg_ctx).await
                             {
@@ -1625,13 +1608,14 @@ mod tests {
     #[test]
     fn provider_lookup_falls_back_to_trace_registry() {
         // Network "anvil" has no contract events but IS present as a native-transfer
-        // target. The provider lookup must resolve to the trace registry's provider.
+        // target. The trace-registry helper must resolve to the configured provider;
+        // both coordinator loops (primary + dep-events) call this helper as their
+        // fallback, so a single test covers both callsites.
         let mock_provider: Arc<dyn ChainProvider> =
             Arc::new(MockChainProvider::new(31337).with_block_number(100));
-        let empty_registry = EventCallbackRegistry::new();
         let trace_registry = trace_registry_with_network("anvil", mock_provider.clone());
 
-        let found = find_provider_for_network(&empty_registry, &trace_registry, "anvil");
+        let found = find_provider_in_trace_registry(&trace_registry, "anvil");
 
         assert!(found.is_some(), "expected provider to be found via trace registry fallback");
         // Identity check: same Arc instance (contract/trace chain provider is the same pointer).
@@ -1640,13 +1624,12 @@ mod tests {
 
     #[test]
     fn provider_lookup_returns_none_for_unknown_network() {
-        // Network "mainnet" is not present in either registry → None.
+        // Network "mainnet" is not present in the trace registry → None.
         let mock_provider: Arc<dyn ChainProvider> =
             Arc::new(MockChainProvider::new(31337).with_block_number(100));
-        let empty_registry = EventCallbackRegistry::new();
         let trace_registry = trace_registry_with_network("anvil", mock_provider);
 
-        let found = find_provider_for_network(&empty_registry, &trace_registry, "mainnet");
+        let found = find_provider_in_trace_registry(&trace_registry, "mainnet");
 
         assert!(found.is_none(), "expected no provider for unknown network");
     }
@@ -1657,14 +1640,47 @@ mod tests {
         // registry so the coordinator still fires startup-rollback notifications.
         let mock_provider: Arc<dyn ChainProvider> =
             Arc::new(MockChainProvider::new(31337).with_block_number(100));
-        let empty_registry = EventCallbackRegistry::new();
         let trace_registry = trace_registry_with_network("anvil", mock_provider);
 
-        let found = find_streams_clients_for_network(&empty_registry, &trace_registry, "anvil");
+        let found = find_streams_clients_in_trace_registry(&trace_registry, "anvil");
 
         // The fixture uses `Arc::new(None)` — we just need to confirm the fallback
         // path is exercised and returns Some(Arc<Option<...>>) instead of None.
         assert!(found.is_some(), "expected streams_clients fallback to trace registry");
         assert!(found.unwrap().is_none(), "fixture carries Arc::new(None) for streams_clients");
+    }
+
+    #[test]
+    fn dep_events_provider_fallback_uses_same_helper() {
+        // Regression test for code-review I1: both the primary and dep-events loops
+        // must resolve native-transfer-only networks via `find_provider_in_trace_registry`.
+        // With `dependency_event_processing_configs` empty (i.e. the primary `.iter()`
+        // step returns nothing for this network), the fallback must still find the
+        // trace-registry provider — i.e. the helper is a drop-in replacement for the
+        // previously-inlined `or_else(|| trace_registry.events.iter()...)` closure.
+        let mock_provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(31337).with_block_number(100));
+        let trace_registry = trace_registry_with_network("anvil", mock_provider.clone());
+
+        // Simulate the dep-events primary lookup yielding None, then the fallback.
+        let primary: Option<Arc<dyn ChainProvider>> = None;
+        let resolved = primary
+            .or_else(|| find_provider_in_trace_registry(&trace_registry, "anvil"));
+
+        assert!(resolved.is_some(), "dep-events fallback must resolve via trace registry");
+        assert!(Arc::ptr_eq(&resolved.unwrap(), &mock_provider));
+    }
+
+    #[test]
+    fn reorg_ctx_streams_unwraps_nested_option_arc() {
+        // `reorg_ctx_streams` peels the `Option<Arc<Option<StreamsClients>>>` wrapper.
+        // No StreamsClients fixture is needed — the `None` cases exercise both the
+        // outer-None and inner-None branches.
+        let none_outer: Option<Arc<Option<crate::streams::StreamsClients>>> = None;
+        assert!(reorg_ctx_streams(&none_outer).is_none());
+
+        let none_inner: Option<Arc<Option<crate::streams::StreamsClients>>> =
+            Some(Arc::new(None));
+        assert!(reorg_ctx_streams(&none_inner).is_none());
     }
 }

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -359,12 +359,7 @@ fn collect_streams_clients_for_network(
         }
     }
     for trace_event in &trace_registry.events {
-        if trace_event
-            .trace_information
-            .details
-            .iter()
-            .any(|d| d.network == network_name)
-        {
+        if trace_event.trace_information.details.iter().any(|d| d.network == network_name) {
             push(&trace_event.streams_clients);
         }
     }
@@ -459,8 +454,7 @@ fn build_derived_tables_for_event(
         }
 
         // Merge into existing entry or create a new one
-        if let Some(existing) =
-            derived.iter_mut().find(|d| d.full_table_name == tr.full_table_name)
+        if let Some(existing) = derived.iter_mut().find(|d| d.full_table_name == tr.full_table_name)
         {
             existing.rollback_ops.extend(rollback_ops);
             for jc in journal_columns {
@@ -1652,10 +1646,9 @@ mod tests {
         let noop_callback: Arc<
             dyn Fn(
                     Vec<crate::event::callback_registry::TraceResult>,
-                ) -> BoxFuture<
-                    'static,
-                    crate::event::callback_registry::EventCallbackResult<()>,
-                > + Send
+                )
+                    -> BoxFuture<'static, crate::event::callback_registry::EventCallbackResult<()>>
+                + Send
                 + Sync,
         > = Arc::new(|_| async { Ok(()) }.boxed());
 
@@ -1729,8 +1722,8 @@ mod tests {
 
         // Simulate the dep-events primary lookup yielding None, then the fallback.
         let primary: Option<Arc<dyn ChainProvider>> = None;
-        let resolved = primary
-            .or_else(|| find_provider_in_trace_registry(&trace_registry, "anvil"));
+        let resolved =
+            primary.or_else(|| find_provider_in_trace_registry(&trace_registry, "anvil"));
 
         assert!(resolved.is_some(), "dep-events fallback must resolve via trace registry");
         assert!(Arc::ptr_eq(&resolved.unwrap(), &mock_provider));
@@ -1746,13 +1739,9 @@ mod tests {
         let trace_registry = trace_registry_with_network("anvil", mock_provider);
         let registry = EventCallbackRegistry::new();
 
-        let collected =
-            collect_streams_clients_for_network(&registry, &trace_registry, "anvil");
+        let collected = collect_streams_clients_for_network(&registry, &trace_registry, "anvil");
 
-        assert!(
-            collected.is_empty(),
-            "entries with Arc::new(None) must be filtered out"
-        );
+        assert!(collected.is_empty(), "entries with Arc::new(None) must be filtered out");
     }
 
     #[test]
@@ -1764,8 +1753,7 @@ mod tests {
         let trace_registry = trace_registry_with_network("anvil", mock_provider);
         let registry = EventCallbackRegistry::new();
 
-        let collected =
-            collect_streams_clients_for_network(&registry, &trace_registry, "mainnet");
+        let collected = collect_streams_clients_for_network(&registry, &trace_registry, "mainnet");
 
         assert!(collected.is_empty(), "no entry matches network 'mainnet'");
     }
@@ -1829,8 +1817,7 @@ mod tests {
             database: None,
         };
 
-        let runtime =
-            TableRuntime::new(table, "test_indexer", NATIVE_TRANSFER_CONTRACT_NAME);
+        let runtime = TableRuntime::new(table, "test_indexer", NATIVE_TRANSFER_CONTRACT_NAME);
         let tables = vec![runtime];
 
         let mut accumulator: HashMap<String, Vec<DerivedTableInfo>> = HashMap::new();

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -4,8 +4,8 @@ use alloy::primitives::U64;
 use futures::future::try_join_all;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use tokio::sync::Mutex;
 use tokio::{
-    join,
     task::{JoinError, JoinHandle},
     time::Instant,
 };
@@ -190,6 +190,7 @@ async fn start_indexing_traces(
     trace_registry: Arc<TraceCallbackRegistry>,
     cancel_token: CancellationToken,
     progress: Arc<IndexingEventsProgressState>,
+    network_coordinators: &HashMap<String, Arc<Mutex<ReorgCoordinator>>>,
 ) -> Result<Vec<JoinHandle<Result<(), ProcessEventError>>>, StartIndexingError> {
     if !manifest.native_transfers.enabled {
         info!("Native transfer indexing disabled!");
@@ -212,6 +213,12 @@ async fn start_indexing_traces(
 
     // Create one pipeline per network
     for (network_name, events) in network_events {
+        // Pick any first event's streams_clients - they all share the same stream
+        // config for the network.
+        let streams_clients = events
+            .first()
+            .map(|e| e.streams_clients.clone())
+            .unwrap_or_else(|| Arc::new(None));
         // Get the first event's network details (they should all be the same for a given network)
         let first_event = events.first().unwrap();
         let network_details = first_event
@@ -276,6 +283,8 @@ async fn start_indexing_traces(
             cancel_token: cancel_token.clone(),
         });
 
+        let reorg_coordinator = network_coordinators.get(&network_name).cloned();
+
         let block_fetch_handle = tokio::spawn(native_transfer_block_fetch(
             network_details.cached_provider.clone(),
             block_tx,
@@ -286,6 +295,9 @@ async fn start_indexing_traces(
             cancel_token.clone(),
             postgres.clone(),
             first_event.indexer_name.clone(),
+            reorg_coordinator,
+            clickhouse.clone(),
+            streams_clients,
         ));
 
         non_blocking_process_events.push(block_fetch_handle);
@@ -360,6 +372,7 @@ async fn start_indexing_contract_events(
         Vec<ProcessedNetworkContract>,
         Vec<(String, Arc<EventProcessingConfig>)>,
         Vec<ContractEventsDependenciesConfig>,
+        HashMap<String, Arc<Mutex<ReorgCoordinator>>>,
     ),
     StartIndexingError,
 > {
@@ -601,7 +614,7 @@ async fn start_indexing_contract_events(
     // historical phase — so that stale checkpoints are corrected before events are
     // fetched.  Coordinators are only kept for live indexing; when we are in the
     // historical-only pass they are dropped after validation.
-    let mut network_coordinators: HashMap<String, ReorgCoordinator> = HashMap::new();
+    let mut network_coordinators: HashMap<String, Arc<Mutex<ReorgCoordinator>>> = HashMap::new();
     for (network_name, (reorg_config, chain_id)) in &reorg_configs {
         let window_size = reorg_config
             .window_size
@@ -693,7 +706,8 @@ async fn start_indexing_contract_events(
             // Only keep coordinators for live indexing; in the historical-only pass
             // they served their purpose (startup validation) and can be dropped.
             if !no_live_indexing_forced {
-                network_coordinators.insert(network_name.clone(), coordinator);
+                network_coordinators
+                    .insert(network_name.clone(), Arc::new(Mutex::new(coordinator)));
             }
         }
     }
@@ -857,16 +871,16 @@ async fn start_indexing_contract_events(
                 &dependencies,
             );
         } else {
-            // DESIGN: One ReorgCoordinator per network, owned by the first non-blocking event
-            // spawned on that network. The coordinator holds ALL event tables for the network,
-            // so reorg rollbacks cover every table regardless of which event task drives
-            // detection. Subsequent events on the same network receive None. This means if
-            // the owning task exits or errors, reorg detection stops for the network. A
-            // future improvement could wrap the coordinator in Arc<Mutex<>> for redundancy.
+            // DESIGN: One ReorgCoordinator per network, shared via Arc<Mutex<_>> across
+            // all tasks that can observe a new block for that network (contract-event
+            // pipelines and the native-transfer block fetcher). The coordinator holds
+            // ALL event tables for the network, so reorg rollbacks cover every table
+            // regardless of which task drives detection. The Mutex serializes
+            // `on_new_block`/`handle_reorg` calls so concurrent detection is idempotent.
             let reorg_coordinator =
                 if event_processing_config.live_indexing() && !no_live_indexing_forced {
                     let network_name = event_processing_config.network_contract().network.clone();
-                    network_coordinators.remove(&network_name)
+                    network_coordinators.get(&network_name).cloned()
                 } else {
                     None
                 };
@@ -895,10 +909,10 @@ async fn start_indexing_contract_events(
             .collect();
 
         // Build coordinators for networks that weren't already consumed
-        let mut dep_coordinators: HashMap<String, ReorgCoordinator> = HashMap::new();
+        let mut dep_coordinators: HashMap<String, Arc<Mutex<ReorgCoordinator>>> = HashMap::new();
         for network_name in &dep_networks {
-            // Try to take a leftover from the non-blocking build
-            if let Some(coord) = network_coordinators.remove(network_name) {
+            // Share the network's coordinator if one already exists
+            if let Some(coord) = network_coordinators.get(network_name).cloned() {
                 dep_coordinators.insert(network_name.clone(), coord);
                 continue;
             }
@@ -993,7 +1007,11 @@ async fn start_indexing_contract_events(
                         }
                     }
 
-                    dep_coordinators.insert(network_name.clone(), coordinator);
+                    let shared = Arc::new(Mutex::new(coordinator));
+                    dep_coordinators.insert(network_name.clone(), shared.clone());
+                    // Also share with the non-blocking network map so any native-transfer
+                    // task running on this network can reach the same coordinator.
+                    network_coordinators.insert(network_name.clone(), shared);
                 }
             }
         }
@@ -1020,6 +1038,7 @@ async fn start_indexing_contract_events(
         processed_network_contracts,
         apply_cross_contract_dependency_events_config_after_processing,
         dependency_event_processing_configs,
+        network_coordinators,
     ))
 }
 
@@ -1098,41 +1117,47 @@ async fn start_indexing(
 
     let indexer = manifest.to_indexer();
 
-    // Start the sub-indexers concurrently to ensure fast startup times
-    let (trace_indexer_handles, contract_events_indexer) = join!(
-        start_indexing_traces(
-            manifest,
-            project_path,
-            database.clone(),
-            clickhouse.clone(),
-            &indexer,
-            trace_registry.clone(),
-            cancel_token.clone(),
-            progress.clone(),
-        ),
-        start_indexing_contract_events(
-            manifest,
-            project_path,
-            database.clone(),
-            clickhouse.clone(),
-            &indexer,
-            registry.clone(),
-            trace_registry.clone(),
-            dependencies,
-            no_live_indexing_forced,
-            cancel_token.clone(),
-            progress.clone(),
-        )
-    );
+    // Contract events must complete their setup first so the per-network reorg
+    // coordinators exist before native-transfer tasks look them up. The returned
+    // `network_coordinators` map is shared (each entry is Arc<Mutex<_>>), so
+    // both pipelines observe the same coordinator for any given network.
+    let contract_events_indexer = start_indexing_contract_events(
+        manifest,
+        project_path,
+        database.clone(),
+        clickhouse.clone(),
+        &indexer,
+        registry.clone(),
+        trace_registry.clone(),
+        dependencies,
+        no_live_indexing_forced,
+        cancel_token.clone(),
+        progress.clone(),
+    )
+    .await;
 
     let (
         non_blocking_contract_handles,
         processed_network_contracts,
         apply_cross_contract_dependency_events_config_after_processing,
         mut dependency_event_processing_configs,
+        network_coordinators,
     ) = contract_events_indexer?;
 
-    non_blocking_process_events.extend(trace_indexer_handles?);
+    let trace_indexer_handles = start_indexing_traces(
+        manifest,
+        project_path,
+        database.clone(),
+        clickhouse.clone(),
+        &indexer,
+        trace_registry.clone(),
+        cancel_token.clone(),
+        progress.clone(),
+        &network_coordinators,
+    )
+    .await?;
+
+    non_blocking_process_events.extend(trace_indexer_handles);
     non_blocking_process_events.extend(non_blocking_contract_handles);
 
     // apply dependency events config after processing to avoid ordering issues

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -206,10 +206,10 @@ async fn start_indexing_traces(
     let mut non_blocking_process_events = Vec::new();
 
     // Group events by network to create one pipeline per network
-    let mut network_events: std::collections::HashMap<
+    let mut network_events: HashMap<
         String,
         Vec<&crate::event::callback_registry::TraceCallbackRegistryInformation>,
-    > = std::collections::HashMap::new();
+    > = HashMap::new();
 
     for event in trace_registry.events.iter() {
         for network in event.trace_information.details.iter() {

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -262,6 +262,7 @@ async fn start_indexing_traces(
         // Create a shared registry for this network's events
         let network_registry = Arc::new(TraceCallbackRegistry {
             events: events.iter().map(|e| (*e).clone()).collect(),
+            on_reorg: trace_registry.on_reorg.clone(),
         });
 
         let config = Arc::new(TraceProcessingConfig {
@@ -298,6 +299,7 @@ async fn start_indexing_traces(
             reorg_coordinator,
             clickhouse.clone(),
             streams_clients,
+            trace_registry.clone(),
         ));
 
         non_blocking_process_events.push(block_fetch_handle);
@@ -716,6 +718,7 @@ async fn start_indexing_contract_events(
                         postgres: postgres.as_deref(),
                         clickhouse: clickhouse.as_ref(),
                         registry: Some(&registry),
+                        trace_registry: Some(&trace_registry),
                         streams_clients: reorg_ctx_streams(&startup_streams_clients),
                     };
                     if let Err(e) = coordinator.handle_reorg(startup_task, &reorg_ctx).await {
@@ -919,6 +922,7 @@ async fn start_indexing_contract_events(
             let process_event = tokio::spawn(process_non_blocking_event(
                 event_processing_config,
                 reorg_coordinator,
+                Some(trace_registry.clone()),
             ));
             non_blocking_process_events.push(process_event);
         }
@@ -1019,6 +1023,7 @@ async fn start_indexing_contract_events(
                                 postgres: postgres.as_deref(),
                                 clickhouse: clickhouse.as_ref(),
                                 registry: Some(&registry),
+                                trace_registry: Some(&trace_registry),
                                 streams_clients: reorg_ctx_streams(&dep_streams_clients),
                             };
                             if let Err(e) = coordinator.handle_reorg(startup_task, &reorg_ctx).await
@@ -1204,6 +1209,7 @@ async fn start_indexing(
     let dependency_handle: JoinHandle<Result<(), ProcessContractsEventsWithDependenciesError>> =
         tokio::spawn(process_contracts_events_with_dependencies(
             dependency_event_processing_configs,
+            trace_registry.clone(),
         ));
 
     let mut handles: Vec<JoinHandle<Result<(), CombinedLogEventProcessingError>>> = Vec::new();
@@ -1659,7 +1665,7 @@ mod tests {
             streams_clients: Arc::new(None),
         };
 
-        TraceCallbackRegistry { events: vec![info] }
+        TraceCallbackRegistry { events: vec![info], on_reorg: vec![] }
     }
 
     #[test]

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -198,8 +198,12 @@ async fn start_indexing_traces(
         return Ok(vec![]);
     }
 
-    if no_live_indexing_forced {
-        info!("Native transfer indexing skipped in historical-only pass (no end_block semantic)");
+    // Historical pass defers to the live pass to avoid double-spawning the NT
+    // pipeline. But when no live pass will follow (e.g. every contract and NT
+    // network has an end_block), this IS NT's only chance to run — so fall
+    // through and spawn it here.
+    if no_live_indexing_forced && manifest.has_any_live_indexing() {
+        info!("Native transfer indexing deferred to live pass to prevent double-spawn");
         return Ok(vec![]);
     }
 

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -585,10 +585,16 @@ async fn start_indexing_contract_events(
                 generate_indexer_contract_schema_name(&event.indexer_name, &event.contract.name);
             let table_name = camel_to_snake(&event.event_name);
             let checkpoint_table = generate_internal_event_table_name(&schema, &event.event_name);
-            network_event_tables
-                .entry(network_contract.network.clone())
-                .or_default()
-                .push(EventTableInfo::try_new(schema, table_name, checkpoint_table)?);
+            network_event_tables.entry(network_contract.network.clone()).or_default().push(
+                EventTableInfo::try_new(
+                    schema,
+                    table_name,
+                    checkpoint_table,
+                    event.indexer_name.clone(),
+                    event.contract.name.clone(),
+                    event.event_name.clone(),
+                )?,
+            );
 
             build_derived_tables_for_event(
                 &event.event_name,
@@ -613,10 +619,16 @@ async fn start_indexing_contract_events(
                 let table_name = camel_to_snake("NativeTransfer");
                 let checkpoint_table =
                     generate_internal_event_table_name(&schema, "NativeTransfer");
-                network_event_tables
-                    .entry(nt_detail.network.clone())
-                    .or_default()
-                    .push(EventTableInfo::try_new(schema, table_name, checkpoint_table)?);
+                network_event_tables.entry(nt_detail.network.clone()).or_default().push(
+                    EventTableInfo::try_new(
+                        schema,
+                        table_name,
+                        checkpoint_table,
+                        manifest.name.clone(),
+                        NATIVE_TRANSFER_CONTRACT_NAME.to_string(),
+                        "NativeTransfer".to_string(),
+                    )?,
+                );
             }
         }
 

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -213,12 +213,6 @@ async fn start_indexing_traces(
 
     // Create one pipeline per network
     for (network_name, events) in network_events {
-        // Pick any first event's streams_clients - they all share the same stream
-        // config for the network.
-        let streams_clients = events
-            .first()
-            .map(|e| e.streams_clients.clone())
-            .unwrap_or_else(|| Arc::new(None));
         // Get the first event's network details (they should all be the same for a given network)
         let first_event = events.first().unwrap();
         let network_details = first_event
@@ -298,7 +292,6 @@ async fn start_indexing_traces(
             first_event.indexer_name.clone(),
             reorg_coordinator,
             clickhouse.clone(),
-            streams_clients,
             trace_registry.clone(),
         ));
 
@@ -332,27 +325,45 @@ fn find_provider_in_trace_registry(
         .map(|nd| nd.cached_provider.clone())
 }
 
-/// Find streams clients for a network in the trace registry. Used as a fallback
-/// when the primary lookup has no entry so native-transfer-only networks still
-/// publish startup-rollback notifications to their configured stream.
-fn find_streams_clients_in_trace_registry(
+/// Collect every distinct `Arc<Option<StreamsClients>>` configured on the given
+/// network across contract events and native-transfer trace events. Dedup is
+/// by `Arc::as_ptr` pointer identity so two pipelines sharing the same instance
+/// only publish once. Entries whose inner `Option` is `None` are skipped.
+fn collect_streams_clients_for_network(
+    registry: &EventCallbackRegistry,
     trace_registry: &TraceCallbackRegistry,
     network_name: &str,
-) -> Option<Arc<Option<crate::streams::StreamsClients>>> {
-    trace_registry
-        .events
-        .iter()
-        .find(|e| e.trace_information.details.iter().any(|d| d.network == network_name))
-        .map(|e| e.streams_clients.clone())
-}
+) -> Vec<Arc<Option<crate::streams::StreamsClients>>> {
+    let mut out: Vec<Arc<Option<crate::streams::StreamsClients>>> = Vec::new();
 
-/// Extract the concrete `StreamsClients` reference from the layered
-/// `Option<Arc<Option<StreamsClients>>>` wrapper that `ReorgContext.streams_clients`
-/// expects. Returns `None` if there is no outer `Arc` or if the `Arc` contains `None`.
-fn reorg_ctx_streams(
-    startup_streams_clients: &Option<Arc<Option<crate::streams::StreamsClients>>>,
-) -> Option<&crate::streams::StreamsClients> {
-    startup_streams_clients.as_ref().and_then(|a| a.as_ref().as_ref())
+    let mut push = |arc_outer: &Arc<Option<crate::streams::StreamsClients>>| {
+        if arc_outer.as_ref().is_none() {
+            return;
+        }
+        let ptr = Arc::as_ptr(arc_outer);
+        if out.iter().any(|existing| Arc::as_ptr(existing) == ptr) {
+            return;
+        }
+        out.push(Arc::clone(arc_outer));
+    };
+
+    for event in &registry.events {
+        if event.contract.details.iter().any(|d| d.network == network_name) {
+            push(&event.streams_clients);
+        }
+    }
+    for trace_event in &trace_registry.events {
+        if trace_event
+            .trace_information
+            .details
+            .iter()
+            .any(|d| d.network == network_name)
+        {
+            push(&trace_event.streams_clients);
+        }
+    }
+
+    out
 }
 
 /// Build derived-table rollback + journal entries for an event's tables and merge
@@ -698,6 +709,8 @@ async fn start_indexing_contract_events(
         if let Some(provider) = provider {
             let derived_tables =
                 network_derived_tables.get(network_name).cloned().unwrap_or_default();
+            let streams_clients =
+                collect_streams_clients_for_network(&registry, &trace_registry, network_name);
             let mut coordinator = ReorgCoordinator::new(
                 network_name.clone(),
                 window,
@@ -705,17 +718,8 @@ async fn start_indexing_contract_events(
                 provider,
                 event_tables,
                 derived_tables,
+                streams_clients,
             )?;
-
-            // Get streams_clients for this network (if any event has one). Fall back to
-            // the trace registry so native-transfer-only networks still publish
-            // startup-rollback notifications to their configured stream.
-            let startup_streams_clients = registry
-                .events
-                .iter()
-                .find(|e| e.contract.details.iter().any(|d| &d.network == network_name))
-                .map(|e| e.streams_clients.clone())
-                .or_else(|| find_streams_clients_in_trace_registry(&trace_registry, network_name));
 
             // Run startup validation
             match coordinator.validate_on_startup().await {
@@ -731,7 +735,6 @@ async fn start_indexing_contract_events(
                         clickhouse: clickhouse.as_ref(),
                         registry: Some(&registry),
                         trace_registry: Some(&trace_registry),
-                        streams_clients: reorg_ctx_streams(&startup_streams_clients),
                     };
                     if let Err(e) = coordinator.handle_reorg(startup_task, &reorg_ctx).await {
                         error!(
@@ -1002,6 +1005,11 @@ async fn start_indexing_contract_events(
                 if let Some(provider) = provider {
                     let derived_tables =
                         network_derived_tables.get(network_name).cloned().unwrap_or_default();
+                    let streams_clients = collect_streams_clients_for_network(
+                        &registry,
+                        &trace_registry,
+                        network_name,
+                    );
                     let mut coordinator = ReorgCoordinator::new(
                         network_name.clone(),
                         window,
@@ -1009,18 +1017,8 @@ async fn start_indexing_contract_events(
                         provider,
                         event_tables,
                         derived_tables,
+                        streams_clients,
                     )?;
-
-                    // Get streams_clients for this network from dependency events, with a
-                    // fall back to the trace registry for native-transfer-only networks.
-                    let dep_streams_clients = dependency_event_processing_configs
-                        .iter()
-                        .flat_map(|dep| dep.events_config.iter())
-                        .find(|e| e.network_contract().network == *network_name)
-                        .map(|e| e.streams_clients())
-                        .or_else(|| {
-                            find_streams_clients_in_trace_registry(&trace_registry, network_name)
-                        });
 
                     match coordinator.validate_on_startup().await {
                         Ok(Some(startup_task)) => {
@@ -1035,7 +1033,6 @@ async fn start_indexing_contract_events(
                                 clickhouse: clickhouse.as_ref(),
                                 registry: Some(&registry),
                                 trace_registry: Some(&trace_registry),
-                                streams_clients: reorg_ctx_streams(&dep_streams_clients),
                             };
                             if let Err(e) = coordinator.handle_reorg(startup_task, &reorg_ctx).await
                             {
@@ -1631,7 +1628,7 @@ mod tests {
     // native-transfer-only networks (Task 1, Step 2 verification).
 
     use crate::event::callback_registry::{
-        TraceCallbackRegistry, TraceCallbackRegistryInformation,
+        EventCallbackRegistry, TraceCallbackRegistry, TraceCallbackRegistryInformation,
     };
     use crate::event::contract_setup::{NetworkTrace, TraceInformation};
     use crate::manifest::native_transfer::TraceProcessingMethod;
@@ -1709,22 +1706,6 @@ mod tests {
     }
 
     #[test]
-    fn streams_clients_lookup_falls_back_to_trace_registry() {
-        // Native-transfer-only network: streams_clients must fall back to the trace
-        // registry so the coordinator still fires startup-rollback notifications.
-        let mock_provider: Arc<dyn ChainProvider> =
-            Arc::new(MockChainProvider::new(31337).with_block_number(100));
-        let trace_registry = trace_registry_with_network("anvil", mock_provider);
-
-        let found = find_streams_clients_in_trace_registry(&trace_registry, "anvil");
-
-        // The fixture uses `Arc::new(None)` — we just need to confirm the fallback
-        // path is exercised and returns Some(Arc<Option<...>>) instead of None.
-        assert!(found.is_some(), "expected streams_clients fallback to trace registry");
-        assert!(found.unwrap().is_none(), "fixture carries Arc::new(None) for streams_clients");
-    }
-
-    #[test]
     fn dep_events_provider_fallback_uses_same_helper() {
         // Regression test for code-review I1: both the primary and dep-events loops
         // must resolve native-transfer-only networks via `find_provider_in_trace_registry`.
@@ -1746,16 +1727,37 @@ mod tests {
     }
 
     #[test]
-    fn reorg_ctx_streams_unwraps_nested_option_arc() {
-        // `reorg_ctx_streams` peels the `Option<Arc<Option<StreamsClients>>>` wrapper.
-        // No StreamsClients fixture is needed — the `None` cases exercise both the
-        // outer-None and inner-None branches.
-        let none_outer: Option<Arc<Option<crate::streams::StreamsClients>>> = None;
-        assert!(reorg_ctx_streams(&none_outer).is_none());
+    fn collect_streams_clients_filters_none_entries() {
+        // The trace-registry fixture uses `Arc::new(None)` for `streams_clients`.
+        // `collect_streams_clients_for_network` must skip entries whose inner
+        // Option is None so the coordinator never iterates an absent client.
+        let mock_provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(31337).with_block_number(100));
+        let trace_registry = trace_registry_with_network("anvil", mock_provider);
+        let registry = EventCallbackRegistry::new();
 
-        let none_inner: Option<Arc<Option<crate::streams::StreamsClients>>> =
-            Some(Arc::new(None));
-        assert!(reorg_ctx_streams(&none_inner).is_none());
+        let collected =
+            collect_streams_clients_for_network(&registry, &trace_registry, "anvil");
+
+        assert!(
+            collected.is_empty(),
+            "entries with Arc::new(None) must be filtered out"
+        );
+    }
+
+    #[test]
+    fn collect_streams_clients_skips_other_networks() {
+        // An event on a different network must not appear in the collected
+        // vector — the network filter is strict.
+        let mock_provider: Arc<dyn ChainProvider> =
+            Arc::new(MockChainProvider::new(31337).with_block_number(100));
+        let trace_registry = trace_registry_with_network("anvil", mock_provider);
+        let registry = EventCallbackRegistry::new();
+
+        let collected =
+            collect_streams_clients_for_network(&registry, &trace_registry, "mainnet");
+
+        assert!(collected.is_empty(), "no entry matches network 'mainnet'");
     }
 
     // --- Derived-table rollback build tests ---

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -208,14 +208,9 @@ impl ProgressCheckpointConfig {
                 "UPDATE rindexer_internal.{table_name} SET last_synced_block = {block_number} WHERE network = '{network}' AND {block_number} > last_synced_block"
             );
             if let Err(e) = postgres.batch_execute(&query).await {
-                tracing::warn!("Failed to checkpoint progress at block {}: {:?}", block_number, e);
+                warn!("Failed to checkpoint progress at block {}: {:?}", block_number, e);
             } else {
-                tracing::info!(
-                    "Checkpointed {}::{} at block {}",
-                    self.event_name,
-                    network,
-                    block_number
-                );
+                info!("Checkpointed {}::{} at block {}", self.event_name, network, block_number);
             }
         }
     }
@@ -363,19 +358,16 @@ async fn get_events_processed(event_name: &str, network: &str) -> usize {
 const DEFAULT_MAX_CONCURRENT_VIEW_CALLS: usize = 10;
 
 /// Semaphore to limit concurrent individual view calls.
-static VIEW_CALL_SEMAPHORE: Lazy<RwLock<std::sync::Arc<tokio::sync::Semaphore>>> =
-    Lazy::new(|| {
-        RwLock::new(std::sync::Arc::new(tokio::sync::Semaphore::new(
-            DEFAULT_MAX_CONCURRENT_VIEW_CALLS,
-        )))
-    });
+static VIEW_CALL_SEMAPHORE: Lazy<RwLock<Arc<tokio::sync::Semaphore>>> = Lazy::new(|| {
+    RwLock::new(Arc::new(tokio::sync::Semaphore::new(DEFAULT_MAX_CONCURRENT_VIEW_CALLS)))
+});
 
 /// Configure the maximum number of concurrent view calls.
 /// Should be called once at startup before any view calls are made.
 /// If not called, defaults to 10 concurrent calls.
 pub async fn configure_view_call_limit(limit: usize) {
     let mut semaphore = VIEW_CALL_SEMAPHORE.write().await;
-    *semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(limit));
+    *semaphore = Arc::new(tokio::sync::Semaphore::new(limit));
     info!("View call concurrency limit set to {}", limit);
 }
 
@@ -425,9 +417,9 @@ async fn prefetch_view_calls(
     tables: &[TableRuntime],
     event_name: &str,
     events_data: &[(Vec<LogParam>, String, TxMetadata)],
-    providers: &std::collections::HashMap<String, Arc<dyn ChainProvider>>,
+    providers: &HashMap<String, Arc<dyn ChainProvider>>,
     constants: &Constants,
-    multicall_addresses: &std::collections::HashMap<String, Option<String>>,
+    multicall_addresses: &HashMap<String, Option<String>>,
 ) {
     use std::collections::HashSet;
 
@@ -615,8 +607,7 @@ async fn prefetch_view_calls(
     let networks_without_multicall = NETWORKS_WITHOUT_MULTICALL3.read().await;
 
     // Group calls by (network, block_number) for batching
-    let mut grouped: std::collections::HashMap<(String, u64), Vec<PendingViewCall>> =
-        std::collections::HashMap::new();
+    let mut grouped: HashMap<(String, u64), Vec<PendingViewCall>> = HashMap::new();
     for call in &pending_calls {
         grouped.entry((call.network.clone(), call.block_number)).or_default().push(call.clone());
     }
@@ -837,8 +828,8 @@ async fn prefetch_view_calls(
 /// Results are stored in STATIC_CALL_CACHE.
 async fn prefetch_static_calls_via_multicall(
     pending_calls: Vec<PendingViewCall>,
-    providers: &std::collections::HashMap<String, Arc<dyn ChainProvider>>,
-    multicall_addresses: &std::collections::HashMap<String, Option<String>>,
+    providers: &HashMap<String, Arc<dyn ChainProvider>>,
+    multicall_addresses: &HashMap<String, Option<String>>,
 ) {
     if pending_calls.is_empty() {
         return;
@@ -848,8 +839,7 @@ async fn prefetch_static_calls_via_multicall(
     let networks_without_multicall = NETWORKS_WITHOUT_MULTICALL3.read().await;
 
     // Group ALL calls by network only (not by block - static calls use latest)
-    let mut grouped: std::collections::HashMap<String, Vec<PendingViewCall>> =
-        std::collections::HashMap::new();
+    let mut grouped: HashMap<String, Vec<PendingViewCall>> = HashMap::new();
     for call in pending_calls {
         grouped.entry(call.network.clone()).or_default().push(call);
     }
@@ -1254,7 +1244,7 @@ async fn execute_multicall3_batch(
 /// Results are stored in the global BLOCK_TIMESTAMP_CACHE.
 async fn prefetch_block_timestamps(
     events_data: &[(Vec<LogParam>, String, TxMetadata)],
-    providers: &std::collections::HashMap<String, Arc<dyn ChainProvider>>,
+    providers: &HashMap<String, Arc<dyn ChainProvider>>,
     needs_timestamp: bool,
 ) {
     if !needs_timestamp {
@@ -2327,10 +2317,7 @@ async fn resolve_calls_in_arithmetic_expression(
             DynSolValue::Int(val, _) => val.to_string(),
             DynSolValue::Bool(b) => if b { "1" } else { "0" }.to_string(),
             _ => {
-                tracing::warn!(
-                    "View call in arithmetic returned non-numeric value: {:?}",
-                    call_result
-                );
+                warn!("View call in arithmetic returned non-numeric value: {:?}", call_result);
                 return None;
             }
         };
@@ -2644,10 +2631,9 @@ async fn extract_value_from_event_async(
             },
             Ok(ComputedValue::String(s)) => Some(EthereumSqlTypeWrapper::String(s)),
             Err(e) => {
-                tracing::debug!(
+                debug!(
                     "Arithmetic expression with calls evaluation failed: {}. Expression: {}",
-                    e,
-                    resolved_expr
+                    e, resolved_expr
                 );
                 None
             }
@@ -2679,11 +2665,10 @@ async fn extract_value_from_event_async(
                 _ => EthereumSqlTypeWrapper::U256Numeric(U256::from(epoch)),
             });
         }
-        tracing::warn!(
+        warn!(
             "block_timestamp unavailable for block {} on {} — RPC may not include \
              blockTimestamp in eth_getLogs and BlockClock cache miss",
-            tx_metadata.block_number,
-            network,
+            tx_metadata.block_number, network,
         );
     }
 
@@ -2871,40 +2856,30 @@ fn extract_value_from_event(
 
     // Check for conditional expression: $if(condition, trueValue, falseValue)
     if is_conditional_value(value_ref) {
-        match parse_conditional_value(value_ref) {
+        return match parse_conditional_value(value_ref) {
             Ok((condition, true_value, false_value)) => {
                 // Evaluate the condition against event data
                 let json_data = log_params_to_json(log_params);
                 match filter_by_expression(&condition, &json_data) {
                     Ok(true) => {
                         // Condition is true, evaluate true_value
-                        return extract_value_from_event(
-                            &true_value,
-                            log_params,
-                            tx_metadata,
-                            column_type,
-                        );
+                        extract_value_from_event(&true_value, log_params, tx_metadata, column_type)
                     }
                     Ok(false) => {
                         // Condition is false, evaluate false_value
-                        return extract_value_from_event(
-                            &false_value,
-                            log_params,
-                            tx_metadata,
-                            column_type,
-                        );
+                        extract_value_from_event(&false_value, log_params, tx_metadata, column_type)
                     }
                     Err(e) => {
                         debug!("$if condition evaluation failed: {}. Condition: {}", e, condition);
-                        return None;
+                        None
                     }
                 }
             }
             Err(e) => {
                 debug!("Failed to parse $if expression: {}. Expression: {}", e, value_ref);
-                return None;
+                None
             }
-        }
+        };
     }
 
     // Check for arithmetic expression first (e.g., "$value * 2", "$amount + $fee")
@@ -3051,11 +3026,9 @@ fn dyn_sol_value_to_wrapper(
         }
         (DynSolValue::FixedBytes(bytes, _), ColumnType::Bytes32) => {
             if bytes.len() == 32 {
-                EthereumSqlTypeWrapper::B256(alloy::primitives::B256::from_slice(bytes.as_slice()))
+                EthereumSqlTypeWrapper::B256(B256::from_slice(bytes.as_slice()))
             } else {
-                EthereumSqlTypeWrapper::Bytes(alloy::primitives::Bytes::copy_from_slice(
-                    bytes.as_slice(),
-                ))
+                EthereumSqlTypeWrapper::Bytes(Bytes::copy_from_slice(bytes.as_slice()))
             }
         }
         (DynSolValue::Uint(val, _), ColumnType::Timestamp) => {
@@ -3233,7 +3206,7 @@ fn literal_to_wrapper(value: &str, column_type: &ColumnType) -> EthereumSqlTypeW
             }
         }
         ColumnType::Uint128 | ColumnType::Uint256 => {
-            if let Ok(num) = value.parse::<alloy::primitives::U256>() {
+            if let Ok(num) = value.parse::<U256>() {
                 EthereumSqlTypeWrapper::U256Numeric(num)
             } else {
                 EthereumSqlTypeWrapper::String(value.to_string())
@@ -3282,21 +3255,21 @@ fn literal_to_wrapper(value: &str, column_type: &ColumnType) -> EthereumSqlTypeW
             EthereumSqlTypeWrapper::Bool(b)
         }
         ColumnType::Address => {
-            if let Ok(addr) = value.parse::<alloy::primitives::Address>() {
+            if let Ok(addr) = value.parse::<Address>() {
                 EthereumSqlTypeWrapper::Address(addr)
             } else {
                 EthereumSqlTypeWrapper::String(value.to_string())
             }
         }
         ColumnType::Bytes => {
-            if let Ok(bytes) = value.parse::<alloy::primitives::Bytes>() {
+            if let Ok(bytes) = value.parse::<Bytes>() {
                 EthereumSqlTypeWrapper::Bytes(bytes)
             } else {
                 EthereumSqlTypeWrapper::String(value.to_string())
             }
         }
         ColumnType::Bytes32 => {
-            if let Ok(bytes) = value.parse::<alloy::primitives::B256>() {
+            if let Ok(bytes) = value.parse::<B256>() {
                 EthereumSqlTypeWrapper::B256(bytes)
             } else {
                 EthereumSqlTypeWrapper::String(value.to_string())
@@ -3499,9 +3472,9 @@ pub async fn process_table_operations(
     events_data: &[(Vec<LogParam>, String, TxMetadata)], // (log_params, network, tx_metadata)
     postgres: Option<Arc<PostgresClient>>,
     clickhouse: Option<Arc<ClickhouseClient>>,
-    providers: Arc<std::collections::HashMap<String, Arc<dyn crate::provider::ChainProvider>>>,
+    providers: Arc<HashMap<String, Arc<dyn ChainProvider>>>,
     constants: &Constants,
-    multicall_addresses: &std::collections::HashMap<String, Option<String>>,
+    multicall_addresses: &HashMap<String, Option<String>>,
     checkpoint_config: Option<&ProgressCheckpointConfig>,
 ) -> Result<(), String> {
     // Exit early if shutdown requested before we start - no progress to save
@@ -4452,15 +4425,15 @@ fn resolve_cron_arg_value(
     expected_type: &DynSolType,
 ) -> Option<DynSolValue> {
     if let Some(field_name) = arg_str.strip_prefix('$') {
-        match field_name {
+        return match field_name {
             "contract" | "rindexer_contract_address" => {
-                return Some(DynSolValue::Address(*contract_address));
+                Some(DynSolValue::Address(*contract_address))
             }
             _ => {
                 warn!("Unknown cron argument reference: {}", arg_str);
-                return None;
+                None
             }
-        }
+        };
     }
 
     // Parse literal value
@@ -4679,10 +4652,7 @@ mod tests {
 
     #[test]
     fn test_evaluate_filter_equals() {
-        let params = vec![LogParam::new(
-            "from".to_string(),
-            DynSolValue::Address(alloy::primitives::Address::ZERO),
-        )];
+        let params = vec![LogParam::new("from".to_string(), DynSolValue::Address(Address::ZERO))];
 
         assert!(evaluate_filter(
             "from == 0x0000000000000000000000000000000000000000",
@@ -4698,10 +4668,7 @@ mod tests {
 
     #[test]
     fn test_evaluate_filter_not_equals() {
-        let params = vec![LogParam::new(
-            "to".to_string(),
-            DynSolValue::Address(alloy::primitives::Address::ZERO),
-        )];
+        let params = vec![LogParam::new("to".to_string(), DynSolValue::Address(Address::ZERO))];
 
         assert!(!evaluate_filter(
             "to != 0x0000000000000000000000000000000000000000",
@@ -4714,10 +4681,7 @@ mod tests {
     #[test]
     fn test_evaluate_filter_complex() {
         let params = vec![
-            LogParam::new(
-                "from".to_string(),
-                DynSolValue::Address(alloy::primitives::Address::ZERO),
-            ),
+            LogParam::new("from".to_string(), DynSolValue::Address(Address::ZERO)),
             LogParam::new("value".to_string(), DynSolValue::Uint(U256::from(1000u64), 256)),
         ];
 
@@ -4752,9 +4716,9 @@ mod tests {
         let meta = TxMetadata {
             block_number: 80114147,
             block_timestamp: Some(U256::from(1700000000u64)),
-            tx_hash: alloy::primitives::B256::ZERO,
-            block_hash: alloy::primitives::B256::ZERO,
-            contract_address: alloy::primitives::Address::ZERO,
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
             log_index: U256::from(5u64),
             tx_index: 3,
         };
@@ -4771,9 +4735,9 @@ mod tests {
         let meta = TxMetadata {
             block_number: 100,
             block_timestamp: None,
-            tx_hash: alloy::primitives::B256::ZERO,
-            block_hash: alloy::primitives::B256::ZERO,
-            contract_address: alloy::primitives::Address::ZERO,
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
             log_index: U256::from(5u64),
             tx_index: 3,
         };
@@ -4793,9 +4757,9 @@ mod tests {
         let meta = TxMetadata {
             block_number: 80114147,
             block_timestamp: None,
-            tx_hash: alloy::primitives::B256::ZERO,
-            block_hash: alloy::primitives::B256::ZERO,
-            contract_address: alloy::primitives::Address::ZERO,
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
             log_index: U256::from(0u64),
             tx_index: 0,
         };
@@ -5090,7 +5054,7 @@ mod tests {
         let result = try_decode_return_value(&uint_bytes);
         assert!(result.is_some());
         if let Some(DynSolValue::Uint(val, 256)) = result {
-            assert_eq!(val, alloy::primitives::U256::from(42));
+            assert_eq!(val, U256::from(42));
         } else {
             panic!("Expected Uint(256)");
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,6 +61,7 @@ pub mod phantom;
 pub mod provider;
 mod start;
 mod streams;
+pub use streams::StreamsClients;
 mod types;
 
 mod events;

--- a/core/src/manifest/contract.rs
+++ b/core/src/manifest/contract.rs
@@ -470,7 +470,7 @@ impl Table {
     /// Ok(()) if all `$null` usages are valid, Err with description otherwise.
     pub fn validate_null_values(&self) -> Result<(), String> {
         // Build a set of nullable column names for quick lookup
-        let nullable_columns: std::collections::HashSet<&str> =
+        let nullable_columns: HashSet<&str> =
             self.columns.iter().filter(|c| c.nullable).map(|c| c.name.as_str()).collect();
 
         // Check all operations for $null values
@@ -515,7 +515,7 @@ impl Table {
     /// Ok(()) if all required columns are set, Err with description otherwise.
     pub fn validate_required_columns(&self) -> Result<(), String> {
         // Auto-generated columns that don't need to be set
-        let auto_columns: std::collections::HashSet<&str> = [
+        let auto_columns: HashSet<&str> = [
             "rindexer_sequence_id",
             "network",
             "rindexer_block_number",
@@ -530,7 +530,7 @@ impl Table {
         .collect();
 
         // Columns that have defaults or are nullable don't need to be set
-        let optional_columns: std::collections::HashSet<&str> = self
+        let optional_columns: HashSet<&str> = self
             .columns
             .iter()
             .filter(|c| c.nullable || c.default.is_some())
@@ -541,7 +541,7 @@ impl Table {
         for event_mapping in &self.events {
             for operation in &event_mapping.operations {
                 if operation.operation_type == OperationType::Insert {
-                    let set_columns: std::collections::HashSet<&str> =
+                    let set_columns: HashSet<&str> =
                         operation.set.iter().map(|s| s.column.as_str()).collect();
 
                     for column in &self.columns {
@@ -766,7 +766,7 @@ impl<'de> serde::Deserialize<'de> for ColumnType {
     where
         D: serde::Deserializer<'de>,
     {
-        let s = std::string::String::deserialize(deserializer)?;
+        let s = String::deserialize(deserializer)?;
         ColumnType::from_type_string(&s)
             .ok_or_else(|| serde::de::Error::custom(format!("Unknown column type: {}", s)))
     }
@@ -1453,7 +1453,7 @@ impl Contract {
                 tables
                     .iter()
                     .flat_map(|table| table.events.iter().map(|e| e.event.clone()))
-                    .collect::<std::collections::HashSet<_>>()
+                    .collect::<HashSet<_>>()
                     .into_iter()
                     .collect()
             })

--- a/core/src/manifest/core.rs
+++ b/core/src/manifest/core.rs
@@ -263,6 +263,25 @@ impl Manifest {
         self.all_contracts().iter().any(|c| c.details.iter().any(|p| p.end_block.is_none()))
     }
 
+    /// Returns true if any contract OR native-transfer network is configured
+    /// for live indexing (i.e., has `end_block` unset). Native-transfer-only
+    /// networks still need the live-indexing path — contracts alone don't
+    /// fully describe the run.
+    pub fn has_any_live_indexing(&self) -> bool {
+        if self.has_any_contracts_live_indexing() {
+            return true;
+        }
+        if !self.native_transfers.enabled {
+            return false;
+        }
+        match self.native_transfers.networks.as_ref() {
+            Some(networks) => networks.iter().any(|n| n.end_block.is_none()),
+            // `None` means "all supported networks" per the NT manifest
+            // semantics (see `set_native_transfer_networks`) — live by default.
+            None => true,
+        }
+    }
+
     /// Check if the manifest has opted-in to indexing native transfers. It is off by default.
     pub fn has_enabled_native_transfers(&self) -> bool {
         self.native_transfers.enabled
@@ -509,5 +528,137 @@ mod tests {
 
         let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(manifest.timestamps, Some(true));
+    }
+
+    // ======================================================================
+    // Manifest::has_any_live_indexing — contracts + native-transfer recognition
+    // ======================================================================
+
+    #[test]
+    fn has_any_live_indexing_empty_manifest() {
+        let yaml = r#"
+        name: test
+        project_type: no-code
+        networks: []
+        contracts: []
+        "#;
+        let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(!manifest.has_any_live_indexing());
+    }
+
+    #[test]
+    fn has_any_live_indexing_contract_without_end_block() {
+        let yaml = r#"
+        name: test
+        project_type: no-code
+        networks:
+          - name: ethereum
+            chain_id: 1
+            rpc: http://localhost:8545
+        contracts:
+          - name: C
+            details:
+              - network: ethereum
+                address: "0x0000000000000000000000000000000000000000"
+                start_block: 1
+            abi: "[]"
+            include_events:
+              - Transfer
+        "#;
+        let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(manifest.has_any_live_indexing());
+    }
+
+    #[test]
+    fn has_any_live_indexing_contract_with_end_block_nt_disabled() {
+        let yaml = r#"
+        name: test
+        project_type: no-code
+        networks:
+          - name: ethereum
+            chain_id: 1
+            rpc: http://localhost:8545
+        contracts:
+          - name: C
+            details:
+              - network: ethereum
+                address: "0x0000000000000000000000000000000000000000"
+                start_block: 1
+                end_block: 100
+            abi: "[]"
+            include_events:
+              - Transfer
+        "#;
+        let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(!manifest.has_any_live_indexing());
+    }
+
+    #[test]
+    fn has_any_live_indexing_nt_enabled_with_live_network() {
+        let yaml = r#"
+        name: test
+        project_type: no-code
+        networks: []
+        contracts: []
+        native_transfers:
+          networks:
+            - network: ethereum
+              start_block: 1
+              end_block: 100
+            - network: base
+              start_block: 1
+        "#;
+        let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
+        // `base` has no end_block → live.
+        assert!(manifest.has_any_live_indexing());
+    }
+
+    #[test]
+    fn has_any_live_indexing_nt_enabled_all_historical() {
+        let yaml = r#"
+        name: test
+        project_type: no-code
+        networks: []
+        contracts: []
+        native_transfers:
+          networks:
+            - network: ethereum
+              start_block: 1
+              end_block: 100
+        "#;
+        let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(!manifest.has_any_live_indexing());
+    }
+
+    #[test]
+    fn has_any_live_indexing_nt_enabled_no_networks_means_all() {
+        // NT enabled with no explicit networks means "all supported networks"
+        // per the native_transfers semantics — always live.
+        let yaml = r#"
+        name: test
+        project_type: no-code
+        networks: []
+        contracts: []
+        native_transfers: true
+        "#;
+        let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(manifest.has_any_live_indexing());
+    }
+
+    #[test]
+    fn has_any_live_indexing_nt_disabled_even_with_populated_networks() {
+        // Enabled is the gate — if NT is off, populated networks are ignored.
+        let yaml = r#"
+        name: test
+        project_type: no-code
+        networks: []
+        contracts: []
+        native_transfers:
+          enabled: false
+          networks:
+            - network: ethereum
+        "#;
+        let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
+        assert!(!manifest.has_any_live_indexing());
     }
 }

--- a/core/src/manifest/native_transfer.rs
+++ b/core/src/manifest/native_transfer.rs
@@ -4,7 +4,7 @@ use alloy::primitives::U64;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::core::serialize_option_u64_as_string;
-use crate::manifest::{chat::ChatConfig, stream::StreamsConfig};
+use crate::manifest::{chat::ChatConfig, contract::Table, stream::StreamsConfig};
 
 #[derive(Serialize, Deserialize)]
 #[serde(untagged)]
@@ -96,6 +96,11 @@ pub struct NativeTransfers {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reorg_safe_distance: Option<super::contract::ReorgSafeDistance>,
+
+    /// Optional derived/custom tables populated from native-transfer events.
+    /// Mirrors `Contract.tables`; allows reorg rollback to target NT-sourced tables.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tables: Option<Vec<Table>>,
 }
 
 /// The config to enable native transfers. This can be either a "simple" opinionated enable-all, or
@@ -128,6 +133,7 @@ where
             chat: None,
             generate_csv: None,
             reorg_safe_distance: None,
+            tables: None,
         },
         NativeTransferFullOrSimple::Full(transfers) => transfers,
     };

--- a/core/src/manifest/yaml.rs
+++ b/core/src/manifest/yaml.rs
@@ -164,7 +164,7 @@ fn is_event_field_reference_for_cron(value: &str) -> Option<String> {
 }
 
 fn substitute_env_variables(contents: &str) -> Result<String, regex::Error> {
-    let re = Regex::new(r"\$\{([^}]+)\}")?;
+    let re = Regex::new(r"\$\{([^}]+)}")?;
     let result = re.replace_all(contents, |caps: &Captures| {
         let var_name = &caps[1];
         match env::var(var_name) {
@@ -420,7 +420,7 @@ fn validate_manifest(
                 }
 
                 // Collect table column names for validation
-                let table_column_names: std::collections::HashSet<&str> =
+                let table_column_names: HashSet<&str> =
                     table.columns.iter().map(|c| c.name.as_str()).collect();
 
                 for event_mapping in &table.events {
@@ -437,7 +437,7 @@ fn validate_manifest(
                     let abi_event = abi_event.unwrap();
 
                     // Collect event input names for validation
-                    let event_input_names: std::collections::HashSet<&str> =
+                    let event_input_names: HashSet<&str> =
                         abi_event.inputs.iter().map(|i| i.name.as_str()).collect();
 
                     // Built-in transaction metadata fields that are always available
@@ -453,8 +453,7 @@ fn validate_manifest(
                     ];
 
                     // Validate iterate bindings and collect aliases for later validation
-                    let mut iterate_aliases: std::collections::HashSet<String> =
-                        std::collections::HashSet::new();
+                    let mut iterate_aliases: HashSet<String> = HashSet::new();
                     for binding in &event_mapping.iterate {
                         // Check that the array field exists in the event
                         // Strip any nested path to get the root field
@@ -695,7 +694,7 @@ fn validate_manifest(
                     use crate::manifest::contract::parse_interval;
 
                     // Collect contract network names for validation
-                    let contract_networks: std::collections::HashSet<&str> =
+                    let contract_networks: HashSet<&str> =
                         contract.details.iter().map(|d| d.network.as_str()).collect();
 
                     for cron in cron_entries {

--- a/core/src/phantom/dyrpc.rs
+++ b/core/src/phantom/dyrpc.rs
@@ -77,7 +77,7 @@ pub async fn deploy_dyrpc_contract(
     )
     .await?;
 
-    let re = Regex::new(r"/eth/([a-fA-F0-9]{64})/").unwrap();
+    let re = Regex::new(r"/eth/([a-fA-F0-9]{64})/")?;
     let rpc_url = re
         .replace(&result.rpc_url, "/eth/{RINDEXER_PHANTOM_API_KEY}/")
         .to_string()

--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -431,8 +431,8 @@ impl JsonRpcCachedProvider {
     #[tracing::instrument(skip_all)]
     pub async fn eth_call(
         &self,
-        to: alloy::primitives::Address,
-        data: alloy::primitives::Bytes,
+        to: Address,
+        data: Bytes,
         block_number: u64,
     ) -> Result<String, ProviderError> {
         let result: String = self
@@ -440,7 +440,7 @@ impl JsonRpcCachedProvider {
             .raw_request(
                 "eth_call".into(),
                 (
-                    serde_json::json!({
+                    json!({
                         "to": format!("{:?}", to),
                         "data": format!("0x{}", hex::encode(&data)),
                     }),
@@ -455,17 +455,13 @@ impl JsonRpcCachedProvider {
     /// Executes eth_call at the "latest" block.
     /// Use this for immutable data (symbol, decimals, name) that doesn't change.
     #[tracing::instrument(skip_all)]
-    pub async fn eth_call_latest(
-        &self,
-        to: alloy::primitives::Address,
-        data: alloy::primitives::Bytes,
-    ) -> Result<String, ProviderError> {
+    pub async fn eth_call_latest(&self, to: Address, data: Bytes) -> Result<String, ProviderError> {
         let result: String = self
             .provider
             .raw_request(
                 "eth_call".into(),
                 (
-                    serde_json::json!({
+                    json!({
                         "to": format!("{:?}", to),
                         "data": format!("0x{}", hex::encode(&data)),
                     }),

--- a/core/src/start.rs
+++ b/core/src/start.rs
@@ -341,7 +341,7 @@ pub async fn start_rindexer(details: StartDetails<'_>) -> Result<(), StartRindex
                     info!("Hot-reload: watching rindexer.yaml for changes");
                 }
 
-                if manifest.has_any_contracts_live_indexing() {
+                if manifest.has_any_live_indexing() {
                     if dependencies.is_empty() {
                         dependencies =
                             ContractEventDependencies::map_from_relationships(&relationships)?;
@@ -365,7 +365,7 @@ pub async fn start_rindexer(details: StartDetails<'_>) -> Result<(), StartRindex
                 }
             }
 
-            if graphql_server_handle.is_none() && !manifest.has_any_contracts_live_indexing() {
+            if graphql_server_handle.is_none() && !manifest.has_any_live_indexing() {
                 // Wait for cron scheduler to complete if it's running
                 if let Some(cron_handle) = details.cron_scheduler_handle {
                     info!("Waiting for cron scheduler to complete...");

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -193,6 +193,23 @@ impl StreamsClients {
         }
     }
 
+    /// Redirects the Cloudflare Queues client to a different base URL. Intended
+    /// solely for integration tests that mock the Cloudflare REST API with
+    /// `mockito` — prefer configuring the real `api_token`/`account_id` in
+    /// production code.
+    #[doc(hidden)]
+    pub fn set_cloudflare_base_url_for_test(&mut self, base_url: &str) {
+        if let Some(cf) = self.cloudflare_queues.as_mut() {
+            cf.client = Arc::new(
+                CloudflareQueues::new(
+                    cf.config.api_token.clone(),
+                    cf.config.account_id.clone(),
+                )
+                .with_base_url(base_url.to_string()),
+            );
+        }
+    }
+
     fn has_any_streams(&self) -> bool {
         self.sns.is_some()
             || self.webhook.is_some()
@@ -834,6 +851,36 @@ impl StreamsClients {
     }
 
     /// Publishes a `__rindexer_reorg` retraction event to all configured streams.
+    ///
+    /// Routing is delegated to the internal `stream_with_mode` path with
+    /// `force_send_network_wide = true`, which bypasses the per-stream
+    /// `events` filter: every destination whose `networks` list contains the
+    /// affected `network` receives the reorg payload regardless of whether
+    /// `__rindexer_reorg` appears in its configured events. Per-stream-type
+    /// routing behaviour:
+    ///
+    /// - **Webhook**: POST to every endpoint whose `networks` matches.
+    ///   Body is the JSON `EventMessage` with `event_name = "__rindexer_reorg"`.
+    /// - **SNS**: publishes to every topic whose `networks` matches. The
+    ///   payload is the JSON-encoded `EventMessage` string; `event_name` is
+    ///   carried inside the payload (no SNS message attributes are set).
+    /// - **Kafka** *(feature-gated)*: publishes to every configured topic
+    ///   whose `networks` matches. The record `key` is the per-topic
+    ///   `key` from config (not derived from `event_name`); the
+    ///   `x-rindexer-id` header carries the generated message id.
+    /// - **RabbitMQ**: publishes to the configured `exchange` with the
+    ///   configured `routing_key`. Fanout exchanges ignore the routing
+    ///   key. Topic and direct exchanges require a non-`None` routing key
+    ///   at manifest-validation time — this is enforced by
+    ///   [`crate::manifest::stream::RabbitMQStreamConfig::validate`].
+    /// - **Redis**: `XADD`s to every configured stream whose `networks`
+    ///   matches, under the `payload` field.
+    /// - **CloudflareQueues**: enqueues (via the Cloudflare REST API) to
+    ///   every queue whose `networks` matches.
+    ///
+    /// All types reach publish through the shared `force_send_network_wide`
+    /// path — no destination is silently dropped because its `events` list
+    /// omits `__rindexer_reorg`.
     pub async fn stream_reorg(
         &self,
         network: &str,

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -201,11 +201,8 @@ impl StreamsClients {
     pub fn set_cloudflare_base_url_for_test(&mut self, base_url: &str) {
         if let Some(cf) = self.cloudflare_queues.as_mut() {
             cf.client = Arc::new(
-                CloudflareQueues::new(
-                    cf.config.api_token.clone(),
-                    cf.config.account_id.clone(),
-                )
-                .with_base_url(base_url.to_string()),
+                CloudflareQueues::new(cf.config.api_token.clone(), cf.config.account_id.clone())
+                    .with_base_url(base_url.to_string()),
             );
         }
     }
@@ -1421,13 +1418,8 @@ mod tests {
             delivery: None,
         };
 
-        let tables = vec![affected_table(
-            "my_indexer_usdc",
-            "transfer",
-            "my_indexer",
-            "USDC",
-            "Transfer",
-        )];
+        let tables =
+            vec![affected_table("my_indexer_usdc", "transfer", "my_indexer", "USDC", "Transfer")];
         let result = webhook_clients(vec![config])
             .stream_reorg("ethereum", 100, 2, 42, &[B256::ZERO], &tables)
             .await;
@@ -1473,9 +1465,8 @@ mod tests {
             "EvmTraces",
             "NativeTransfer",
         )];
-        let result = webhook_clients(vec![config])
-            .stream_reorg("ethereum", 500, 1, 0, &[], &tables)
-            .await;
+        let result =
+            webhook_clients(vec![config]).stream_reorg("ethereum", 500, 1, 0, &[], &tables).await;
 
         assert!(result.is_ok());
         mock.assert_async().await;
@@ -1513,9 +1504,8 @@ mod tests {
             delivery: None,
         };
 
-        let result = webhook_clients(vec![config])
-            .stream_reorg("ethereum", 7, 1, 0, &[], &[])
-            .await;
+        let result =
+            webhook_clients(vec![config]).stream_reorg("ethereum", 7, 1, 0, &[], &[]).await;
 
         assert!(result.is_ok());
         mock.assert_async().await;

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -839,6 +839,7 @@ impl StreamsClients {
         network: &str,
         fork_block: u64,
         depth: u64,
+        events_deleted: u64,
         affected_tx_hashes: &[B256],
         affected_tables: &[AffectedTable],
     ) -> Result<usize, StreamError> {
@@ -851,6 +852,7 @@ impl StreamsClients {
             "network": network,
             "fork_block": fork_block,
             "depth": depth,
+            "events_deleted": events_deleted,
             "affected_tx_hashes": affected_tx_hashes.iter().map(|h| format!("{:#x}", h)).collect::<Vec<_>>(),
             "affected_events": affected_tables.iter().map(|t| json!({
                 "indexer": t.indexer_name,
@@ -1320,7 +1322,6 @@ mod tests {
             schema: schema.to_string(),
             table_name: table.to_string(),
             rows_deleted: 0,
-            event_signature_hash: None,
             indexer_name: indexer.to_string(),
             contract_name: contract.to_string(),
             event_name: event.to_string(),
@@ -1330,7 +1331,7 @@ mod tests {
     #[tokio::test]
     async fn stream_reorg_returns_zero_without_streams() {
         // No streams configured — empty `affected_tables` slice is fine.
-        let result = empty_clients().stream_reorg("ethereum", 100, 2, &[], &[]).await;
+        let result = empty_clients().stream_reorg("ethereum", 100, 2, 0, &[], &[]).await;
         assert_eq!(result.unwrap(), 0);
     }
 
@@ -1350,6 +1351,7 @@ mod tests {
                     "network": "ethereum",
                     "fork_block": 100,
                     "depth": 2,
+                    "events_deleted": 42,
                     "affected_events": [{
                         "indexer": "my_indexer",
                         "contract": "USDC",
@@ -1380,7 +1382,7 @@ mod tests {
             "Transfer",
         )];
         let result = webhook_clients(vec![config])
-            .stream_reorg("ethereum", 100, 2, &[B256::ZERO], &tables)
+            .stream_reorg("ethereum", 100, 2, 42, &[B256::ZERO], &tables)
             .await;
 
         assert!(result.is_ok());
@@ -1425,7 +1427,47 @@ mod tests {
             "NativeTransfer",
         )];
         let result = webhook_clients(vec![config])
-            .stream_reorg("ethereum", 500, 1, &[], &tables)
+            .stream_reorg("ethereum", 500, 1, 0, &[], &tables)
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn stream_reorg_empty_affected_serializes_empty_array() {
+        // Streams configured, but no affected tables and no affected tx hashes.
+        // The payload must still serialize with `affected_events: []` and
+        // `events_deleted: 0` so downstream consumers can rely on their presence.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/hook")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "event_name": "__rindexer_reorg",
+                "network": "ethereum",
+                "event_data": [{
+                    "type": "reorg",
+                    "network": "ethereum",
+                    "fork_block": 7,
+                    "depth": 1,
+                    "events_deleted": 0,
+                    "affected_events": [],
+                }],
+            })))
+            .with_status(200)
+            .create_async()
+            .await;
+
+        let config = WebhookStreamConfig {
+            endpoint: format!("{}/hook", server.url()),
+            shared_secret: "s".to_string(),
+            networks: vec!["ethereum".to_string()],
+            events: vec![stream_event("Transfer")],
+            delivery: None,
+        };
+
+        let result = webhook_clients(vec![config])
+            .stream_reorg("ethereum", 7, 1, 0, &[], &[])
             .await;
 
         assert!(result.is_ok());

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -869,7 +869,7 @@ impl StreamsClients {
     ///   configured `routing_key`. Fanout exchanges ignore the routing
     ///   key. Topic and direct exchanges require a non-`None` routing key
     ///   at manifest-validation time — this is enforced by
-    ///   [`crate::manifest::stream::RabbitMQStreamConfig::validate`].
+    ///   [`RabbitMQStreamConfig::validate`].
     /// - **Redis**: `XADD`s to every configured stream whose `networks`
     ///   matches, under the `payload` field.
     /// - **CloudflareQueues**: enqueues (via the Cloudflare REST API) to

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -13,6 +13,7 @@ use tokio::{
 use crate::{
     event::{filter_event_data_by_conditions, EventMessage},
     indexer::native_transfer::EVENT_NAME,
+    indexer::reorg::AffectedTable,
     manifest::stream::{
         CloudflareQueuesStreamConfig, CloudflareQueuesStreamQueueConfig, RabbitMQStreamConfig,
         RabbitMQStreamQueueConfig, RedisStreamConfig, RedisStreamStreamConfig,
@@ -839,6 +840,7 @@ impl StreamsClients {
         fork_block: u64,
         depth: u64,
         affected_tx_hashes: &[B256],
+        affected_tables: &[AffectedTable],
     ) -> Result<usize, StreamError> {
         if !self.has_any_streams() {
             return Ok(0);
@@ -850,6 +852,14 @@ impl StreamsClients {
             "fork_block": fork_block,
             "depth": depth,
             "affected_tx_hashes": affected_tx_hashes.iter().map(|h| format!("{:#x}", h)).collect::<Vec<_>>(),
+            "affected_events": affected_tables.iter().map(|t| json!({
+                "indexer": t.indexer_name,
+                "contract": t.contract_name,
+                "event": t.event_name,
+                "schema": t.schema,
+                "table": t.table_name,
+                "rows_deleted": t.rows_deleted,
+            })).collect::<Vec<_>>(),
         });
 
         let event_message = EventMessage {
@@ -1299,16 +1309,60 @@ mod tests {
 
     // ---- stream_reorg ----
 
+    fn affected_table(
+        schema: &str,
+        table: &str,
+        indexer: &str,
+        contract: &str,
+        event: &str,
+    ) -> AffectedTable {
+        AffectedTable {
+            schema: schema.to_string(),
+            table_name: table.to_string(),
+            rows_deleted: 0,
+            event_signature_hash: None,
+            indexer_name: indexer.to_string(),
+            contract_name: contract.to_string(),
+            event_name: event.to_string(),
+        }
+    }
+
     #[tokio::test]
     async fn stream_reorg_returns_zero_without_streams() {
-        let result = empty_clients().stream_reorg("ethereum", 100, 2, &[]).await;
+        // No streams configured — empty `affected_tables` slice is fine.
+        let result = empty_clients().stream_reorg("ethereum", 100, 2, &[], &[]).await;
         assert_eq!(result.unwrap(), 0);
     }
 
     #[tokio::test]
     async fn stream_reorg_publishes_to_webhook() {
+        // Capture the webhook body and assert the enriched payload shape:
+        // the inner `reorg_payload` carried in `event_data[0]` must contain
+        // `affected_events` with the table metadata we pass in.
         let mut server = mockito::Server::new_async().await;
-        let mock = server.mock("POST", "/hook").with_status(200).create_async().await;
+        let mock = server
+            .mock("POST", "/hook")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "event_name": "__rindexer_reorg",
+                "network": "ethereum",
+                "event_data": [{
+                    "type": "reorg",
+                    "network": "ethereum",
+                    "fork_block": 100,
+                    "depth": 2,
+                    "affected_events": [{
+                        "indexer": "my_indexer",
+                        "contract": "USDC",
+                        "event": "Transfer",
+                        "schema": "my_indexer_usdc",
+                        "table": "transfer",
+                        "rows_deleted": 0,
+                    }],
+                }],
+            })))
+            .with_status(200)
+            .create_async()
+            .await;
 
         let config = WebhookStreamConfig {
             endpoint: format!("{}/hook", server.url()),
@@ -1318,8 +1372,61 @@ mod tests {
             delivery: None,
         };
 
-        let result =
-            webhook_clients(vec![config]).stream_reorg("ethereum", 100, 2, &[B256::ZERO]).await;
+        let tables = vec![affected_table(
+            "my_indexer_usdc",
+            "transfer",
+            "my_indexer",
+            "USDC",
+            "Transfer",
+        )];
+        let result = webhook_clients(vec![config])
+            .stream_reorg("ethereum", 100, 2, &[B256::ZERO], &tables)
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn stream_reorg_payload_includes_native_transfer_rows() {
+        // NativeTransfer-sourced rows must appear as a distinct entry in the
+        // `affected_events` array so downstream consumers can detect them.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/hook")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "event_data": [{
+                    "affected_events": [{
+                        "indexer": "my_indexer",
+                        "contract": "EvmTraces",
+                        "event": "NativeTransfer",
+                        "schema": "my_indexer_evm_traces",
+                        "table": "native_transfer",
+                    }],
+                }],
+            })))
+            .with_status(200)
+            .create_async()
+            .await;
+
+        let config = WebhookStreamConfig {
+            endpoint: format!("{}/hook", server.url()),
+            shared_secret: "s".to_string(),
+            networks: vec!["ethereum".to_string()],
+            events: vec![stream_event("Transfer")],
+            delivery: None,
+        };
+
+        let tables = vec![affected_table(
+            "my_indexer_evm_traces",
+            "native_transfer",
+            "my_indexer",
+            "EvmTraces",
+            "NativeTransfer",
+        )];
+        let result = webhook_clients(vec![config])
+            .stream_reorg("ethereum", 500, 1, &[], &tables)
+            .await;
 
         assert!(result.is_ok());
         mock.assert_async().await;

--- a/core/src/streams/cloudflare_queues.rs
+++ b/core/src/streams/cloudflare_queues.rs
@@ -37,8 +37,7 @@ impl CloudflareQueues {
         }
     }
 
-    #[doc(hidden)]
-    pub fn with_base_url(mut self, base_url: String) -> Self {
+    pub(crate) fn with_base_url(mut self, base_url: String) -> Self {
         self.base_url = base_url;
         self
     }

--- a/core/src/streams/cloudflare_queues.rs
+++ b/core/src/streams/cloudflare_queues.rs
@@ -37,8 +37,8 @@ impl CloudflareQueues {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn with_base_url(mut self, base_url: String) -> Self {
+    #[doc(hidden)]
+    pub fn with_base_url(mut self, base_url: String) -> Self {
         self.base_url = base_url;
         self
     }

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -585,6 +585,9 @@ async fn test_reorg_detection_and_rollback() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -694,6 +697,9 @@ async fn test_reorg_single_block() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -756,6 +762,9 @@ async fn test_reorg_deep() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -811,6 +820,9 @@ async fn test_reorg_no_events_in_range() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -909,12 +921,18 @@ async fn test_reorg_multiple_event_tables() {
                 "test_schema".to_string(),
                 "ping_pong_ping".to_string(),
                 "test_schema_ping".to_string(),
+                "test_indexer".to_string(),
+                "PingPong".to_string(),
+                "Ping".to_string(),
             )
             .unwrap(),
             EventTableInfo::try_new(
                 "test_schema".to_string(),
                 "ping_pong_pong".to_string(),
                 "test_schema_pong".to_string(),
+                "test_indexer".to_string(),
+                "PingPong".to_string(),
+                "Pong".to_string(),
             )
             .unwrap(),
         ],
@@ -989,6 +1007,9 @@ async fn test_reorg_checkpoint_rewind() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -1080,6 +1101,9 @@ async fn test_reorg_derived_table_cleanup() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -1175,6 +1199,9 @@ async fn test_reorg_derived_table_cross_chain() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -1245,6 +1272,9 @@ async fn test_reorg_consecutive() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -1273,6 +1303,9 @@ async fn test_reorg_consecutive() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -1430,6 +1463,9 @@ async fn test_reorg_multicall_tx_deduplication() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -1514,6 +1550,9 @@ async fn test_reorg_reindex_continuation() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -1693,6 +1732,9 @@ async fn test_reorg_on_reorg_callback_fired() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -1784,6 +1826,9 @@ async fn test_reorg_unregistered_derived_table_survives() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![],
@@ -1885,6 +1930,9 @@ async fn test_reorg_multiple_derived_tables() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![
@@ -1977,6 +2025,9 @@ async fn test_reorg_derived_table_deep_range() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2061,6 +2112,9 @@ async fn test_reorg_reversal_add() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2152,6 +2206,9 @@ async fn test_reorg_reversal_subtract() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2244,6 +2301,9 @@ async fn test_reorg_reversal_increment() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2334,6 +2394,9 @@ async fn test_reorg_reversal_with_condition() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2450,6 +2513,9 @@ async fn test_reorg_journal_max_recalculation() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2556,6 +2622,9 @@ async fn test_reorg_journal_set_recalculation() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2646,6 +2715,9 @@ async fn test_reorg_reversal_decrement() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2752,6 +2824,9 @@ async fn test_reorg_journal_min_recalculation() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2864,6 +2939,9 @@ async fn test_reorg_mixed_reversible_and_journal() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -2978,6 +3056,9 @@ async fn test_reorg_reversal_uninvolved_row_unchanged() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -3121,6 +3202,9 @@ async fn test_reorg_clickhouse_add_reversal() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
@@ -3279,12 +3363,18 @@ async fn test_reorg_two_events_same_table_reversible() {
                 "test_schema".to_string(),
                 "ping_pong_ping".to_string(),
                 "test_schema_ping".to_string(),
+                "test_indexer".to_string(),
+                "PingPong".to_string(),
+                "Ping".to_string(),
             )
             .unwrap(),
             EventTableInfo::try_new(
                 "test_schema".to_string(),
                 "ping_pong_pong".to_string(),
                 "test_schema_pong".to_string(),
+                "test_indexer".to_string(),
+                "PingPong".to_string(),
+                "Pong".to_string(),
             )
             .unwrap(),
         ],
@@ -3461,6 +3551,9 @@ async fn test_reorg_two_events_same_table_journal() {
             "test_schema".to_string(),
             "ping_pong_ping".to_string(),
             "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {

--- a/core/tests/e2e_reorg_streams.rs
+++ b/core/tests/e2e_reorg_streams.rs
@@ -1,0 +1,423 @@
+//! Integration tests for `StreamsClients::stream_reorg` across each stream type.
+//!
+//! The goal is to confirm that a `__rindexer_reorg` payload actually reaches
+//! each concrete broker/endpoint when the stream is configured, with the
+//! expected identifying markers in the body.
+//!
+//! Coverage:
+//! - Redis — testcontainers `redis` image, `XREAD` from the configured stream.
+//! - RabbitMQ — testcontainers `rabbitmq` image, consume a queue bound to
+//!   the configured exchange.
+//! - Kafka — testcontainers `kafka` image (KRaft, no Zookeeper),
+//!   `#[cfg(feature = "kafka")]` only.
+//! - Cloudflare — mockito server in place of the Cloudflare REST API.
+//!
+//! SNS is deliberately deferred. `testcontainers-modules 0.15` does ship a
+//! `localstack` module, and `AwsConfig.endpoint_url` already lets the SNS
+//! client target a non-AWS endpoint — so an integration test is technically
+//! feasible. It's held back for two reasons: (1) the plan's original scoping
+//! (Task 6 step 2e) explicitly defers it; (2) `SNS::new` performs an eager
+//! `list_topics` handshake on construction and panics on failure, which
+//! makes a robust localstack bring-up fiddly (requires pre-creating the
+//! topic ARN before `StreamsClients::new` is called). Future work: wire up
+//! a localstack container, create the topic via the AWS SDK, then construct
+//! `StreamsClients` with the matching topic ARN.
+//!
+//! All tests are `#[ignore]` and require a working Docker daemon. Run with:
+//!   cargo test -q -p rindexer --test e2e_reorg_streams -- --ignored
+//!   cargo test -q -p rindexer --test e2e_reorg_streams --features kafka -- --ignored
+
+use std::time::Duration;
+
+use alloy::primitives::B256;
+use serde_json::{json, Value};
+
+use rindexer::manifest::stream::{
+    CloudflareQueuesStreamConfig, CloudflareQueuesStreamQueueConfig, ExchangeKindWrapper,
+    RabbitMQStreamConfig, RabbitMQStreamQueueConfig, RedisStreamConfig, RedisStreamStreamConfig,
+    StreamsConfig,
+};
+use rindexer::StreamsClients;
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+/// A hash we pass into `stream_reorg` to assert on round-tripped payloads.
+const MARKER_HASH_HEX: &str = "0x0101010101010101010101010101010101010101010101010101010101010101";
+
+fn marker_hash() -> B256 {
+    MARKER_HASH_HEX.parse().expect("valid B256")
+}
+
+/// Invoke `stream_reorg` with a canonical payload. Returns the count reported
+/// by the call.
+async fn publish_reorg(clients: &StreamsClients) -> usize {
+    clients
+        .stream_reorg(
+            "ethereum",
+            100,
+            2,
+            7,
+            &[marker_hash()],
+            &[], // no affected tables — keep payload tight for assertions
+        )
+        .await
+        .expect("stream_reorg should succeed")
+}
+
+/// Asserts that a JSON blob representing the outer `EventMessage` carries the
+/// expected reorg identifiers:
+/// - `event_name == "__rindexer_reorg"`
+/// - `network == "ethereum"`
+/// - `event_data[0]` contains the marker hash in `affected_tx_hashes`
+fn assert_reorg_envelope(payload: &Value) {
+    assert_eq!(
+        payload["event_name"], "__rindexer_reorg",
+        "event_name mismatch, got payload: {payload}"
+    );
+    assert_eq!(payload["network"], "ethereum", "network mismatch, got payload: {payload}");
+    let inner = &payload["event_data"][0];
+    assert_eq!(inner["type"], "reorg", "missing reorg marker, got payload: {payload}");
+    assert_eq!(inner["fork_block"], 100);
+    assert_eq!(inner["depth"], 2);
+    assert_eq!(inner["events_deleted"], 7);
+    let hashes = inner["affected_tx_hashes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("affected_tx_hashes should be an array: {payload}"));
+    assert!(
+        hashes.iter().any(|h| h.as_str() == Some(MARKER_HASH_HEX)),
+        "missing marker hash in affected_tx_hashes: {payload}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Redis
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn stream_reorg_reaches_redis() {
+    use bb8_redis::redis::{cmd, AsyncCommands, Value as RedisValue};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::redis::{Redis as RedisImage, REDIS_PORT};
+
+    let redis = RedisImage::default().start().await.expect("start redis");
+    let host = redis.get_host().await.expect("redis host");
+    let port = redis.get_host_port_ipv4(REDIS_PORT).await.expect("redis port");
+    let url = format!("redis://{host}:{port}");
+
+    let stream_name = "rindexer_reorg_test";
+    let redis_config = RedisStreamConfig {
+        connection_uri: url.clone(),
+        max_pool_size: 4,
+        streams: vec![RedisStreamStreamConfig {
+            stream_name: stream_name.to_string(),
+            networks: vec!["ethereum".to_string()],
+            // Intentionally empty — reorg routing must bypass event-name filtering.
+            events: vec![],
+            delivery: None,
+        }],
+    };
+
+    let clients = StreamsClients::new(StreamsConfig {
+        sns: None,
+        webhooks: None,
+        rabbitmq: None,
+        #[cfg(feature = "kafka")]
+        kafka: None,
+        redis: Some(redis_config),
+        cloudflare_queues: None,
+    })
+    .await;
+
+    let streamed = publish_reorg(&clients).await;
+    assert_eq!(streamed, 1, "should publish exactly one reorg payload");
+
+    // Read it back with a plain redis client so we don't depend on
+    // rindexer::streams::Redis internals.
+    let client = redis::Client::open(url.as_str()).expect("redis client");
+    let mut con = client.get_multiplexed_async_connection().await.expect("redis connection");
+
+    // XLEN — confirm we have a single entry.
+    let len: i64 = cmd("XLEN").arg(stream_name).query_async(&mut con).await.expect("XLEN");
+    assert_eq!(len, 1, "expected exactly one XADD into the stream");
+
+    // XRANGE to fetch the entry.
+    let entries: Vec<(String, Vec<(String, RedisValue)>)> = con
+        .xrange_all(stream_name)
+        .await
+        .expect("xrange");
+    assert_eq!(entries.len(), 1);
+    let (_id, fields) = &entries[0];
+
+    let payload_str = fields
+        .iter()
+        .find_map(|(k, v)| {
+            if k == "payload" {
+                match v {
+                    RedisValue::BulkString(b) => String::from_utf8(b.clone()).ok(),
+                    RedisValue::SimpleString(s) => Some(s.clone()),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        })
+        .expect("payload field missing");
+
+    let payload: Value = serde_json::from_str(&payload_str).expect("payload JSON");
+    assert_reorg_envelope(&payload);
+    // The Redis publish path injects `message_id` alongside the EventMessage fields.
+    assert!(
+        payload["message_id"].as_str().is_some(),
+        "expected message_id in redis payload: {payload}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RabbitMQ
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn stream_reorg_reaches_rabbitmq() {
+    use futures::StreamExt;
+    use lapin::{
+        options::{BasicConsumeOptions, ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions},
+        types::FieldTable,
+        Connection, ConnectionProperties, ExchangeKind,
+    };
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::rabbitmq::RabbitMq as RabbitMqImage;
+
+    let rabbit = RabbitMqImage::default().start().await.expect("start rabbitmq");
+    let host = rabbit.get_host().await.expect("rabbitmq host");
+    let port = rabbit.get_host_port_ipv4(5672).await.expect("rabbitmq amqp port");
+    let url = format!("amqp://{host}:{port}");
+
+    // Pre-declare the exchange and bind a queue BEFORE the rindexer client
+    // publishes, so the message isn't dropped.
+    let consumer_conn = Connection::connect(&url, ConnectionProperties::default())
+        .await
+        .expect("consumer connect");
+    let channel = consumer_conn.create_channel().await.expect("channel");
+
+    let exchange = "rindexer_reorg_exchange";
+    let routing_key = "reorg";
+    let queue_name = "rindexer_reorg_queue";
+
+    channel
+        .exchange_declare(
+            exchange,
+            ExchangeKind::Direct,
+            ExchangeDeclareOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .expect("exchange_declare");
+
+    channel
+        .queue_declare(queue_name, QueueDeclareOptions::default(), FieldTable::default())
+        .await
+        .expect("queue_declare");
+
+    channel
+        .queue_bind(
+            queue_name,
+            exchange,
+            routing_key,
+            QueueBindOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .expect("queue_bind");
+
+    let mut consumer = channel
+        .basic_consume(
+            queue_name,
+            "e2e-reorg-consumer",
+            BasicConsumeOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .expect("basic_consume");
+
+    let rabbit_config = RabbitMQStreamConfig {
+        url,
+        exchanges: vec![RabbitMQStreamQueueConfig {
+            exchange: exchange.to_string(),
+            exchange_type: ExchangeKindWrapper(ExchangeKind::Direct),
+            routing_key: Some(routing_key.to_string()),
+            networks: vec!["ethereum".to_string()],
+            events: vec![],
+            delivery: None,
+        }],
+    };
+
+    let clients = StreamsClients::new(StreamsConfig {
+        sns: None,
+        webhooks: None,
+        rabbitmq: Some(rabbit_config),
+        #[cfg(feature = "kafka")]
+        kafka: None,
+        redis: None,
+        cloudflare_queues: None,
+    })
+    .await;
+
+    let streamed = publish_reorg(&clients).await;
+    assert_eq!(streamed, 1);
+
+    let delivery = tokio::time::timeout(Duration::from_secs(15), consumer.next())
+        .await
+        .expect("consumer timed out")
+        .expect("no delivery received")
+        .expect("delivery error");
+
+    let payload: Value = serde_json::from_slice(&delivery.data).expect("payload JSON");
+    assert_reorg_envelope(&payload);
+    assert_eq!(delivery.exchange.as_str(), exchange);
+    assert_eq!(delivery.routing_key.as_str(), routing_key);
+}
+
+// ---------------------------------------------------------------------------
+// Kafka (feature-gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "kafka")]
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn stream_reorg_reaches_kafka() {
+    use futures::StreamExt;
+    use rdkafka::{
+        consumer::{Consumer, StreamConsumer},
+        ClientConfig, Message,
+    };
+    use rindexer::manifest::stream::{KafkaStreamConfig, KafkaStreamQueueConfig};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::kafka::apache::{Kafka as KafkaImage, KAFKA_PORT};
+
+    let kafka = KafkaImage::default().start().await.expect("start kafka");
+    let port = kafka.get_host_port_ipv4(KAFKA_PORT).await.expect("kafka port");
+    let bootstrap = format!("127.0.0.1:{port}");
+
+    let topic = "rindexer_reorg_topic";
+
+    // Subscribe BEFORE producing with `earliest` offset reset so we don't miss the message.
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("group.id", "e2e-reorg-consumer")
+        .set("bootstrap.servers", &bootstrap)
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "earliest")
+        .create()
+        .expect("kafka consumer");
+    consumer.subscribe(&[topic]).expect("subscribe");
+
+    let kafka_config = KafkaStreamConfig {
+        brokers: vec![bootstrap.clone()],
+        security_protocol: "PLAINTEXT".to_string(),
+        sasl_mechanisms: None,
+        sasl_username: None,
+        sasl_password: None,
+        acks: "all".to_string(),
+        topics: vec![KafkaStreamQueueConfig {
+            topic: topic.to_string(),
+            key: Some("reorg".to_string()),
+            networks: vec!["ethereum".to_string()],
+            events: vec![],
+            delivery: None,
+        }],
+    };
+
+    let clients = StreamsClients::new(StreamsConfig {
+        sns: None,
+        webhooks: None,
+        rabbitmq: None,
+        kafka: Some(kafka_config),
+        redis: None,
+        cloudflare_queues: None,
+    })
+    .await;
+
+    let streamed = publish_reorg(&clients).await;
+    assert_eq!(streamed, 1);
+
+    let mut stream = consumer.stream();
+    let msg = tokio::time::timeout(Duration::from_secs(30), stream.next())
+        .await
+        .expect("kafka consumer timed out")
+        .expect("no message")
+        .expect("kafka delivery error");
+
+    let body = msg.payload().expect("message payload");
+    let payload: Value = serde_json::from_slice(body).expect("kafka payload JSON");
+    assert_reorg_envelope(&payload);
+
+    // Record key is the configured `key`, not the event name.
+    assert_eq!(msg.key().map(|k| std::str::from_utf8(k).unwrap()), Some("reorg"));
+}
+
+// ---------------------------------------------------------------------------
+// Cloudflare Queues (mockito — no Docker required, but tagged ignore for
+// parity and to keep this file runnable in CI under a single command).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn stream_reorg_reaches_cloudflare_queues() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/client/v4/accounts/acc-123/queues/q-reorg/messages")
+        .match_header("authorization", "Bearer test-token")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "body": {
+                "event_name": "__rindexer_reorg",
+                "network": "ethereum",
+                "event_data": [{
+                    "type": "reorg",
+                    "network": "ethereum",
+                    "fork_block": 100,
+                    "depth": 2,
+                    "events_deleted": 7,
+                    "affected_tx_hashes": [MARKER_HASH_HEX],
+                }],
+            }
+        })))
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let cloudflare_config = CloudflareQueuesStreamConfig {
+        api_token: "test-token".to_string(),
+        account_id: "acc-123".to_string(),
+        queues: vec![CloudflareQueuesStreamQueueConfig {
+            queue_id: "q-reorg".to_string(),
+            networks: vec!["ethereum".to_string()],
+            events: vec![],
+            delivery: None,
+        }],
+    };
+
+    // Construct via public API so we exercise the full `StreamsClients::new` path.
+    let mut clients = StreamsClients::new(StreamsConfig {
+        sns: None,
+        webhooks: None,
+        rabbitmq: None,
+        #[cfg(feature = "kafka")]
+        kafka: None,
+        redis: None,
+        cloudflare_queues: Some(cloudflare_config),
+    })
+    .await;
+
+    // Swap the internal client to a mockito-backed one so the POST hits the
+    // test server rather than the real Cloudflare API.
+    clients.set_cloudflare_base_url_for_test(&server.url());
+
+    let streamed = publish_reorg(&clients).await;
+    assert_eq!(streamed, 1);
+    mock.assert_async().await;
+}
+

--- a/core/tests/e2e_reorg_streams.rs
+++ b/core/tests/e2e_reorg_streams.rs
@@ -144,10 +144,8 @@ async fn stream_reorg_reaches_redis() {
     assert_eq!(len, 1, "expected exactly one XADD into the stream");
 
     // XRANGE to fetch the entry.
-    let entries: Vec<(String, Vec<(String, RedisValue)>)> = con
-        .xrange_all(stream_name)
-        .await
-        .expect("xrange");
+    let entries: Vec<(String, Vec<(String, RedisValue)>)> =
+        con.xrange_all(stream_name).await.expect("xrange");
     assert_eq!(entries.len(), 1);
     let (_id, fields) = &entries[0];
 
@@ -184,7 +182,9 @@ async fn stream_reorg_reaches_redis() {
 async fn stream_reorg_reaches_rabbitmq() {
     use futures::StreamExt;
     use lapin::{
-        options::{BasicConsumeOptions, ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions},
+        options::{
+            BasicConsumeOptions, ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions,
+        },
         types::FieldTable,
         Connection, ConnectionProperties, ExchangeKind,
     };
@@ -198,9 +198,8 @@ async fn stream_reorg_reaches_rabbitmq() {
 
     // Pre-declare the exchange and bind a queue BEFORE the rindexer client
     // publishes, so the message isn't dropped.
-    let consumer_conn = Connection::connect(&url, ConnectionProperties::default())
-        .await
-        .expect("consumer connect");
+    let consumer_conn =
+        Connection::connect(&url, ConnectionProperties::default()).await.expect("consumer connect");
     let channel = consumer_conn.create_channel().await.expect("channel");
 
     let exchange = "rindexer_reorg_exchange";
@@ -420,4 +419,3 @@ async fn stream_reorg_reaches_cloudflare_queues() {
     assert_eq!(streamed, 1);
     mock.assert_async().await;
 }
-

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -9,6 +9,7 @@
 - fix: Handle int/uint array types (e.g. `uint256[]`) in `parse_solidity_integer_type` to prevent ParseIntError during codegen
 
 - fix: ClickHouse hash serialization so String are stored as proper strings instead of corrupted scientific-notation values.
+- fix: native-transfer indexing no longer panics on trace batches containing only block entries (empty blocks).
 - fix: **Live-indexing heartbeat log replaced** — the previous `"No new blocks published in the last 5 minutes"` info log fired spuriously whenever the RPC provider returned a cached tip (every ~half block-time) and could not distinguish a healthy cache hit from a genuinely stuck RPC. It is replaced with a new tip-advance heartbeat that emits either `"Indexing alive - chain tip X"` (info) when the tip has advanced within the interval, or `"RPC tip has not advanced past block X in the last 5 minutes"` (warn) when the tip is genuinely stuck. Log-based alerts that grepped the old message must be updated to match the new warn text.
 
 ### Features
@@ -25,6 +26,11 @@
 - feat: **`latest_blocks` internal table** — new `rindexer_internal.latest_blocks` table (PostgreSQL + ClickHouse) persists the block hash window for offline reorg detection on restart.
 - feat: **SQL injection defenses** — all user-supplied identifiers from YAML specs are validated at startup before SQL interpolation: table/column names, network names, and filter conditions are checked against injection patterns.
 - feat: **Reorg metrics** — four new Prometheus metrics: `rindexer_reorg_handling_duration_seconds`, `rindexer_reorg_events_deleted_total`, `rindexer_reorg_detection_source_total`, `rindexer_reorg_cascade_total`.
+- feat: **Native-transfer-only reorg detection** — networks indexing only native transfers now get their own `ReorgCoordinator`. Mixed contract+NT configs share one coordinator so a reorg detected by either pipeline rolls back both.
+- feat: **`native_transfers.tables`** — new `tables` field mirroring `contracts[].tables`. Aggregation tables keyed on `NativeTransfer` events participate in reorg rollback.
+- feat: **`on_reorg` for native transfers** — register reorg callbacks on `TraceCallbackRegistry::register_on_reorg`, matching the `EventCallbackRegistry` API.
+- feat: **Enriched `__rindexer_reorg` payload** — adds `events_deleted` total and `affected_events` array (`{indexer, contract, event, schema, table, rows_deleted}` per source table). Additive JSON.
+- feat: **Reorg notifications fan out across all streams on a network** — `__rindexer_reorg` reaches every configured stream on the network regardless of which pipeline detected the reorg. Dispatched in parallel.
 
 ## Releases
 -------------------------------------------------

--- a/documentation/docs/pages/docs/start-building/rust-project-deep-dive/indexers.mdx
+++ b/documentation/docs/pages/docs/start-building/rust-project-deep-dive/indexers.mdx
@@ -1062,7 +1062,7 @@ async fn main() {
                 indexing_details: if enable_indexer {
                     Some(IndexingDetails {
                         registry: register_all_handlers(&manifest_path).await,
-                        trace_registry: TraceCallbackRegistry { events: vec![] },
+                        trace_registry: TraceCallbackRegistry::new(),
                         event_stream: None,
                     })
                 } else {
@@ -1172,7 +1172,7 @@ async fn main() {
                 manifest_path: &manifest_path,
                 indexing_details: Some(IndexingDetails {
                     registry: register_all_handlers(&manifest_path).await,
-                    trace_registry: TraceCallbackRegistry { events: vec![] },
+                    trace_registry: TraceCallbackRegistry::new(),
                     event_stream: Some(indexer_event_stream),
                 }),
                 graphql_details: GraphqlOverrideSettings {

--- a/e2e-tests/src/anvil_setup.rs
+++ b/e2e-tests/src/anvil_setup.rs
@@ -351,42 +351,6 @@ impl AnvilInstance {
         Ok(tx_hash)
     }
 
-    /// Send a native ETH transfer. Returns the tx hash.
-    /// Does NOT auto-mine — call `mine_block()` afterwards if using manual mining.
-    pub async fn send_native_eth(
-        &self,
-        to: &ethers::types::Address,
-        amount: ethers::types::U256,
-    ) -> Result<String> {
-        use ethers::middleware::MiddlewareBuilder;
-        use ethers::providers::{Http, Middleware, Provider};
-        use ethers::signers::{LocalWallet, Signer};
-        use ethers::types::TransactionRequest;
-
-        let base_provider = Provider::<Http>::try_from(&self.rpc_url)?;
-        let chain_id = base_provider.get_chainid().await?.as_u64();
-        let wallet: LocalWallet = ANVIL_DEFAULT_PRIVATE_KEY.parse()?;
-        let wallet = wallet.with_chain_id(chain_id);
-        let signer_address = wallet.address();
-        let provider = base_provider.with_signer(wallet);
-        let nonce = provider.get_transaction_count(signer_address, None).await?;
-
-        let tx = TransactionRequest {
-            from: Some(signer_address),
-            to: Some((*to).into()),
-            data: None,
-            gas: Some(21000u64.into()),
-            nonce: Some(nonce),
-            gas_price: Some(20000000000u128.into()),
-            value: Some(amount),
-            chain_id: None,
-        };
-
-        let pending = provider.send_transaction(tx, None).await?;
-        let tx_hash = format!("{:?}", pending.tx_hash()).to_lowercase();
-        Ok(tx_hash)
-    }
-
     /// Send multiple ERC20 transfers without mining between them.
     /// All transactions sit in the mempool until the next `mine_block()`.
     /// Returns tx hashes in submission order.

--- a/e2e-tests/src/anvil_setup.rs
+++ b/e2e-tests/src/anvil_setup.rs
@@ -351,6 +351,42 @@ impl AnvilInstance {
         Ok(tx_hash)
     }
 
+    /// Send a native ETH transfer. Returns the tx hash.
+    /// Does NOT auto-mine — call `mine_block()` afterwards if using manual mining.
+    pub async fn send_native_eth(
+        &self,
+        to: &ethers::types::Address,
+        amount: ethers::types::U256,
+    ) -> Result<String> {
+        use ethers::middleware::MiddlewareBuilder;
+        use ethers::providers::{Http, Middleware, Provider};
+        use ethers::signers::{LocalWallet, Signer};
+        use ethers::types::TransactionRequest;
+
+        let base_provider = Provider::<Http>::try_from(&self.rpc_url)?;
+        let chain_id = base_provider.get_chainid().await?.as_u64();
+        let wallet: LocalWallet = ANVIL_DEFAULT_PRIVATE_KEY.parse()?;
+        let wallet = wallet.with_chain_id(chain_id);
+        let signer_address = wallet.address();
+        let provider = base_provider.with_signer(wallet);
+        let nonce = provider.get_transaction_count(signer_address, None).await?;
+
+        let tx = TransactionRequest {
+            from: Some(signer_address),
+            to: Some((*to).into()),
+            data: None,
+            gas: Some(21000u64.into()),
+            nonce: Some(nonce),
+            gas_price: Some(20000000000u128.into()),
+            value: Some(amount),
+            chain_id: None,
+        };
+
+        let pending = provider.send_transaction(tx, None).await?;
+        let tx_hash = format!("{:?}", pending.tx_hash()).to_lowercase();
+        Ok(tx_hash)
+    }
+
     /// Send multiple ERC20 transfers without mining between them.
     /// All transactions sit in the mempool until the next `mine_block()`.
     /// Returns tx hashes in submission order.

--- a/e2e-tests/src/docker.rs
+++ b/e2e-tests/src/docker.rs
@@ -63,7 +63,7 @@ pub async fn start_postgres_container() -> Result<(String, u16)> {
 /// Wait for Postgres to accept connections via `tokio-postgres`.
 pub async fn wait_for_postgres_ready(port: u16, timeout_seconds: u64) -> Result<()> {
     let start = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(timeout_seconds);
+    let timeout = Duration::from_secs(timeout_seconds);
     let conn_str =
         format!("host=localhost port={} user=postgres password=postgres dbname=postgres", port);
 
@@ -190,7 +190,7 @@ pub async fn start_clickhouse_container() -> Result<(String, u16)> {
 #[allow(dead_code)]
 pub async fn wait_for_clickhouse_ready(port: u16, timeout_seconds: u64) -> Result<()> {
     let start = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(timeout_seconds);
+    let timeout = Duration::from_secs(timeout_seconds);
     let url = format!("http://localhost:{}/?query=SELECT%201", port);
     let client = reqwest::Client::new();
 

--- a/e2e-tests/src/rindexer_client.rs
+++ b/e2e-tests/src/rindexer_client.rs
@@ -422,11 +422,7 @@ impl RindexerInstance {
                 csv: crate::test_suite::CsvConfig { enabled: true },
                 clickhouse: None,
             },
-            native_transfers: crate::test_suite::NativeTransfersConfig {
-                enabled: false,
-                networks: None,
-                generate_csv: None,
-            },
+            native_transfers: crate::test_suite::NativeTransfersConfig::default(),
             contracts: vec![],
         }
     }

--- a/e2e-tests/src/test_suite.rs
+++ b/e2e-tests/src/test_suite.rs
@@ -68,13 +68,19 @@ pub struct CsvConfig {
     pub enabled: bool,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct NativeTransfersConfig {
     pub enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<Vec<NativeTransferNetworkDetail>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub streams: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub generate_csv: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reorg_safe_distance: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tables: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -84,6 +90,8 @@ pub struct NativeTransferNetworkDetail {
     pub start_block: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_block: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/e2e-tests/src/tests/direct_rpc.rs
+++ b/e2e-tests/src/tests/direct_rpc.rs
@@ -111,11 +111,7 @@ fn build_direct_rpc_config(
             csv: CsvConfig { enabled: true },
             clickhouse: None,
         },
-        native_transfers: NativeTransfersConfig {
-            enabled: false,
-            networks: None,
-            generate_csv: None,
-        },
+        native_transfers: NativeTransfersConfig::default(),
         contracts: vec![ContractConfig {
             name: "ERC20".to_string(),
             details: vec![ContractDetail {

--- a/e2e-tests/src/tests/helpers.rs
+++ b/e2e-tests/src/tests/helpers.rs
@@ -156,8 +156,8 @@ pub fn validate_csv_headers(headers: &[String]) -> Result<()> {
 
 /// Validate format of all fields in parsed rows.
 pub fn validate_row_formats(rows: &[TransferRow]) -> Result<()> {
-    let addr_re = regex::Regex::new(r"^0x[0-9a-f]{40}$").unwrap();
-    let hash_re = regex::Regex::new(r"^0x[0-9a-f]{64}$").unwrap();
+    let addr_re = regex::Regex::new(r"^0x[0-9a-f]{40}$")?;
+    let hash_re = regex::Regex::new(r"^0x[0-9a-f]{64}$")?;
 
     for (i, row) in rows.iter().enumerate() {
         // Address fields

--- a/e2e-tests/src/tests/multi_network.rs
+++ b/e2e-tests/src/tests/multi_network.rs
@@ -268,11 +268,7 @@ fn build_multi_network_config(
             csv: CsvConfig { enabled: true },
             clickhouse: None,
         },
-        native_transfers: NativeTransfersConfig {
-            enabled: false,
-            networks: None,
-            generate_csv: None,
-        },
+        native_transfers: NativeTransfersConfig::default(),
         contracts: vec![
             ContractConfig {
                 name: "RocketPoolETH".to_string(),

--- a/e2e-tests/src/tests/native_transfer.rs
+++ b/e2e-tests/src/tests/native_transfer.rs
@@ -93,8 +93,12 @@ fn native_transfer_csv_no_panic_test(
                     network: "anvil".to_string(),
                     start_block: Some("0".to_string()),
                     end_block: Some(end_block.to_string()),
+                    method: None,
                 }]),
+                streams: None,
                 generate_csv: Some(true),
+                reorg_safe_distance: None,
+                tables: None,
             },
             contracts: vec![ContractConfig {
                 name: "SimpleERC20".to_string(),

--- a/e2e-tests/src/tests/reorg_e2e.rs
+++ b/e2e-tests/src/tests/reorg_e2e.rs
@@ -1860,7 +1860,7 @@ fn reorg_native_transfer_only(
         let recipients: Vec<_> = (300..305u64).map(generate_test_address).collect();
         for (i, r) in recipients.iter().enumerate() {
             let amount = U256::from((i as u64 + 1) * 1_000_000_000u64); // wei
-            context.anvil.send_native_eth(r, amount).await?;
+            context.anvil.send_eth_transfer(r, amount).await?;
             context.anvil.mine_block().await?;
         }
 
@@ -1886,7 +1886,7 @@ fn reorg_native_transfer_only(
 
         // Confirm the poller is live by sending one more NT and waiting for it.
         let live_rcpt = generate_test_address(311);
-        context.anvil.send_native_eth(&live_rcpt, U256::from(5_000_000_000u64)).await?;
+        context.anvil.send_eth_transfer(&live_rcpt, U256::from(5_000_000_000u64)).await?;
         context.anvil.mine_block().await?;
         let live_count = wait_for_pg_count(&conn_str, nt_table, pre_count + 1, 20).await?;
         info!("After live NT: {} rows", live_count);
@@ -1976,7 +1976,7 @@ fn reorg_native_transfer_and_contracts(
         let nt_recipients: Vec<_> = (500..504u64).map(generate_test_address).collect();
         for (i, r) in nt_recipients.iter().enumerate() {
             let amount = U256::from((i as u64 + 1) * 1_000_000_000u64);
-            context.anvil.send_native_eth(r, amount).await?;
+            context.anvil.send_eth_transfer(r, amount).await?;
             context.anvil.mine_block().await?;
         }
 
@@ -2018,7 +2018,7 @@ fn reorg_native_transfer_and_contracts(
             .await?;
         context.anvil.mine_block().await?;
         let live_nt_rcpt = generate_test_address(510);
-        context.anvil.send_native_eth(&live_nt_rcpt, U256::from(8_000_000_000u64)).await?;
+        context.anvil.send_eth_transfer(&live_nt_rcpt, U256::from(8_000_000_000u64)).await?;
         context.anvil.mine_block().await?;
         let live_nt = wait_for_pg_count(&conn_str, nt_table, pre_nt + 1, 20).await?;
         let live_erc20 = wait_for_pg_count(&conn_str, erc20_table, pre_erc20 + 1, 20).await?;

--- a/e2e-tests/src/tests/reorg_e2e.rs
+++ b/e2e-tests/src/tests/reorg_e2e.rs
@@ -1744,7 +1744,23 @@ fn create_mixed_reorg_config(
             end_block: None,
             method: None,
         }]),
-        streams: None,
+        // Attach the webhook to NT too so reorgs detected first by the NT
+        // fetch path (before the contract fetcher polls) still reach the
+        // webhook. stream_reorg uses force_send_network_wide, so the
+        // __rindexer_reorg payload fires on every configured stream on the
+        // network — but only from the StreamsClients the coordinator holds
+        // for the detecting path. Wiring both ensures the test sees both
+        // event types regardless of which path detects the reorg first.
+        streams: Some(serde_json::json!({
+            "webhooks": [{
+                "endpoint": webhook_endpoint,
+                "shared_secret": "test-secret",
+                "networks": ["polygon"],
+                "events": [
+                    { "event_name": "NativeTransfer" }
+                ]
+            }]
+        })),
         reorg_safe_distance: Some(serde_json::json!(false)),
         tables: None,
     };

--- a/e2e-tests/src/tests/reorg_e2e.rs
+++ b/e2e-tests/src/tests/reorg_e2e.rs
@@ -1687,7 +1687,7 @@ fn create_native_transfer_reorg_config(
     config.contracts = vec![];
     config.native_transfers = crate::test_suite::NativeTransfersConfig {
         enabled: true,
-        networks: Some(vec![crate::test_suite::NativeTransferDetail {
+        networks: Some(vec![crate::test_suite::NativeTransferNetworkDetail {
             network: "polygon".to_string(),
             start_block: Some("0".to_string()),
             end_block: None,
@@ -1703,6 +1703,7 @@ fn create_native_transfer_reorg_config(
                 ]
             }]
         })),
+        generate_csv: None,
         reorg_safe_distance: Some(serde_json::json!(false)),
         tables: None,
     };
@@ -1738,7 +1739,7 @@ fn create_mixed_reorg_config(
 
     config.native_transfers = crate::test_suite::NativeTransfersConfig {
         enabled: true,
-        networks: Some(vec![crate::test_suite::NativeTransferDetail {
+        networks: Some(vec![crate::test_suite::NativeTransferNetworkDetail {
             network: "polygon".to_string(),
             start_block: Some("0".to_string()),
             end_block: None,
@@ -1749,6 +1750,7 @@ fn create_mixed_reorg_config(
         // contract webhook receives the payload regardless of which pipeline
         // detected the reorg first.
         streams: None,
+        generate_csv: None,
         reorg_safe_distance: Some(serde_json::json!(false)),
         tables: None,
     };

--- a/e2e-tests/src/tests/reorg_e2e.rs
+++ b/e2e-tests/src/tests/reorg_e2e.rs
@@ -1744,23 +1744,11 @@ fn create_mixed_reorg_config(
             end_block: None,
             method: None,
         }]),
-        // Attach the webhook to NT too so reorgs detected first by the NT
-        // fetch path (before the contract fetcher polls) still reach the
-        // webhook. stream_reorg uses force_send_network_wide, so the
-        // __rindexer_reorg payload fires on every configured stream on the
-        // network — but only from the StreamsClients the coordinator holds
-        // for the detecting path. Wiring both ensures the test sees both
-        // event types regardless of which path detects the reorg first.
-        streams: Some(serde_json::json!({
-            "webhooks": [{
-                "endpoint": webhook_endpoint,
-                "shared_secret": "test-secret",
-                "networks": ["polygon"],
-                "events": [
-                    { "event_name": "NativeTransfer" }
-                ]
-            }]
-        })),
+        // No NT-side webhook: the coordinator fans `__rindexer_reorg`
+        // notifications across every StreamsClients on the network, so the
+        // contract webhook receives the payload regardless of which pipeline
+        // detected the reorg first.
+        streams: None,
         reorg_safe_distance: Some(serde_json::json!(false)),
         tables: None,
     };

--- a/e2e-tests/src/tests/reorg_e2e.rs
+++ b/e2e-tests/src/tests/reorg_e2e.rs
@@ -97,6 +97,20 @@ impl TestModule for ReorgTests {
             )
             .with_timeout(240)
             .with_chain_id(137),
+            TestDefinition::new(
+                "test_reorg_native_transfer_only",
+                "Reorg: native-transfer-only network rollback + webhook notification",
+                reorg_native_transfer_only,
+            )
+            .with_timeout(180)
+            .with_chain_id(137),
+            TestDefinition::new(
+                "test_reorg_native_transfer_and_contracts",
+                "Reorg: native transfers + contract events on same network rollback together",
+                reorg_native_transfer_and_contracts,
+            )
+            .with_timeout(240)
+            .with_chain_id(137),
         ]
     }
 }
@@ -1642,6 +1656,413 @@ fn reorg_webhook_stream_notification(
         assert_no_pg_duplicates(&conn_str, table).await?;
 
         info!("Reorg Webhook Stream Notification Test PASSED");
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Native-transfer reorg helpers
+// ---------------------------------------------------------------------------
+
+/// Build a reorg-aware config with ONLY native_transfers enabled (no contracts).
+/// Wires a webhook stream onto the native_transfers block so the reorg
+/// notification can be asserted without any contract event config.
+fn create_native_transfer_reorg_config(
+    context: &TestContext,
+    webhook_endpoint: &str,
+) -> crate::test_suite::RindexerConfig {
+    let mut config = crate::rindexer_client::RindexerInstance::create_minimal_config(
+        &context.anvil.rpc_url,
+        context.health_port,
+    );
+    config.name = "reorg_nt_test".to_string();
+    config.networks[0].name = "polygon".to_string();
+    config.networks[0].chain_id = 137;
+    config.networks[0].reorg_handling =
+        Some(crate::test_suite::ReorgHandlingConfig { enabled: true, window_size: None });
+
+    config.storage.postgres = Some(crate::test_suite::PostgresConfig { enabled: true });
+    config.storage.csv.enabled = false;
+
+    config.contracts = vec![];
+    config.native_transfers = crate::test_suite::NativeTransfersConfig {
+        enabled: true,
+        networks: Some(vec![crate::test_suite::NativeTransferDetail {
+            network: "polygon".to_string(),
+            start_block: Some("0".to_string()),
+            end_block: None,
+            method: None,
+        }]),
+        streams: Some(serde_json::json!({
+            "webhooks": [{
+                "endpoint": webhook_endpoint,
+                "shared_secret": "test-secret",
+                "networks": ["polygon"],
+                "events": [
+                    { "event_name": "NativeTransfer" }
+                ]
+            }]
+        })),
+        reorg_safe_distance: Some(serde_json::json!(false)),
+        tables: None,
+    };
+    config
+}
+
+/// Build a reorg-aware config with BOTH a SimpleERC20 contract AND
+/// native_transfers enabled on the same network. A webhook on the contract
+/// receives __rindexer_reorg notifications (they are force-sent network-wide
+/// regardless of the configured events list).
+fn create_mixed_reorg_config(
+    context: &TestContext,
+    contract_address: &str,
+    webhook_endpoint: &str,
+) -> crate::test_suite::RindexerConfig {
+    let mut config = create_reorg_config(context, contract_address);
+    config.name = "reorg_mixed_test".to_string();
+    config.storage.postgres = Some(crate::test_suite::PostgresConfig { enabled: true });
+    config.storage.csv.enabled = false;
+
+    if let Some(contract) = config.contracts.get_mut(0) {
+        contract.streams = Some(serde_json::json!({
+            "webhooks": [{
+                "endpoint": webhook_endpoint,
+                "shared_secret": "test-secret",
+                "networks": ["polygon"],
+                "events": [
+                    { "event_name": "Transfer" }
+                ]
+            }]
+        }));
+    }
+
+    config.native_transfers = crate::test_suite::NativeTransfersConfig {
+        enabled: true,
+        networks: Some(vec![crate::test_suite::NativeTransferDetail {
+            network: "polygon".to_string(),
+            start_block: Some("0".to_string()),
+            end_block: None,
+            method: None,
+        }]),
+        streams: None,
+        reorg_safe_distance: Some(serde_json::json!(false)),
+        tables: None,
+    };
+    config
+}
+
+/// Spawn a collector that reads HTTP POST bodies on a random TCP port.
+/// Returns the port and a shared Vec that accumulates received bodies.
+async fn spawn_webhook_collector() -> Result<(u16, std::sync::Arc<tokio::sync::Mutex<Vec<String>>>)>
+{
+    let port = crate::docker::allocate_free_port()?;
+    let bodies: std::sync::Arc<tokio::sync::Mutex<Vec<String>>> =
+        std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port))
+        .await
+        .context("Failed to bind webhook listener")?;
+
+    let bodies_clone = bodies.clone();
+    tokio::spawn(async move {
+        loop {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let bodies = bodies_clone.clone();
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = vec![0u8; 65536];
+                    if let Ok(n) = stream.read(&mut buf).await {
+                        let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                        if let Some(body_start) = request.find("\r\n\r\n") {
+                            let body = request[body_start + 4..].to_string();
+                            if !body.is_empty() {
+                                bodies.lock().await.push(body);
+                            }
+                        }
+                        let response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+                        let _ = stream.write_all(response.as_bytes()).await;
+                    }
+                });
+            }
+        }
+    });
+
+    info!("Webhook listener started on port {}", port);
+    Ok((port, bodies))
+}
+
+/// Scan collected webhook bodies for a __rindexer_reorg payload and return
+/// the parsed `affected_events` array from its first `event_data` entry.
+fn extract_reorg_affected_events(bodies: &[String]) -> Result<Vec<serde_json::Value>> {
+    for body in bodies {
+        if !body.contains("__rindexer_reorg") {
+            continue;
+        }
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else { continue };
+        if json.get("event_name").and_then(|v| v.as_str()) != Some("__rindexer_reorg") {
+            continue;
+        }
+        let Some(first) =
+            json.get("event_data").and_then(|v| v.as_array()).and_then(|arr| arr.first())
+        else {
+            continue;
+        };
+        let Some(affected) = first.get("affected_events").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        return Ok(affected.clone());
+    }
+    Err(anyhow::anyhow!(
+        "No __rindexer_reorg payload with affected_events found in {} webhook bodies",
+        bodies.len()
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: Reorg on a native-transfer-only network
+//
+// Indexer is configured with ONLY native_transfers (no contracts). After
+// indexing some native ETH transfers, trigger a reorg and assert:
+//   - PG rows in <name>_evm_traces.native_transfer for the reorg range
+//     are rolled back (no duplicates).
+//   - Webhook receives __rindexer_reorg with `affected_events` containing
+//     an entry with event="NativeTransfer".
+// ---------------------------------------------------------------------------
+fn reorg_native_transfer_only(
+    context: &mut TestContext,
+) -> Pin<Box<dyn Future<Output = Result<()>> + '_>> {
+    Box::pin(async move {
+        info!("Running Reorg Native-Transfer-Only Test");
+
+        let (container_name, pg_port) = match crate::docker::start_postgres_container().await {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(crate::tests::test_runner::SkipTest(format!(
+                    "Docker not available: {}",
+                    e
+                ))
+                .into());
+            }
+        };
+        context.register_container(container_name);
+        crate::docker::wait_for_postgres_ready(pg_port, 30).await?;
+
+        let (webhook_port, bodies) = spawn_webhook_collector().await?;
+        let webhook_endpoint = format!("http://127.0.0.1:{}/webhook", webhook_port);
+
+        // Produce some native ETH transfers on Anvil before starting the indexer.
+        let recipients: Vec<_> = (300..305u64).map(generate_test_address).collect();
+        for (i, r) in recipients.iter().enumerate() {
+            let amount = U256::from((i as u64 + 1) * 1_000_000_000u64); // wei
+            context.anvil.send_native_eth(r, amount).await?;
+            context.anvil.mine_block().await?;
+        }
+
+        let config = create_native_transfer_reorg_config(context, &webhook_endpoint);
+        start_indexer_with_pg(context, config, pg_port).await?;
+
+        let conn_str = format!(
+            "host=localhost port={} user=postgres password=postgres dbname=postgres",
+            pg_port
+        );
+        let nt_table = "reorg_nt_test_evm_traces.native_transfer";
+
+        // Wait for the NT rows to land in PG.
+        let pre_count = wait_for_pg_count(&conn_str, nt_table, recipients.len() as i64, 30).await?;
+        info!("Pre-reorg native_transfer rows: {}", pre_count);
+        if pre_count < recipients.len() as i64 {
+            return Err(anyhow::anyhow!(
+                "Expected at least {} native_transfer rows, got {}",
+                recipients.len(),
+                pre_count
+            ));
+        }
+
+        // Confirm the poller is live by sending one more NT and waiting for it.
+        let live_rcpt = generate_test_address(311);
+        context.anvil.send_native_eth(&live_rcpt, U256::from(5_000_000_000u64)).await?;
+        context.anvil.mine_block().await?;
+        let live_count = wait_for_pg_count(&conn_str, nt_table, pre_count + 1, 20).await?;
+        info!("After live NT: {} rows", live_count);
+
+        bodies.lock().await.clear();
+
+        // Trigger a reorg of depth 2.
+        context.anvil.trigger_reorg(2).await?;
+        context.anvil.mine_block().await?;
+
+        if let Some(r) = &context.rindexer {
+            r.wait_for_reorg_recovery(60).await?;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+        // Assertion 1: no duplicate tx_hashes in the native_transfer table.
+        assert_no_pg_duplicates(&conn_str, nt_table).await?;
+
+        // Assertion 2: webhook received __rindexer_reorg with a NativeTransfer entry.
+        let collected = bodies.lock().await.clone();
+        info!("Webhook received {} payloads", collected.len());
+        let affected_events = extract_reorg_affected_events(&collected)?;
+        let nt_entry = affected_events
+            .iter()
+            .find(|e| e.get("event").and_then(|v| v.as_str()) == Some("NativeTransfer"));
+        let nt_entry = nt_entry.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Reorg payload missing a NativeTransfer entry. affected_events={:?}",
+                affected_events
+            )
+        })?;
+        let indexer_name = nt_entry.get("indexer").and_then(|v| v.as_str());
+        if indexer_name != Some("reorg_nt_test") {
+            return Err(anyhow::anyhow!(
+                "Expected indexer=reorg_nt_test in NativeTransfer entry, got {:?}",
+                indexer_name
+            ));
+        }
+
+        info!("Reorg Native-Transfer-Only Test PASSED");
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Test 14: Reorg over a mixed NT + contract-event network
+//
+// Indexer has both native_transfers AND a SimpleERC20 contract on the same
+// network. After indexing both kinds of rows, trigger a reorg and assert:
+//   - PG rows in <name>_evm_traces.native_transfer AND
+//     <name>_simple_erc_20.transfer are rolled back consistently (no dupes).
+//   - Webhook receives __rindexer_reorg with `affected_events` containing
+//     entries for BOTH event="NativeTransfer" AND event="Transfer".
+// ---------------------------------------------------------------------------
+fn reorg_native_transfer_and_contracts(
+    context: &mut TestContext,
+) -> Pin<Box<dyn Future<Output = Result<()>> + '_>> {
+    Box::pin(async move {
+        info!("Running Reorg Native-Transfer + Contracts Test");
+
+        let (container_name, pg_port) = match crate::docker::start_postgres_container().await {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(crate::tests::test_runner::SkipTest(format!(
+                    "Docker not available: {}",
+                    e
+                ))
+                .into());
+            }
+        };
+        context.register_container(container_name);
+        crate::docker::wait_for_postgres_ready(pg_port, 30).await?;
+
+        let (webhook_port, bodies) = spawn_webhook_collector().await?;
+        let webhook_endpoint = format!("http://127.0.0.1:{}/webhook", webhook_port);
+
+        let contract_address = context.deploy_test_contract().await?;
+
+        // Interleave ERC20 transfers with native ETH transfers so the reorg
+        // range touches both tables.
+        let erc20_amounts = [1000u64, 2000, 3000, 4000];
+        let erc20_recipients: Vec<_> = (400..404u64).map(generate_test_address).collect();
+        for (r, a) in erc20_recipients.iter().zip(erc20_amounts.iter()) {
+            context.anvil.send_transfer(&contract_address, r, U256::from(*a)).await?;
+            context.anvil.mine_block().await?;
+        }
+        let nt_recipients: Vec<_> = (500..504u64).map(generate_test_address).collect();
+        for (i, r) in nt_recipients.iter().enumerate() {
+            let amount = U256::from((i as u64 + 1) * 1_000_000_000u64);
+            context.anvil.send_native_eth(r, amount).await?;
+            context.anvil.mine_block().await?;
+        }
+
+        let config = create_mixed_reorg_config(context, &contract_address, &webhook_endpoint);
+        start_indexer_with_pg(context, config, pg_port).await?;
+
+        let conn_str = format!(
+            "host=localhost port={} user=postgres password=postgres dbname=postgres",
+            pg_port
+        );
+        let nt_table = "reorg_mixed_test_evm_traces.native_transfer";
+        let erc20_table = "reorg_mixed_test_simple_erc_20.transfer";
+
+        // Wait for both tables to populate.
+        let pre_nt = wait_for_pg_count(&conn_str, nt_table, nt_recipients.len() as i64, 30).await?;
+        let pre_erc20 =
+            wait_for_pg_count(&conn_str, erc20_table, erc20_recipients.len() as i64, 30).await?;
+        info!("Pre-reorg rows: NT={}, ERC20={}", pre_nt, pre_erc20);
+        if pre_nt < nt_recipients.len() as i64 {
+            return Err(anyhow::anyhow!(
+                "Expected >= {} native_transfer rows pre-reorg, got {}",
+                nt_recipients.len(),
+                pre_nt
+            ));
+        }
+        if pre_erc20 < erc20_recipients.len() as i64 {
+            return Err(anyhow::anyhow!(
+                "Expected >= {} ERC20 Transfer rows pre-reorg, got {}",
+                erc20_recipients.len(),
+                pre_erc20
+            ));
+        }
+
+        // Keep the poller warm: fire one of each, mine a block, wait for PG.
+        let live_erc20_rcpt = generate_test_address(410);
+        context
+            .anvil
+            .send_transfer(&contract_address, &live_erc20_rcpt, U256::from(7777u64))
+            .await?;
+        context.anvil.mine_block().await?;
+        let live_nt_rcpt = generate_test_address(510);
+        context.anvil.send_native_eth(&live_nt_rcpt, U256::from(8_000_000_000u64)).await?;
+        context.anvil.mine_block().await?;
+        let live_nt = wait_for_pg_count(&conn_str, nt_table, pre_nt + 1, 20).await?;
+        let live_erc20 = wait_for_pg_count(&conn_str, erc20_table, pre_erc20 + 1, 20).await?;
+        info!("After live txs: NT={}, ERC20={}", live_nt, live_erc20);
+
+        bodies.lock().await.clear();
+
+        // Trigger a reorg of depth 2 — covers the last live txs on both tables.
+        context.anvil.trigger_reorg(2).await?;
+        context.anvil.mine_block().await?;
+
+        if let Some(r) = &context.rindexer {
+            r.wait_for_reorg_recovery(60).await?;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+        // Assertion 1: no duplicates in either table after rollback + resync.
+        assert_no_pg_duplicates(&conn_str, nt_table).await?;
+        assert_no_pg_duplicates(&conn_str, erc20_table).await?;
+
+        // Assertion 2: webhook received __rindexer_reorg mentioning BOTH events.
+        let collected = bodies.lock().await.clone();
+        info!("Webhook received {} payloads", collected.len());
+
+        // Merge affected_events across all reorg payloads (multiple reorg
+        // notifications may be emitted if processing re-enters the detector).
+        let mut merged: Vec<serde_json::Value> = Vec::new();
+        for body in &collected {
+            if let Ok(events) = extract_reorg_affected_events(std::slice::from_ref(body)) {
+                merged.extend(events);
+            }
+        }
+
+        let has_nt = merged
+            .iter()
+            .any(|e| e.get("event").and_then(|v| v.as_str()) == Some("NativeTransfer"));
+        let has_transfer =
+            merged.iter().any(|e| e.get("event").and_then(|v| v.as_str()) == Some("Transfer"));
+
+        if !has_nt || !has_transfer {
+            return Err(anyhow::anyhow!(
+                "Expected reorg payloads to cover both NativeTransfer and Transfer. \
+                 has_nt={}, has_transfer={}, affected_events={:?}",
+                has_nt,
+                has_transfer,
+                merged
+            ));
+        }
+
+        info!("Reorg Native-Transfer + Contracts Test PASSED");
         Ok(())
     })
 }

--- a/examples/clickhouse_factory_indexing/src/main.rs
+++ b/examples/clickhouse_factory_indexing/src/main.rs
@@ -53,7 +53,7 @@ async fn main() {
                 indexing_details: if enable_indexer {
                     Some(IndexingDetails {
                         registry: register_all_handlers(&manifest_path).await,
-                        trace_registry: TraceCallbackRegistry { events: vec![] },
+                        trace_registry: TraceCallbackRegistry { events: vec![], on_reorg: vec![] },
                         event_stream: None,
                     })
                 } else {

--- a/examples/rindexer_factory_indexing/src/main.rs
+++ b/examples/rindexer_factory_indexing/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
                 indexing_details: if enable_indexer {
                     Some(IndexingDetails {
                         registry: register_all_handlers(&manifest_path).await,
-                        trace_registry: TraceCallbackRegistry { events: vec![] },
+                        trace_registry: TraceCallbackRegistry { events: vec![], on_reorg: vec![] },
                         event_stream: None,
                     })
                 } else {

--- a/examples/rindexer_rust_playground/src/main.rs
+++ b/examples/rindexer_rust_playground/src/main.rs
@@ -56,7 +56,7 @@ async fn main() {
                 indexing_details: if enable_indexer {
                     Some(IndexingDetails {
                         registry: register_all_handlers(&manifest_path).await,
-                        trace_registry: TraceCallbackRegistry { events: vec![] },
+                        trace_registry: TraceCallbackRegistry { events: vec![], on_reorg: vec![] },
                         event_stream: None,
                     })
                 } else {

--- a/examples/rust_clickhouse/src/main.rs
+++ b/examples/rust_clickhouse/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
                 indexing_details: if enable_indexer {
                     Some(IndexingDetails {
                         registry: register_all_handlers(&manifest_path).await,
-                        trace_registry: TraceCallbackRegistry { events: vec![] },
+                        trace_registry: TraceCallbackRegistry { events: vec![], on_reorg: vec![] },
                         event_stream: None,
                     })
                 } else {


### PR DESCRIPTION
## Summary

Brings native-transfer indexing to feature parity with contract-event indexing for reorg handling. Native-transfer-only networks now get their own `ReorgCoordinator`, mixed contract+NT configs share a single coordinator so a reorg detected by either pipeline rolls back both, and downstream stream/callback integrations are wired through the same path.

## What's new

- **Native-transfer-only reorg detection** — networks that only index native transfers build a `ReorgCoordinator` and detect tip reorgs on every poll (not just on tip advance).
- **`native_transfers.tables`** — new config field mirroring `contracts[].tables`. Aggregation tables keyed on `NativeTransfer` events participate in reorg rollback. Column types are resolved against the `NativeTransfer` ABI.
- **`on_reorg` for native transfers** — `TraceCallbackRegistry::register_on_reorg` matches the `EventCallbackRegistry` API, so no-code and rust projects can hook reorg events for NT pipelines.
- **Enriched `__rindexer_reorg` payload** — adds `events_deleted` (total) and `affected_events` (`{indexer, contract, event, schema, table, rows_deleted}` per source table). Additive JSON, existing consumers unaffected.
- **Stream fan-out across the network** — `__rindexer_reorg` is dispatched in parallel to every configured stream on the network, regardless of which pipeline detected the reorg.

## Fixes

- NT cursor rewind off-by-one and short-read path hardening.
- Live-indexing detection now considers native-transfer-only networks.
- Historical-only pass no longer double-spawns native-transfer tasks.
- No-code trace callback short-circuits when a batch has no native transfers (prevents panic on empty-block batches).
- `native_transfers.tables` column types resolve against the `NativeTransfer` ABI in no-code mode.

## Tests

- Unit tests for `TraceCallbackRegistry` reorg registration and reorg task types.
- Integration coverage for reorg notifications across every stream type.
- E2E coverage for native-transfer-only reorgs and mixed contract+NT reorgs, plus webhook wiring against `native_transfers` in the mixed reorg test.

## Docs

- Changelog entries under Fixes and Features.
- Rust-project deep-dive `indexers.mdx` updated for the `on_reorg` wiring.