### PR TITLE
fix(block-timestamp): retry RPC fetch, refuse NULL writes, NOT NULL on schema

### DIFF
--- a/core/src/database/clickhouse/generate.rs
+++ b/core/src/database/clickhouse/generate.rs
@@ -111,7 +111,7 @@ fn generate_event_table_clickhouse(abi_inputs: &[EventInfo], schema_name: &str) 
                     {}
                     tx_hash FixedString(66),
                     block_number UInt64,
-                    block_timestamp Nullable(DateTime('UTC')),
+                    block_timestamp DateTime('UTC'),
                     block_hash FixedString(66),
                     network String,
                     tx_index UInt64,

--- a/core/src/database/generate.rs
+++ b/core/src/database/generate.rs
@@ -39,7 +39,7 @@ fn generate_event_table_sql_with_comments(
                     {event_columns} \
                     tx_hash CHAR(66) NOT NULL, \
                     block_number NUMERIC NOT NULL, \
-                    block_timestamp TIMESTAMPTZ, \
+                    block_timestamp TIMESTAMPTZ NOT NULL, \
                     block_hash CHAR(66) NOT NULL, \
                     network VARCHAR(50) NOT NULL, \
                     tx_index NUMERIC NOT NULL, \

--- a/core/src/indexer/last_synced.rs
+++ b/core/src/indexer/last_synced.rs
@@ -249,6 +249,9 @@ async fn update_last_synced_block_number_for_file(
         if let Some(last_block_value) = last_block { to_block > last_block_value } else { true };
 
     if last_block.is_none() || to_block_higher_then_last_block {
+        if let Some(parent) = Path::new(&file_path).parent() {
+            fs::create_dir_all(parent).await?;
+        }
         let temp_file_path = format!("{file_path}.tmp");
 
         let mut file = File::create(&temp_file_path).await?;

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -1,6 +1,7 @@
 use alloy::{
     dyn_abi::DynSolValue,
     json_abi::{Event, JsonAbi},
+    primitives::U256,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -417,6 +418,39 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
             // table operations data: (log_params, network, tx_metadata)
             let mut table_events_data: Vec<(Vec<LogParam>, String, TxMetadata)> = Vec::new();
 
+            // Hydrate block_timestamp from the BLOCK_TIMESTAMP_CACHE for events
+            // missing it on tx_information. RPC providers that omit `blockTimestamp`
+            // in eth_getLogs leave tx_information.block_timestamp = None — without
+            // this hydration, the row would emit DateTimeNullable(None), which on
+            // a NOT NULL schema fails the insert and kicks the outer retry loop.
+            // Snapshot is taken once before the sync filter_map, so lookups stay sync.
+            let block_ts_snapshot: std::collections::HashMap<(String, u64), u64> = {
+                let pairs: Vec<(String, u64)> = match &results {
+                    CallbackResult::Event(events) => events
+                        .iter()
+                        .filter(|r| r.tx_information.block_timestamp.is_none())
+                        .map(|r| {
+                            (r.tx_information.network.to_string(), r.tx_information.block_number)
+                        })
+                        .collect(),
+                    CallbackResult::Trace(events) => events
+                        .iter()
+                        .filter_map(|r| match r {
+                            TraceResult::NativeTransfer { tx_information, .. } => {
+                                tx_information.block_timestamp.is_none().then(|| {
+                                    (
+                                        tx_information.network.to_string(),
+                                        tx_information.block_number,
+                                    )
+                                })
+                            }
+                            TraceResult::Block { .. } => None,
+                        })
+                        .collect(),
+                };
+                crate::indexer::tables::snapshot_cached_block_timestamps(&pairs).await
+            };
+
             let owned_results = match &results {
                 CallbackResult::Event(events) => events
                     .iter()
@@ -426,9 +460,14 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
                         let address = result.tx_information.address;
                         let transaction_hash = result.tx_information.transaction_hash;
                         let block_number = result.tx_information.block_number;
-                        let block_timestamp = result
-                            .tx_information
-                            .block_timestamp
+                        // Hydrate from snapshot when tx_information lacks the timestamp.
+                        let block_ts_u256 = result.tx_information.block_timestamp.or_else(|| {
+                            block_ts_snapshot
+                                .get(&(result.tx_information.network.to_string(), block_number))
+                                .copied()
+                                .map(U256::from)
+                        });
+                        let block_timestamp = block_ts_u256
                             .and_then(|ts| chrono::DateTime::from_timestamp(ts.to(), 0));
                         let block_hash = result.tx_information.block_hash;
                         let network = result.tx_information.network.to_string();
@@ -489,11 +528,16 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
                                 let address = tx_information.address;
                                 let transaction_hash = tx_information.transaction_hash;
                                 let block_number = tx_information.block_number;
-                                let block_timestamp = tx_information
-                                    .block_timestamp
+                                let network = tx_information.network.to_string();
+                                let block_ts_u256 = tx_information.block_timestamp.or_else(|| {
+                                    block_ts_snapshot
+                                        .get(&(network.clone(), block_number))
+                                        .copied()
+                                        .map(U256::from)
+                                });
+                                let block_timestamp = block_ts_u256
                                     .and_then(|ts| chrono::DateTime::from_timestamp(ts.to(), 0));
                                 let block_hash = tx_information.block_hash;
-                                let network = tx_information.network.to_string();
                                 let chain_id = tx_information.chain_id;
                                 let transaction_index = tx_information.transaction_index;
                                 let log_index = tx_information.log_index;

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -1430,6 +1430,33 @@ async fn get_cached_block_timestamp(network: &str, block_number: u64) -> Option<
     cache.get(&(network.to_string(), block_number)).copied()
 }
 
+/// Predicate: would the column-write path silently emit Null for a critical
+/// block_timestamp column? True when the row is missing the value AND no DDL
+/// default is configured. Narrow scope — only `block_timestamp` /
+/// `rindexer_block_timestamp`; other columns retain Null-fallback for legitimate
+/// optional-value cases (failed view calls, optional enrichment).
+fn block_ts_guard_trips(
+    column_name: &str,
+    column_default: Option<&String>,
+    row_has_value: bool,
+) -> bool {
+    if row_has_value || column_default.is_some() {
+        return false;
+    }
+    column_name == "block_timestamp" || column_name == "rindexer_block_timestamp"
+}
+
+/// Best-effort block-number hint for guard-trip error messages. Prefers the
+/// canonical `rindexer_block_number` injected key, falls back to user-aliased
+/// `block_number`, returns `<unknown>` when neither is present.
+fn extract_block_num_hint(columns: &HashMap<String, EthereumSqlTypeWrapper>) -> String {
+    columns
+        .get("rindexer_block_number")
+        .or_else(|| columns.get("block_number"))
+        .map(|v| format!("{:?}", v))
+        .unwrap_or_else(|| "<unknown>".to_string())
+}
+
 /// Transaction metadata available for table value references.
 #[derive(Clone, Debug)]
 pub struct TxMetadata {
@@ -3974,19 +4001,13 @@ async fn execute_postgres_operation(
                 // wrapper would surface as block_timestamp=0 on a NOT NULL
                 // column, corrupting downstream partition routing. Halt the
                 // batch so the outer retry loop re-attempts.
-                if column.name == "block_timestamp" || column.name == "rindexer_block_timestamp" {
-                    // Try the canonical injected key first (rindexer_block_number per
-                    // injected_columns::BLOCK_NUMBER), fall back to user-aliased.
-                    let block_num_hint = row
-                        .columns
-                        .get("rindexer_block_number")
-                        .or_else(|| row.columns.get("block_number"))
-                        .map(|v| format!("{:?}", v))
-                        .unwrap_or_else(|| "<unknown>".to_string());
+                if block_ts_guard_trips(&column.name, column.default.as_ref(), false) {
                     return Err(format!(
                         "refusing to write {}=NULL for block {} on table {} \
                          (RPC block-header resolution failed; batch will retry)",
-                        column.name, block_num_hint, table_name
+                        column.name,
+                        extract_block_num_hint(&row.columns),
+                        table_name
                     ));
                 }
                 // No value and no default - use NULL
@@ -4156,19 +4177,13 @@ async fn execute_clickhouse_operation(
                 // wrapper would surface as block_timestamp=0 on a NOT NULL
                 // column, corrupting downstream partition routing. Halt the
                 // batch so the outer retry loop re-attempts.
-                if column.name == "block_timestamp" || column.name == "rindexer_block_timestamp" {
-                    // Try the canonical injected key first (rindexer_block_number per
-                    // injected_columns::BLOCK_NUMBER), fall back to user-aliased.
-                    let block_num_hint = row
-                        .columns
-                        .get("rindexer_block_number")
-                        .or_else(|| row.columns.get("block_number"))
-                        .map(|v| format!("{:?}", v))
-                        .unwrap_or_else(|| "<unknown>".to_string());
+                if block_ts_guard_trips(&column.name, column.default.as_ref(), false) {
                     return Err(format!(
                         "refusing to write {}=NULL for block {} on table {} \
                          (RPC block-header resolution failed; batch will retry)",
-                        column.name, block_num_hint, table_name
+                        column.name,
+                        extract_block_num_hint(&row.columns),
+                        table_name
                     ));
                 }
                 // No value and no default - use NULL
@@ -5395,31 +5410,153 @@ mod tests {
     }
 
     // =========================================================================
+    // prefetch_block_timestamps retry path — Layer 1 of the block_timestamp
+    // silent-write fix. Uses MockChainProvider's failure-injection to simulate
+    // transient RPC errors and asserts the retry loop populates the cache
+    // correctly within the budget (3 attempts).
+    // =========================================================================
+
+    fn make_prefetch_block(number: u64, timestamp: u64) -> alloy::network::AnyRpcBlock {
+        use alloy::network::{AnyHeader, AnyRpcBlock, AnyRpcHeader};
+        use alloy::primitives::B256;
+        use alloy::rpc::types::{Block, BlockTransactions};
+        AnyRpcBlock::new(
+            Block::new(
+                AnyRpcHeader::from_sealed(
+                    AnyHeader { number, timestamp, ..Default::default() }.seal(B256::ZERO),
+                ),
+                BlockTransactions::Full(vec![]),
+            )
+            .into(),
+        )
+    }
+
+    fn make_prefetch_tx_metadata(block_number: u64) -> TxMetadata {
+        TxMetadata {
+            block_number,
+            block_timestamp: None,
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::from(0u64),
+            tx_index: 0,
+        }
+    }
+
+    /// Layer 1 retry: 2 transient failures, succeeds on attempt 3.
+    /// Cache must be populated after the retry budget consumes the failures.
+    #[tokio::test]
+    async fn test_prefetch_retries_then_succeeds() {
+        use crate::provider::mock::MockChainProvider;
+        use crate::provider::ChainProvider;
+
+        // Clear any leftover cache from prior tests on this block.
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.remove(&("anvil-retry-1".to_string(), 12345));
+        }
+
+        let mock = MockChainProvider::new(31337)
+            .with_blocks(vec![make_prefetch_block(12345, 1_700_000_000)])
+            .with_block_fetch_failures(2); // fail twice, succeed on 3rd
+
+        let provider: Arc<dyn ChainProvider> = Arc::new(mock);
+        let mut providers: HashMap<String, Arc<dyn ChainProvider>> = HashMap::new();
+        providers.insert("anvil-retry-1".to_string(), Arc::clone(&provider));
+
+        let events_data = vec![(
+            Vec::<LogParam>::new(),
+            "anvil-retry-1".to_string(),
+            make_prefetch_tx_metadata(12345),
+        )];
+
+        prefetch_block_timestamps(&events_data, &providers, true).await;
+
+        let cached = get_cached_block_timestamp("anvil-retry-1", 12345).await;
+        assert_eq!(
+            cached,
+            Some(1_700_000_000),
+            "cache must be populated after retry budget exhausts the injected failures"
+        );
+
+        // Cleanup
+        let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+        cache.remove(&("anvil-retry-1".to_string(), 12345));
+    }
+
+    /// Layer 1 exhaustion: more transient failures than the retry budget. The
+    /// task gives up; cache stays empty for that (network, block); downstream
+    /// guard will then refuse to emit. Must NOT panic / hang.
+    #[tokio::test]
+    async fn test_prefetch_exhausts_budget_leaves_cache_empty() {
+        use crate::provider::mock::MockChainProvider;
+        use crate::provider::ChainProvider;
+
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.remove(&("anvil-retry-2".to_string(), 67890));
+        }
+
+        // 4 failures > MAX_RETRIES (3). The task exhausts the budget on every
+        // attempt and gives up.
+        let mock = MockChainProvider::new(31337)
+            .with_blocks(vec![make_prefetch_block(67890, 1_700_000_001)])
+            .with_block_fetch_failures(4);
+
+        let provider: Arc<dyn ChainProvider> = Arc::new(mock);
+        let mut providers: HashMap<String, Arc<dyn ChainProvider>> = HashMap::new();
+        providers.insert("anvil-retry-2".to_string(), Arc::clone(&provider));
+
+        let events_data = vec![(
+            Vec::<LogParam>::new(),
+            "anvil-retry-2".to_string(),
+            make_prefetch_tx_metadata(67890),
+        )];
+
+        prefetch_block_timestamps(&events_data, &providers, true).await;
+
+        let cached = get_cached_block_timestamp("anvil-retry-2", 67890).await;
+        assert_eq!(cached, None, "cache must remain empty when retry budget is exhausted");
+    }
+
+    /// Layer 1 short-circuit: when needs_timestamp=false, no RPC calls happen.
+    /// The injected failure budget should NOT be consumed.
+    #[tokio::test]
+    async fn test_prefetch_skips_when_not_needed() {
+        use crate::provider::mock::MockChainProvider;
+        use crate::provider::ChainProvider;
+
+        let mock = MockChainProvider::new(31337)
+            .with_blocks(vec![make_prefetch_block(99999, 1_700_000_002)])
+            .with_block_fetch_failures(1);
+        let budget_arc = mock.block_fetch_failures_remaining();
+        assert_eq!(budget_arc, 1, "budget should be 1 before prefetch");
+
+        let provider: Arc<dyn ChainProvider> = Arc::new(mock);
+        let mut providers: HashMap<String, Arc<dyn ChainProvider>> = HashMap::new();
+        providers.insert("anvil-retry-3".to_string(), provider);
+
+        let events_data = vec![(
+            Vec::<LogParam>::new(),
+            "anvil-retry-3".to_string(),
+            make_prefetch_tx_metadata(99999),
+        )];
+
+        // needs_timestamp=false → early return, no RPC calls
+        prefetch_block_timestamps(&events_data, &providers, false).await;
+
+        // Cache stays empty because no fetch happened.
+        let cached = get_cached_block_timestamp("anvil-retry-3", 99999).await;
+        assert_eq!(cached, None);
+    }
+
+    // =========================================================================
     // block_timestamp NULL-write guard
     // =========================================================================
 
-    /// Predicate: does the column-write path refuse this row?
-    /// True when block_timestamp / rindexer_block_timestamp would land as Null.
-    fn block_ts_guard_trips(
-        column_name: &str,
-        column_default: Option<&String>,
-        row_has_value: bool,
-    ) -> bool {
-        if row_has_value || column_default.is_some() {
-            return false;
-        }
-        column_name == "block_timestamp" || column_name == "rindexer_block_timestamp"
-    }
-
-    /// Extracts a debug-formatted block-number hint from a row's columns,
-    /// preferring the canonical injected `rindexer_block_number` key.
-    fn extract_block_num_hint(columns: &HashMap<String, EthereumSqlTypeWrapper>) -> String {
-        columns
-            .get("rindexer_block_number")
-            .or_else(|| columns.get("block_number"))
-            .map(|v| format!("{:?}", v))
-            .unwrap_or_else(|| "<unknown>".to_string())
-    }
+    // block_ts_guard_trips + extract_block_num_hint live in the parent module
+    // (production helpers used by execute_postgres_operation +
+    // execute_clickhouse_operation). Tests below exercise them directly.
 
     #[test]
     fn test_block_ts_guard_trips_on_missing_block_timestamp() {

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -1314,36 +1314,60 @@ async fn prefetch_block_timestamps(
                 // Wait for backoff if rate limited (for free nodes)
                 ADAPTIVE_CONCURRENCY.wait_for_backoff().await;
 
-                match provider_clone
-                    .get_block_by_number_batch_with_size(
-                        &block_numbers_u64,
-                        false,
-                        Some(rpc_batch_size),
-                    )
-                    .await
-                {
-                    Ok(blocks) => {
-                        ADAPTIVE_CONCURRENCY.record_success();
-                        Some((network_clone, blocks))
-                    }
-                    Err(e) => {
-                        let err_str = e.to_string().to_lowercase();
-                        if err_str.contains("429")
-                            || err_str.contains("rate limit")
-                            || err_str.contains("too many")
-                        {
-                            ADAPTIVE_CONCURRENCY.record_rate_limit();
-                        } else {
-                            ADAPTIVE_CONCURRENCY.record_error();
+                // Retry-with-backoff: 3 attempts (100ms / 500ms / 2s) before
+                // giving up. Without retry, transient RPC failures leave the
+                // cache un-populated and downstream writes silently fall back
+                // to block_timestamp=0.
+                const MAX_RETRIES: u32 = 3;
+                let backoffs = [
+                    std::time::Duration::from_millis(100),
+                    std::time::Duration::from_millis(500),
+                    std::time::Duration::from_secs(2),
+                ];
+                let mut attempt: u32 = 0;
+                loop {
+                    match provider_clone
+                        .get_block_by_number_batch_with_size(
+                            &block_numbers_u64,
+                            false,
+                            Some(rpc_batch_size),
+                        )
+                        .await
+                    {
+                        Ok(blocks) => {
+                            ADAPTIVE_CONCURRENCY.record_success();
+                            return Some((network_clone, blocks));
                         }
-                        crate::metrics::definitions::BLOCK_TIMESTAMP_FETCH_FAILURES_TOTAL
-                            .with_label_values(&[&network_clone])
-                            .inc();
-                        tracing::error!(
-                            "Failed to batch fetch block timestamps for {}: {} — downstream writes will retry",
-                            network_clone, e
-                        );
-                        None
+                        Err(e) => {
+                            let err_str = e.to_string().to_lowercase();
+                            let is_rate_limited = err_str.contains("429")
+                                || err_str.contains("rate limit")
+                                || err_str.contains("too many");
+                            if is_rate_limited {
+                                ADAPTIVE_CONCURRENCY.record_rate_limit();
+                            } else {
+                                ADAPTIVE_CONCURRENCY.record_error();
+                            }
+                            crate::metrics::definitions::BLOCK_TIMESTAMP_FETCH_FAILURES_TOTAL
+                                .with_label_values(&[&network_clone])
+                                .inc();
+
+                            if attempt >= MAX_RETRIES {
+                                tracing::error!(
+                                    "Block timestamp fetch failed after {} retries for {} ({} blocks): {} — downstream writes will refuse to emit",
+                                    MAX_RETRIES, network_clone, block_numbers_u64.len(), e
+                                );
+                                return None;
+                            }
+
+                            let backoff = backoffs[attempt as usize];
+                            tracing::warn!(
+                                "Block timestamp fetch attempt {}/{} failed for {} ({} blocks): {} — retrying in {:?}",
+                                attempt + 1, MAX_RETRIES, network_clone, block_numbers_u64.len(), e, backoff,
+                            );
+                            tokio::time::sleep(backoff).await;
+                            attempt += 1;
+                        }
                     }
                 }
             }));
@@ -3941,6 +3965,23 @@ async fn execute_postgres_operation(
             } else if let Some(default) = &column.default {
                 literal_to_wrapper(default, column_type)
             } else {
+                // Refuse to silently emit NULL for block_timestamp. The Null
+                // wrapper would surface as block_timestamp=0 on a NOT NULL
+                // column, corrupting downstream partition routing. Halt the
+                // batch so the outer retry loop re-attempts.
+                if column.name == "block_timestamp" || column.name == "rindexer_block_timestamp" {
+                    let block_num_hint = row
+                        .columns
+                        .get("block_number")
+                        .or_else(|| row.columns.get("rindexer_block_number"))
+                        .map(|v| format!("{:?}", v))
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    return Err(format!(
+                        "refusing to write {}=NULL for block {} on table {} \
+                         (RPC block-header resolution failed; batch will retry)",
+                        column.name, block_num_hint, table_name
+                    ));
+                }
                 // No value and no default - use NULL
                 // This handles cases like failed view calls where we don't have a value
                 EthereumSqlTypeWrapper::Null
@@ -4104,6 +4145,23 @@ async fn execute_clickhouse_operation(
             } else if let Some(default) = &column.default {
                 literal_to_wrapper(default, column_type)
             } else {
+                // Refuse to silently emit NULL for block_timestamp. The Null
+                // wrapper would surface as block_timestamp=0 on a NOT NULL
+                // column, corrupting downstream partition routing. Halt the
+                // batch so the outer retry loop re-attempts.
+                if column.name == "block_timestamp" || column.name == "rindexer_block_timestamp" {
+                    let block_num_hint = row
+                        .columns
+                        .get("block_number")
+                        .or_else(|| row.columns.get("rindexer_block_number"))
+                        .map(|v| format!("{:?}", v))
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    return Err(format!(
+                        "refusing to write {}=NULL for block {} on table {} \
+                         (RPC block-header resolution failed; batch will retry)",
+                        column.name, block_num_hint, table_name
+                    ));
+                }
                 // No value and no default - use NULL
                 // This handles cases like failed view calls where we don't have a value
                 EthereumSqlTypeWrapper::Null
@@ -5325,6 +5383,52 @@ mod tests {
             let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
             cache.remove(&("polygon".to_string(), 77777777));
         }
+    }
+
+    // =========================================================================
+    // block_timestamp NULL-write guard
+    // =========================================================================
+
+    /// Predicate: does the column-write path refuse this row?
+    /// True when block_timestamp / rindexer_block_timestamp would land as Null.
+    fn block_ts_guard_trips(
+        column_name: &str,
+        column_default: Option<&String>,
+        row_has_value: bool,
+    ) -> bool {
+        if row_has_value || column_default.is_some() {
+            return false;
+        }
+        column_name == "block_timestamp" || column_name == "rindexer_block_timestamp"
+    }
+
+    #[test]
+    fn test_block_ts_guard_trips_on_missing_block_timestamp() {
+        assert!(block_ts_guard_trips("block_timestamp", None, false));
+    }
+
+    #[test]
+    fn test_block_ts_guard_trips_on_missing_rindexer_block_timestamp() {
+        assert!(block_ts_guard_trips("rindexer_block_timestamp", None, false));
+    }
+
+    #[test]
+    fn test_block_ts_guard_passes_when_value_present() {
+        assert!(!block_ts_guard_trips("block_timestamp", None, true));
+    }
+
+    #[test]
+    fn test_block_ts_guard_passes_when_column_has_default() {
+        let default = "0".to_string();
+        assert!(!block_ts_guard_trips("block_timestamp", Some(&default), false));
+    }
+
+    #[test]
+    fn test_block_ts_guard_does_not_apply_to_other_columns() {
+        // Non-block_timestamp columns retain Null-fallback (failed view calls,
+        // optional enrichment).
+        assert!(!block_ts_guard_trips("some_view_call_result", None, false));
+        assert!(!block_ts_guard_trips("title", None, false));
     }
 
     // =========================================================================

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -1339,6 +1339,11 @@ async fn prefetch_block_timestamps(
                             return Some((network_clone, blocks));
                         }
                         Err(e) => {
+                            // ADAPTIVE_CONCURRENCY records every attempt's signal so
+                            // global concurrency adapts to transient noise. The metric
+                            // counter only fires once we exhaust the retry budget,
+                            // preserving the "permanent failure" semantic operators
+                            // alert on.
                             let err_str = e.to_string().to_lowercase();
                             let is_rate_limited = err_str.contains("429")
                                 || err_str.contains("rate limit")
@@ -1348,11 +1353,11 @@ async fn prefetch_block_timestamps(
                             } else {
                                 ADAPTIVE_CONCURRENCY.record_error();
                             }
-                            crate::metrics::definitions::BLOCK_TIMESTAMP_FETCH_FAILURES_TOTAL
-                                .with_label_values(&[&network_clone])
-                                .inc();
 
                             if attempt >= MAX_RETRIES {
+                                crate::metrics::definitions::BLOCK_TIMESTAMP_FETCH_FAILURES_TOTAL
+                                    .with_label_values(&[&network_clone])
+                                    .inc();
                                 tracing::error!(
                                     "Block timestamp fetch failed after {} retries for {} ({} blocks): {} — downstream writes will refuse to emit",
                                     MAX_RETRIES, network_clone, block_numbers_u64.len(), e
@@ -1361,7 +1366,7 @@ async fn prefetch_block_timestamps(
                             }
 
                             let backoff = backoffs[attempt as usize];
-                            tracing::warn!(
+                            tracing::debug!(
                                 "Block timestamp fetch attempt {}/{} failed for {} ({} blocks): {} — retrying in {:?}",
                                 attempt + 1, MAX_RETRIES, network_clone, block_numbers_u64.len(), e, backoff,
                             );
@@ -3970,10 +3975,12 @@ async fn execute_postgres_operation(
                 // column, corrupting downstream partition routing. Halt the
                 // batch so the outer retry loop re-attempts.
                 if column.name == "block_timestamp" || column.name == "rindexer_block_timestamp" {
+                    // Try the canonical injected key first (rindexer_block_number per
+                    // injected_columns::BLOCK_NUMBER), fall back to user-aliased.
                     let block_num_hint = row
                         .columns
-                        .get("block_number")
-                        .or_else(|| row.columns.get("rindexer_block_number"))
+                        .get("rindexer_block_number")
+                        .or_else(|| row.columns.get("block_number"))
                         .map(|v| format!("{:?}", v))
                         .unwrap_or_else(|| "<unknown>".to_string());
                     return Err(format!(
@@ -4150,10 +4157,12 @@ async fn execute_clickhouse_operation(
                 // column, corrupting downstream partition routing. Halt the
                 // batch so the outer retry loop re-attempts.
                 if column.name == "block_timestamp" || column.name == "rindexer_block_timestamp" {
+                    // Try the canonical injected key first (rindexer_block_number per
+                    // injected_columns::BLOCK_NUMBER), fall back to user-aliased.
                     let block_num_hint = row
                         .columns
-                        .get("block_number")
-                        .or_else(|| row.columns.get("rindexer_block_number"))
+                        .get("rindexer_block_number")
+                        .or_else(|| row.columns.get("block_number"))
                         .map(|v| format!("{:?}", v))
                         .unwrap_or_else(|| "<unknown>".to_string());
                     return Err(format!(
@@ -5402,6 +5411,16 @@ mod tests {
         column_name == "block_timestamp" || column_name == "rindexer_block_timestamp"
     }
 
+    /// Extracts a debug-formatted block-number hint from a row's columns,
+    /// preferring the canonical injected `rindexer_block_number` key.
+    fn extract_block_num_hint(columns: &HashMap<String, EthereumSqlTypeWrapper>) -> String {
+        columns
+            .get("rindexer_block_number")
+            .or_else(|| columns.get("block_number"))
+            .map(|v| format!("{:?}", v))
+            .unwrap_or_else(|| "<unknown>".to_string())
+    }
+
     #[test]
     fn test_block_ts_guard_trips_on_missing_block_timestamp() {
         assert!(block_ts_guard_trips("block_timestamp", None, false));
@@ -5429,6 +5448,32 @@ mod tests {
         // optional enrichment).
         assert!(!block_ts_guard_trips("some_view_call_result", None, false));
         assert!(!block_ts_guard_trips("title", None, false));
+    }
+
+    #[test]
+    fn test_extract_block_num_hint_prefers_rindexer_canonical_key() {
+        let mut cols: HashMap<String, EthereumSqlTypeWrapper> = HashMap::new();
+        cols.insert(
+            "rindexer_block_number".to_string(),
+            EthereumSqlTypeWrapper::U64BigInt(61_407_661),
+        );
+        cols.insert("block_number".to_string(), EthereumSqlTypeWrapper::U64BigInt(99_999_999));
+        let hint = extract_block_num_hint(&cols);
+        assert!(hint.contains("61407661"), "should prefer rindexer_block_number; got: {}", hint);
+    }
+
+    #[test]
+    fn test_extract_block_num_hint_falls_back_to_block_number() {
+        let mut cols: HashMap<String, EthereumSqlTypeWrapper> = HashMap::new();
+        cols.insert("block_number".to_string(), EthereumSqlTypeWrapper::U64BigInt(61_407_661));
+        let hint = extract_block_num_hint(&cols);
+        assert!(hint.contains("61407661"), "fallback path failed; got: {}", hint);
+    }
+
+    #[test]
+    fn test_extract_block_num_hint_unknown_when_absent() {
+        let cols: HashMap<String, EthereumSqlTypeWrapper> = HashMap::new();
+        assert_eq!(extract_block_num_hint(&cols), "<unknown>");
     }
 
     // =========================================================================

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -1425,9 +1425,31 @@ async fn prefetch_block_timestamps(
 
 /// Gets a block timestamp from the cache, or returns None if not cached.
 /// Should be called after prefetch_block_timestamps has populated the cache.
-async fn get_cached_block_timestamp(network: &str, block_number: u64) -> Option<u64> {
+pub(crate) async fn get_cached_block_timestamp(network: &str, block_number: u64) -> Option<u64> {
     let cache = BLOCK_TIMESTAMP_CACHE.read().await;
     cache.get(&(network.to_string(), block_number)).copied()
+}
+
+/// Snapshots block timestamps from the cache for a batch of (network, block_number)
+/// pairs. Used by the no-code event-table writer to hydrate
+/// `tx_information.block_timestamp` before serialization — recovers from RPC
+/// providers that don't include `blockTimestamp` in `eth_getLogs` responses.
+/// One async lock acquisition; lookups against the returned map are sync, so
+/// the writer's sync iterator stays sync.
+pub(crate) async fn snapshot_cached_block_timestamps(
+    pairs: &[(String, u64)],
+) -> std::collections::HashMap<(String, u64), u64> {
+    let mut out = std::collections::HashMap::with_capacity(pairs.len());
+    if pairs.is_empty() {
+        return out;
+    }
+    let cache = BLOCK_TIMESTAMP_CACHE.read().await;
+    for key in pairs {
+        if let Some(ts) = cache.get(key).copied() {
+            out.insert(key.clone(), ts);
+        }
+    }
+    out
 }
 
 /// Predicate: would the column-write path silently emit Null for a critical
@@ -1448,13 +1470,20 @@ fn block_ts_guard_trips(
 
 /// Best-effort block-number hint for guard-trip error messages. Prefers the
 /// canonical `rindexer_block_number` injected key, falls back to user-aliased
-/// `block_number`, returns `<unknown>` when neither is present.
+/// `block_number`. When neither is present we emit a diagnostic sentinel and
+/// log at error level so operators can spot mis-shaped rows that would otherwise
+/// produce a hint-less error.
 fn extract_block_num_hint(columns: &HashMap<String, EthereumSqlTypeWrapper>) -> String {
-    columns
-        .get("rindexer_block_number")
-        .or_else(|| columns.get("block_number"))
-        .map(|v| format!("{:?}", v))
-        .unwrap_or_else(|| "<unknown>".to_string())
+    if let Some(v) = columns.get("rindexer_block_number").or_else(|| columns.get("block_number")) {
+        return format!("{:?}", v);
+    }
+    tracing::error!(
+        target: "rindexer::block_timestamp_guard",
+        column_keys = ?columns.keys().collect::<Vec<_>>(),
+        "block_timestamp guard tripped on a row missing both rindexer_block_number and block_number — \
+         row shape is unexpected; emitting <missing-block-number> sentinel"
+    );
+    "<missing-block-number>".to_string()
 }
 
 /// Transaction metadata available for table value references.
@@ -5608,9 +5637,9 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_block_num_hint_unknown_when_absent() {
+    fn test_extract_block_num_hint_sentinel_when_absent() {
         let cols: HashMap<String, EthereumSqlTypeWrapper> = HashMap::new();
-        assert_eq!(extract_block_num_hint(&cols), "<unknown>");
+        assert_eq!(extract_block_num_hint(&cols), "<missing-block-number>");
     }
 
     // =========================================================================

--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -937,6 +937,12 @@ pub mod mock {
         block_number: U64,
         receipts: Vec<AnyTransactionReceipt>,
         traces: Vec<LocalizedTransactionTrace>,
+        /// When > 0, the next N calls to `get_block_by_number_batch{,_with_size}`
+        /// return `Err(ProviderError::CustomError(...))`. Each call decrements
+        /// the counter atomically, so on call N+1 the mock behaves normally.
+        /// Lets tests exercise the retry path in `prefetch_block_timestamps`
+        /// without spinning a real RPC.
+        block_fetch_failures_remaining: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     }
 
     impl MockChainProvider {
@@ -949,6 +955,9 @@ pub mod mock {
                 block_number: U64::ZERO,
                 receipts: vec![],
                 traces: vec![],
+                block_fetch_failures_remaining: std::sync::Arc::new(
+                    std::sync::atomic::AtomicUsize::new(0),
+                ),
             }
         }
 
@@ -975,6 +984,19 @@ pub mod mock {
         pub fn with_max_block_range(mut self, range: u64) -> Self {
             self.max_block_range = Some(U64::from(range));
             self
+        }
+
+        /// Inject N consecutive failures into `get_block_by_number_batch{,_with_size}`.
+        /// Subsequent calls succeed normally. Counter is shared across clones via Arc.
+        pub fn with_block_fetch_failures(self, n: usize) -> Self {
+            self.block_fetch_failures_remaining.store(n, std::sync::atomic::Ordering::SeqCst);
+            self
+        }
+
+        /// Snapshot the remaining failure budget (for test assertions on
+        /// "did the retry actually consume the configured failures?").
+        pub fn block_fetch_failures_remaining(&self) -> usize {
+            self.block_fetch_failures_remaining.load(std::sync::atomic::Ordering::SeqCst)
         }
     }
 
@@ -1039,6 +1061,22 @@ pub mod mock {
             block_numbers: &[U64],
             _include_txs: bool,
         ) -> Result<Vec<AnyRpcBlock>, ProviderError> {
+            // Failure-injection: if the budget is positive, decrement it and
+            // return an error to simulate a transient RPC failure. SeqCst keeps
+            // multi-task visibility predictable across the spawned retry tasks.
+            let prev = self
+                .block_fetch_failures_remaining
+                .fetch_update(
+                    std::sync::atomic::Ordering::SeqCst,
+                    std::sync::atomic::Ordering::SeqCst,
+                    |n| if n > 0 { Some(n - 1) } else { None },
+                )
+                .unwrap_or(0);
+            if prev > 0 {
+                return Err(ProviderError::CustomError(
+                    "mock: injected block-fetch failure".to_string(),
+                ));
+            }
             use std::collections::HashSet;
             let requested: HashSet<u64> = block_numbers.iter().map(|n| n.to::<u64>()).collect();
             Ok(self


### PR DESCRIPTION
## Summary                                             

Fix against silent `block_timestamp = 0` writes when the upstream RPC fails to return a block header. 

## Root cause                                          

When `manifest.timestamps = false` (default), `eth_getLogs` responses without a `blockTimestamp` field flow through with `tx_metadata.block_timestamp = None`. The write path tried a per-block cache populated by `prefetch_block_timestamps`, which on RPC failure logged the error, returned `None`, and **never inserted the cache entry**. Downstream the column was silently skipped from the row, then the executor emitted `EthereumSqlTypeWrapper::Null`, which surfaced as `0` on the destination NUMERIC column.

