### PR TITLE
fix(streams): address code-review findings on finalized stream delivery (#418)

### DIFF
--- a/core/src/metrics/definitions.rs
+++ b/core/src/metrics/definitions.rs
@@ -282,6 +282,12 @@ pub static STREAM_FINALIZED_BUFFER_OVERFLOW_TOTAL: Lazy<CounterVec> = Lazy::new(
 /// — overflow answers "did the buffer ever breach the soft cap?" while this
 /// gauge answers "is the buffer draining?". Alert if this stays non-zero and
 /// non-decreasing across consecutive scrapes.
+///
+/// The gauge updates when an event leaves the in-memory buffer (post-drain),
+/// not when its downstream publish completes — events in flight after a
+/// flush are not reflected. Pair with `STREAM_PUBLISH_DROPPED_TOTAL` and the
+/// `record_finalized_flush_duration` histogram for the publish-side picture.
+///
 /// Labels: stream_type, network
 pub static STREAM_FINALIZED_BUFFER_DEPTH: Lazy<GaugeVec> = Lazy::new(|| {
     register_gauge_vec!(

--- a/core/src/metrics/definitions.rs
+++ b/core/src/metrics/definitions.rs
@@ -276,6 +276,34 @@ pub static STREAM_FINALIZED_BUFFER_OVERFLOW_TOTAL: Lazy<CounterVec> = Lazy::new(
     .expect("failed to register STREAM_FINALIZED_BUFFER_OVERFLOW_TOTAL")
 });
 
+/// Current number of events sitting in a finalized-delivery buffer for a
+/// `(stream_type, network)` pair, summed across all `config_index`es and
+/// `event_name`s on that pair. Complements `STREAM_FINALIZED_BUFFER_OVERFLOW_TOTAL`
+/// — overflow answers "did the buffer ever breach the soft cap?" while this
+/// gauge answers "is the buffer draining?". Alert if this stays non-zero and
+/// non-decreasing across consecutive scrapes.
+/// Labels: stream_type, network
+pub static STREAM_FINALIZED_BUFFER_DEPTH: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        "rindexer_stream_finalized_buffer_depth",
+        "Current events buffered for finalized delivery per (stream_type, network)",
+        &["stream_type", "network"]
+    )
+    .expect("failed to register STREAM_FINALIZED_BUFFER_DEPTH")
+});
+
+/// End-to-end duration of a `flush_finalized(network, head)` call. Captures
+/// lock acquire + drain-decision + publisher fanout. Labels: network.
+pub static STREAM_FINALIZED_FLUSH_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "rindexer_stream_finalized_flush_duration_seconds",
+        "End-to-end finalized-buffer flush duration in seconds per network",
+        &["network"],
+        vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0]
+    )
+    .expect("failed to register STREAM_FINALIZED_FLUSH_DURATION")
+});
+
 /// Terminal publish failures — a message hit `publish_with_retry`'s final
 /// attempt and was not delivered. In Instant delivery mode this is a lost
 /// message from the consumer's point of view. Alert on any sustained non-zero

--- a/core/src/metrics/streams.rs
+++ b/core/src/metrics/streams.rs
@@ -3,7 +3,8 @@
 use std::time::Instant;
 
 use super::definitions::{
-    STREAM_FINALIZED_BUFFER_OVERFLOW_TOTAL, STREAM_MESSAGES_TOTAL, STREAM_MESSAGE_DURATION,
+    STREAM_FINALIZED_BUFFER_DEPTH, STREAM_FINALIZED_BUFFER_OVERFLOW_TOTAL,
+    STREAM_FINALIZED_FLUSH_DURATION, STREAM_MESSAGES_TOTAL, STREAM_MESSAGE_DURATION,
     STREAM_PUBLISH_DROPPED_TOTAL,
 };
 
@@ -36,6 +37,19 @@ pub fn record_stream_error(stream_type: &str, duration_secs: f64) {
 /// visibility.
 pub fn record_finalized_buffer_overflow(stream_type: &str, network: &str) {
     STREAM_FINALIZED_BUFFER_OVERFLOW_TOTAL.with_label_values(&[stream_type, network]).inc();
+}
+
+/// Set the current depth of a finalized-delivery buffer for a given
+/// `(stream_type, network)` pair. Called after every add / flush / discard
+/// so the gauge reflects live buffer state.
+pub fn set_finalized_buffer_depth(stream_type: &str, network: &str, depth: f64) {
+    STREAM_FINALIZED_BUFFER_DEPTH.with_label_values(&[stream_type, network]).set(depth);
+}
+
+/// Record the end-to-end duration of a `flush_finalized` call for a network,
+/// useful for detecting flush stalls or unusually slow publisher fanouts.
+pub fn record_finalized_flush_duration(network: &str, duration_secs: f64) {
+    STREAM_FINALIZED_FLUSH_DURATION.with_label_values(&[network]).observe(duration_secs);
 }
 
 /// Record a terminal publish failure — retries were exhausted and the message

--- a/core/src/metrics/streams.rs
+++ b/core/src/metrics/streams.rs
@@ -16,6 +16,10 @@ pub mod stream_type {
     pub const KAFKA: &str = "kafka";
     pub const REDIS: &str = "redis";
     pub const CLOUDFLARE_QUEUES: &str = "cloudflare_queues";
+
+    /// Iterator-driven label set so callers (e.g. depth-gauge zero-out
+    /// loops) don't drift when a new backend is added.
+    pub const ALL: &[&str] = &[SNS, WEBHOOK, RABBITMQ, KAFKA, REDIS, CLOUDFLARE_QUEUES];
 }
 
 /// Record a successful stream message send.

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -1352,13 +1352,30 @@ impl StreamsClients {
             all_tasks.extend(tasks);
         }
 
+        // Mirrors `flush_finalized`'s cross-key continue-on-error: tasks in
+        // `join_all` already executed in parallel by the time we iterate, so
+        // a per-task `return Err` would short-circuit the count rather than
+        // the work. Accumulate `total_sent` across every successful task and
+        // surface the first observed error after the loop.
         let mut total_sent = 0;
+        let mut first_err: Option<StreamError> = None;
         for result in join_all(all_tasks).await {
             match result {
                 Ok(Ok(n)) => total_sent += n,
-                Ok(Err(e)) => return Err(e),
-                Err(e) => return Err(StreamError::JoinError(e)),
+                Ok(Err(e)) => {
+                    if first_err.is_none() {
+                        first_err = Some(e);
+                    }
+                }
+                Err(e) => {
+                    if first_err.is_none() {
+                        first_err = Some(StreamError::JoinError(e));
+                    }
+                }
             }
+        }
+        if let Some(e) = first_err {
+            return Err(e);
         }
         Ok(total_sent)
     }
@@ -1840,7 +1857,11 @@ mod tests {
     #[tokio::test]
     async fn stream_trace_event_with_finalized_delivery_buffers_instead_of_sending() {
         let mut server = mockito::Server::new_async().await;
-        let mock = server.mock("POST", "/hook").expect(0).create_async().await;
+        // Expect exactly one POST after the deferred flush, and zero before
+        // it — the buffered_blocks assertion below proves the pre-flush
+        // count is zero, so a passing mock.assert_async() at the end is
+        // strictly the post-flush hit.
+        let mock = server.mock("POST", "/hook").with_status(200).expect(1).create_async().await;
 
         let config = WebhookStreamConfig {
             endpoint: format!("{}/hook", server.url()),
@@ -1864,12 +1885,23 @@ mod tests {
         let sent = clients.stream("id".to_string(), &msg, false, true).await.unwrap();
 
         assert_eq!(sent, 0, "finalized trace event must not dispatch instantly");
-        mock.assert_async().await;
         assert_eq!(
             buffered_blocks(&clients, "ethereum").await,
             vec![100],
             "event must be parked in the finalized buffer for later flush"
         );
+
+        // Drive a flush so the event traverses the dispatch path. Catches
+        // regressions in `filter_chunk_event_data_by_conditions`'s
+        // EVENT_NAME passthrough — without it, the flushed dispatch would
+        // panic via the `expect("Failed to find stream event ...")`.
+        let flushed = clients.flush_finalized("ethereum", 200).await.unwrap();
+        assert_eq!(flushed, 1, "buffered native-transfer event must flush once safe");
+        assert!(
+            buffered_blocks(&clients, "ethereum").await.is_empty(),
+            "buffer must drain after flush"
+        );
+        mock.assert_async().await;
     }
 
     #[tokio::test]
@@ -2439,6 +2471,40 @@ mod tests {
             buffered_blocks(&clients, "ethereum").await,
             vec![100],
             "block 100 must remain buffered under the re-registered distance of 50"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn flush_finalized_respects_re_registered_smaller_distance() {
+        // Symmetric to the larger-distance regression: a distance re-registered
+        // SMALLER must also take effect — otherwise a buffer seeded with a
+        // generous distance would keep events parked even when the user has
+        // since reduced the safe window. Catches a regression that re-cached
+        // the distance only in one direction.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("POST", "/hook").with_status(200).expect(1).create_async().await;
+
+        let config = WebhookStreamConfig {
+            endpoint: format!("{}/hook", server.url()),
+            shared_secret: "s".to_string(),
+            networks: vec!["ethereum".to_string()],
+            events: vec![stream_event("Transfer")],
+            delivery: None,
+        };
+        let clients = webhook_clients(vec![config]);
+
+        // Seed under distance=50 (so block 100 would NOT be ready at head 110:
+        // 110 - 50 = 60 < 100). Pre-fix: distance pinned at 50 forever.
+        seed_buffer(&clients, "ethereum", "Transfer", &[100], 50).await;
+        // Re-register smaller; head=110 - 5 = 105 >= 100, so 100 must flush.
+        clients.register_network_reorg_distance("ethereum".to_string(), 5);
+        let sent = clients.flush_finalized("ethereum", 110).await.unwrap();
+
+        assert_eq!(sent, 1, "flush must honor the newly-registered smaller distance");
+        assert!(
+            buffered_blocks(&clients, "ethereum").await.is_empty(),
+            "block 100 must drain under the re-registered distance of 5"
         );
         mock.assert_async().await;
     }

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -1182,9 +1182,26 @@ impl StreamsClients {
             }
         }
 
+        // Continue-on-error across keys: a persistent publish failure on one
+        // stream-type/config must NOT cause the remaining keys' already-drained
+        // events to be dropped. Per-key dispatch already reports drops via
+        // `STREAM_PUBLISH_DROPPED_TOTAL` after the retry budget is exhausted;
+        // here we surface the first error (so callers see something went
+        // wrong) while letting every other key's events reach their backend.
         let mut total_sent = 0;
+        let mut first_err: Option<StreamError> = None;
         for (key, ready) in ready_by_key {
-            total_sent += self.dispatch_flushed(&key, ready).await?;
+            match self.dispatch_flushed(&key, ready).await {
+                Ok(n) => total_sent += n,
+                Err(e) => {
+                    if first_err.is_none() {
+                        first_err = Some(e);
+                    }
+                }
+            }
+        }
+        if let Some(e) = first_err {
+            return Err(e);
         }
         Ok(total_sent)
     }
@@ -2233,5 +2250,97 @@ mod tests {
 
         assert_eq!(sent, 0);
         assert_eq!(buffered_blocks(&clients, "ethereum").await, vec![1, 2, 5]);
+    }
+
+    async fn seed_buffer_for_config(
+        clients: &StreamsClients,
+        stream_type: &'static str,
+        config_index: usize,
+        network: &str,
+        event_name: &str,
+        blocks: &[u64],
+        distance: u64,
+    ) {
+        clients.register_network_reorg_distance(network.to_string(), distance);
+        let key = BufferKey {
+            stream_type,
+            config_index,
+            network: network.to_string(),
+            event_name: event_name.to_string(),
+            event_signature_hash: B256::ZERO,
+        };
+        let mut map = clients.finalized_buffers.lock().await;
+        let buf = map.entry(key).or_insert_with(|| FinalizedBuffer::new(distance));
+        for &b in blocks {
+            buf.add(b, vec![json!({"block": b})]);
+        }
+    }
+
+    #[tokio::test]
+    async fn flush_finalized_healthy_backend_delivers_when_other_backend_fails() {
+        // C1 regression: a persistent publish error on backend A must not
+        // cause backend B's already-drained events to be dropped. Pre-fix,
+        // the `?` in the per-key dispatch loop propagated the first Err and
+        // skipped every subsequent key — silent data loss with no
+        // STREAM_PUBLISH_DROPPED_TOTAL entry for the lost events because
+        // they never reached `publish_with_retry`.
+        let mut server = mockito::Server::new_async().await;
+        let bad =
+            server.mock("POST", "/bad").with_status(500).expect_at_least(1).create_async().await;
+        let good = server.mock("POST", "/good").with_status(200).expect(1).create_async().await;
+
+        let bad_cfg = WebhookStreamConfig {
+            endpoint: format!("{}/bad", server.url()),
+            shared_secret: "s".to_string(),
+            networks: vec!["ethereum".to_string()],
+            events: vec![stream_event("Transfer")],
+            delivery: None,
+        };
+        let good_cfg = WebhookStreamConfig {
+            endpoint: format!("{}/good", server.url()),
+            shared_secret: "s".to_string(),
+            networks: vec!["ethereum".to_string()],
+            events: vec![stream_event("Transfer")],
+            delivery: None,
+        };
+        let clients = webhook_clients(vec![bad_cfg, good_cfg]);
+
+        // Seed both config buckets with the same block so flush produces two
+        // BufferKey entries (differing only in `config_index`).
+        seed_buffer_for_config(
+            &clients,
+            stream_type::WEBHOOK,
+            0,
+            "ethereum",
+            "Transfer",
+            &[100],
+            10,
+        )
+        .await;
+        seed_buffer_for_config(
+            &clients,
+            stream_type::WEBHOOK,
+            1,
+            "ethereum",
+            "Transfer",
+            &[100],
+            10,
+        )
+        .await;
+
+        let result = clients.flush_finalized("ethereum", 110).await;
+
+        // /bad exhausts retries and surfaces a WebhookError — that's expected
+        // and the coordinator warn-logs it. The critical post-fix invariant is
+        // that /good still received its event regardless of HashMap iteration
+        // order: before the fix, if /bad's key iterated first, /good's
+        // already-drained events were silently lost.
+        assert!(
+            matches!(result, Err(StreamError::WebhookCouldNotPublish(_))),
+            "expected webhook err surfaced, got {:?}",
+            result
+        );
+        good.assert_async().await;
+        bad.assert_async().await;
     }
 }

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -1166,10 +1166,6 @@ impl StreamsClients {
         network: &str,
         head_block: u64,
     ) -> Result<usize, StreamError> {
-        // Read the latest registered reorg_safe_distance at flush time, not
-        // at buffer insertion time. Lets `register_network_reorg_distance`
-        // updates take effect on the next flush without needing to reset the
-        // buffer map.
         let distance = self.reorg_safe_distance_for(network);
         let flush_start = Instant::now();
         let mut ready_by_key: Vec<FinalizedDeliveryBuffer> = Vec::new();
@@ -1217,14 +1213,11 @@ impl StreamsClients {
 
     /// Sum the buffer size per `(stream_type, network)` for `network` across
     /// every entry in `map` and push the result into the depth gauge. Assumes
-    /// the caller holds `finalized_buffers` lock — emits no metric if
-    /// `network` has no buffer entries at all (leaving any stale gauge value
-    /// untouched would be misleading, so explicitly zero out on empty).
+    /// the caller holds `finalized_buffers` lock. Iterates every
+    /// `stream_type::ALL` label so a buffer that just fully drained does not
+    /// leave its previous gauge value stuck — Prometheus gauges otherwise
+    /// retain the last `set` value indefinitely.
     fn refresh_depth_gauge_under_lock(map: &HashMap<BufferKey, FinalizedBuffer>, network: &str) {
-        // Collect per-stream_type counts for this network. Any stream_type
-        // that has NO current entries for the network must still be zeroed
-        // out on the gauge, otherwise a gauge for a buffer that fully
-        // drained would get stuck at its last non-zero value.
         let mut totals: HashMap<&'static str, u64> = HashMap::new();
         for (key, buf) in map.iter() {
             if key.network != network {
@@ -1232,20 +1225,9 @@ impl StreamsClients {
             }
             *totals.entry(key.stream_type).or_default() += buf.len() as u64;
         }
-        // Zero out any stream_type that previously had a gauge emission for
-        // this network but is now empty. We only track `totals` keys — a
-        // stream_type never observed on this network has no prior emission
-        // and needs no zero write.
-        for known_stream_type in [
-            stream_type::SNS,
-            stream_type::WEBHOOK,
-            stream_type::RABBITMQ,
-            stream_type::KAFKA,
-            stream_type::REDIS,
-            stream_type::CLOUDFLARE_QUEUES,
-        ] {
-            let depth = totals.remove(known_stream_type).unwrap_or(0);
-            stream_metrics::set_finalized_buffer_depth(known_stream_type, network, depth as f64);
+        for &st in stream_type::ALL {
+            let depth = totals.remove(st).unwrap_or(0);
+            stream_metrics::set_finalized_buffer_depth(st, network, depth as f64);
         }
     }
 
@@ -1411,9 +1393,15 @@ impl FinalizedBuffer {
 
     pub fn flush(&mut self, current_head: u64, reorg_safe_distance: u64) -> Vec<(u64, Vec<Value>)> {
         let finality_threshold = current_head.saturating_sub(reorg_safe_distance);
-        let ready_keys: Vec<u64> =
-            self.buffer.keys().copied().filter(|&k| k <= finality_threshold).collect();
-        ready_keys.into_iter().filter_map(|k| self.buffer.remove(&k).map(|v| (k, v))).collect()
+        // BTreeMap::split_off keeps keys < arg in self, returns keys >= arg.
+        // We want to drain keys ≤ threshold and retain keys > threshold, so
+        // split at `threshold + 1`: the high half (returned) becomes the new
+        // buffer, the original low half drains. Single O(log n + drained)
+        // pass, no per-key remove.
+        let cutoff = finality_threshold.saturating_add(1);
+        let keep = self.buffer.split_off(&cutoff);
+        let drained = std::mem::replace(&mut self.buffer, keep);
+        drained.into_iter().collect()
     }
 
     pub fn discard_range(&mut self, fork_point: u64, detection_point: u64) {
@@ -1851,16 +1839,7 @@ mod tests {
 
     #[tokio::test]
     async fn stream_trace_event_with_finalized_delivery_buffers_instead_of_sending() {
-        // I2 regression: a NativeTransfer / trace event on a stream configured
-        // with `delivery: finalized` must be buffered, not delivered
-        // instantly. Pre-fix, `should_buffer` unconditionally bypassed the
-        // buffer when `is_trace_event == true`, so users opting into
-        // finalized delivery on native-transfer streams got instant delivery
-        // with no warning — a silent violation of the configured reorg
-        // safety expectation.
         let mut server = mockito::Server::new_async().await;
-        // Expect ZERO hits: buffered means nothing should reach the endpoint
-        // until flush_finalized is invoked.
         let mock = server.mock("POST", "/hook").expect(0).create_async().await;
 
         let config = WebhookStreamConfig {
@@ -1872,9 +1851,6 @@ mod tests {
         };
 
         let clients = webhook_clients(vec![config]);
-        // Simulate coordinator registering the network's reorg distance at
-        // startup. Without this, FinalizedBuffer::new would be created with 0
-        // and the next flush would leak the event instantly.
         clients.register_network_reorg_distance("ethereum".to_string(), 10);
 
         let msg = EventMessage {
@@ -1885,12 +1861,8 @@ mod tests {
             block_number: 100,
         };
 
-        let sent = clients
-            .stream("id".to_string(), &msg, false, true) // is_trace_event = true
-            .await
-            .unwrap();
+        let sent = clients.stream("id".to_string(), &msg, false, true).await.unwrap();
 
-        // Post-fix: buffered, not dispatched. Pre-fix: hit the endpoint.
         assert_eq!(sent, 0, "finalized trace event must not dispatch instantly");
         mock.assert_async().await;
         assert_eq!(
@@ -2378,12 +2350,10 @@ mod tests {
 
     #[tokio::test]
     async fn flush_finalized_healthy_backend_delivers_when_other_backend_fails() {
-        // C1 regression: a persistent publish error on backend A must not
-        // cause backend B's already-drained events to be dropped. Pre-fix,
-        // the `?` in the per-key dispatch loop propagated the first Err and
-        // skipped every subsequent key — silent data loss with no
-        // STREAM_PUBLISH_DROPPED_TOTAL entry for the lost events because
-        // they never reached `publish_with_retry`.
+        // A persistent publish error on backend A must not cause backend B's
+        // already-drained events to be dropped — the per-key dispatch loop
+        // intentionally records the failure, continues, and surfaces the
+        // first error after every key has had a chance to publish.
         let mut server = mockito::Server::new_async().await;
         let bad =
             server.mock("POST", "/bad").with_status(500).expect_at_least(1).create_async().await;
@@ -2405,8 +2375,9 @@ mod tests {
         };
         let clients = webhook_clients(vec![bad_cfg, good_cfg]);
 
-        // Seed both config buckets with the same block so flush produces two
-        // BufferKey entries (differing only in `config_index`).
+        // Two BufferKey entries — same network/event, differing config_index —
+        // so the dispatch loop has to traverse both and the bug surfaces
+        // when /bad iterates first under HashMap's nondeterministic order.
         seed_buffer_for_config(
             &clients,
             stream_type::WEBHOOK,
@@ -2430,11 +2401,6 @@ mod tests {
 
         let result = clients.flush_finalized("ethereum", 110).await;
 
-        // /bad exhausts retries and surfaces a WebhookError — that's expected
-        // and the coordinator warn-logs it. The critical post-fix invariant is
-        // that /good still received its event regardless of HashMap iteration
-        // order: before the fix, if /bad's key iterated first, /good's
-        // already-drained events were silently lost.
         assert!(
             matches!(result, Err(StreamError::WebhookCouldNotPublish(_))),
             "expected webhook err surfaced, got {:?}",
@@ -2446,15 +2412,11 @@ mod tests {
 
     #[tokio::test]
     async fn flush_finalized_respects_re_registered_larger_distance() {
-        // I3 regression: the per-buffer distance must come from the registry
-        // at flush time, not be cached inside `FinalizedBuffer` at first
-        // insert. The scary direction: a distance that is re-registered
-        // LARGER after the buffer exists must take effect — otherwise events
-        // flush too early relative to the newly-configured reorg-safe
-        // window, which is a silent correctness deviation from the manifest.
+        // The scary direction: a distance re-registered LARGER after the
+        // buffer exists must take effect on the next flush, otherwise
+        // events ship too early relative to the newly-configured
+        // reorg-safe window — a silent correctness deviation.
         let mut server = mockito::Server::new_async().await;
-        // Expect zero hits: under the re-registered distance of 50, head=110
-        // is not enough to surface block 100 (110 - 50 = 60 < 100).
         let mock = server.mock("POST", "/hook").expect(0).create_async().await;
 
         let config = WebhookStreamConfig {
@@ -2466,11 +2428,9 @@ mod tests {
         };
         let clients = webhook_clients(vec![config]);
 
-        // Seed under distance=10 (so block 100 would be ready at head 110).
+        // Seed under distance=10 (block 100 would be ready at head 110).
         seed_buffer(&clients, "ethereum", "Transfer", &[100], 10).await;
-
-        // Re-register a larger distance. Post-fix, this must take effect on
-        // the next flush.
+        // Re-register larger; head=110 - 50 = 60 < 100, so 100 must stay parked.
         clients.register_network_reorg_distance("ethereum".to_string(), 50);
         let sent = clients.flush_finalized("ethereum", 110).await.unwrap();
 
@@ -2485,14 +2445,11 @@ mod tests {
 
     #[tokio::test]
     async fn finalized_buffer_depth_gauge_tracks_add_and_flush() {
-        // I4 regression: the finalized-buffer depth gauge must reflect the
-        // current in-memory buffer size per (stream_type, network) so
-        // operators can alert on stuck buffers. Pre-fix, only an overflow
-        // counter existed — useless for answering "is the buffer draining?".
+        // Operators alert on "buffer not draining" via this gauge — verify
+        // it actually moves with add and flush. The unique network label
+        // isolates this test from process-wide metric emissions.
         use crate::metrics::definitions::STREAM_FINALIZED_BUFFER_DEPTH;
 
-        // Isolate this test from others by using a label combination unlikely
-        // to collide with other tests' metric emissions.
         let network = "depth_gauge_test_network";
 
         let mut server = mockito::Server::new_async().await;
@@ -2506,22 +2463,18 @@ mod tests {
         };
         let clients = webhook_clients(vec![config]);
 
-        // Start: gauge should be 0 (no buffered events for this network).
         let before =
             STREAM_FINALIZED_BUFFER_DEPTH.with_label_values(&[stream_type::WEBHOOK, network]).get();
         assert_eq!(before, 0.0, "depth gauge must start at zero");
 
-        // Seed a buffered event — the gauge should move to 1.
         seed_buffer(&clients, network, "Transfer", &[100], 10).await;
-        // Trigger a gauge refresh through a production code path. We call
-        // flush_finalized at a head below threshold so nothing drains, but
-        // the depth gauge is refreshed as part of the flush.
+        // head=50 < threshold(100), so flush drains nothing but still
+        // refreshes the gauge from the post-seed map state.
         let _ = clients.flush_finalized(network, 50).await.unwrap();
         let after_seed =
             STREAM_FINALIZED_BUFFER_DEPTH.with_label_values(&[stream_type::WEBHOOK, network]).get();
         assert_eq!(after_seed, 1.0, "depth gauge must track buffered event count");
 
-        // Drain — gauge must drop back to zero.
         let sent = clients.flush_finalized(network, 110).await.unwrap();
         assert_eq!(sent, 1);
         let after_flush =

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -141,8 +141,9 @@ pub struct StreamsClients {
     /// `flush_finalized` and invalidation via `discard_finalized`.
     finalized_buffers: AsyncMutex<HashMap<BufferKey, FinalizedBuffer>>,
     /// Per-network `reorg_safe_distance`. Populated at startup by
-    /// `register_network_reorg_distance`. `FinalizedBuffer::new` needs this to
-    /// know how far behind the chain head a block must be before flushing.
+    /// `register_network_reorg_distance` and re-read at every
+    /// `flush_finalized` call so post-insertion re-registration takes
+    /// effect (see `FinalizedBuffer::flush`).
     reorg_safe_distances: StdMutex<HashMap<String, u64>>,
 }
 
@@ -289,7 +290,7 @@ impl StreamsClients {
             event_signature_hash: B256::ZERO,
         };
         let mut map = self.finalized_buffers.lock().await;
-        let buf = map.entry(key).or_insert_with(|| FinalizedBuffer::new(distance));
+        let buf = map.entry(key).or_insert_with(FinalizedBuffer::new);
         for &b in blocks {
             buf.add(b, vec![serde_json::json!({"block": b})]);
         }
@@ -498,7 +499,6 @@ impl StreamsClients {
         config_index: usize,
         event_message: &EventMessage,
     ) {
-        let distance = self.reorg_safe_distance_for(&event_message.network);
         let key = BufferKey {
             stream_type,
             config_index,
@@ -507,7 +507,7 @@ impl StreamsClients {
             event_signature_hash: event_message.event_signature_hash,
         };
         let mut map = self.finalized_buffers.lock().await;
-        let buffer = map.entry(key).or_insert_with(|| FinalizedBuffer::new(distance));
+        let buffer = map.entry(key).or_insert_with(FinalizedBuffer::new);
         if let Value::Array(data) = &event_message.event_data {
             buffer.add(event_message.block_number, data.clone());
         }
@@ -1165,6 +1165,11 @@ impl StreamsClients {
         network: &str,
         head_block: u64,
     ) -> Result<usize, StreamError> {
+        // Read the latest registered reorg_safe_distance at flush time, not
+        // at buffer insertion time. Lets `register_network_reorg_distance`
+        // updates take effect on the next flush without needing to reset the
+        // buffer map.
+        let distance = self.reorg_safe_distance_for(network);
         let mut ready_by_key: Vec<FinalizedDeliveryBuffer> = Vec::new();
         {
             let mut map = self.finalized_buffers.lock().await;
@@ -1172,7 +1177,7 @@ impl StreamsClients {
                 if key.network != network {
                     continue;
                 }
-                let ready = buffer.flush(head_block);
+                let ready = buffer.flush(head_block, distance);
                 if !ready.is_empty() {
                     ready_by_key.push((key.clone(), ready));
                 }
@@ -1339,26 +1344,31 @@ impl StreamsClients {
 /// source block number. Used by `StreamDeliveryMode::Finalized` to delay
 /// dispatch until a block is deeper than the chain's `reorg_safe_distance`.
 ///
-/// `flush(current_head)` drains every bucket whose block is `<= current_head -
-/// reorg_safe_distance`; `discard_range(fork_point, detection_point)` removes
-/// buckets in an invalidated range when a reorg is detected.
+/// `flush(current_head, reorg_safe_distance)` drains every bucket whose block
+/// is `<= current_head - reorg_safe_distance`; `discard_range(fork_point,
+/// detection_point)` removes buckets in an invalidated range when a reorg is
+/// detected.
+///
+/// The `reorg_safe_distance` is NOT stored on the buffer — it is passed at
+/// flush time from `StreamsClients::reorg_safe_distances`. Caching the
+/// distance on first insert would silently pin a stale value if the manifest
+/// (or test wiring) later re-registered a new distance for the same network.
 #[derive(Debug)]
 pub(crate) struct FinalizedBuffer {
     buffer: BTreeMap<u64, Vec<Value>>,
-    reorg_safe_distance: u64,
 }
 
 impl FinalizedBuffer {
-    pub fn new(reorg_safe_distance: u64) -> Self {
-        Self { buffer: BTreeMap::new(), reorg_safe_distance }
+    pub fn new() -> Self {
+        Self { buffer: BTreeMap::new() }
     }
 
     pub fn add(&mut self, block_number: u64, events: Vec<Value>) {
         self.buffer.entry(block_number).or_default().extend(events);
     }
 
-    pub fn flush(&mut self, current_head: u64) -> Vec<(u64, Vec<Value>)> {
-        let finality_threshold = current_head.saturating_sub(self.reorg_safe_distance);
+    pub fn flush(&mut self, current_head: u64, reorg_safe_distance: u64) -> Vec<(u64, Vec<Value>)> {
+        let finality_threshold = current_head.saturating_sub(reorg_safe_distance);
         let ready_keys: Vec<u64> =
             self.buffer.keys().copied().filter(|&k| k <= finality_threshold).collect();
         ready_keys.into_iter().filter_map(|k| self.buffer.remove(&k).map(|v| (k, v))).collect()
@@ -2076,43 +2086,43 @@ mod tests {
 
     #[test]
     fn finalized_buffer_flushes_only_below_threshold() {
-        let mut buf = FinalizedBuffer::new(10);
+        let mut buf = FinalizedBuffer::new();
         buf.add(100, vec![json!({"event": "a"})]);
         buf.add(105, vec![json!({"event": "b"})]);
 
-        let flushed = buf.flush(112); // threshold = 102
+        let flushed = buf.flush(112, 10); // threshold = 102
         assert_eq!(flushed.len(), 1);
         assert_eq!(flushed[0].0, 100);
 
-        let flushed2 = buf.flush(120);
+        let flushed2 = buf.flush(120, 10);
         assert_eq!(flushed2.len(), 1);
         assert_eq!(flushed2[0].0, 105);
     }
 
     #[test]
     fn finalized_buffer_discards_range_inclusive() {
-        let mut buf = FinalizedBuffer::new(10);
+        let mut buf = FinalizedBuffer::new();
         buf.add(98, vec![json!({"event": "a"})]);
         buf.add(99, vec![json!({"event": "b"})]);
         buf.add(100, vec![json!({"event": "c"})]);
 
         buf.discard_range(99, 100);
 
-        let flushed = buf.flush(200);
+        let flushed = buf.flush(200, 10);
         assert_eq!(flushed.len(), 1);
         assert_eq!(flushed[0].0, 98);
     }
 
     #[test]
     fn finalized_buffer_discard_on_empty_is_noop() {
-        let mut buf = FinalizedBuffer::new(10);
+        let mut buf = FinalizedBuffer::new();
         buf.discard_range(5, 10);
         assert_eq!(buf.len(), 0);
     }
 
     #[test]
     fn finalized_buffer_add_merges_same_block() {
-        let mut buf = FinalizedBuffer::new(10);
+        let mut buf = FinalizedBuffer::new();
         buf.add(50, vec![json!({"a": 1})]);
         buf.add(50, vec![json!({"a": 2})]);
         assert_eq!(buf.len(), 2);
@@ -2142,7 +2152,7 @@ mod tests {
             event_signature_hash: B256::ZERO,
         };
         let mut map = clients.finalized_buffers.lock().await;
-        let buf = map.entry(key).or_insert_with(|| FinalizedBuffer::new(distance));
+        let buf = map.entry(key).or_insert_with(FinalizedBuffer::new);
         for &b in blocks {
             buf.add(b, vec![json!({"block": b})]);
         }
@@ -2318,7 +2328,7 @@ mod tests {
             event_signature_hash: B256::ZERO,
         };
         let mut map = clients.finalized_buffers.lock().await;
-        let buf = map.entry(key).or_insert_with(|| FinalizedBuffer::new(distance));
+        let buf = map.entry(key).or_insert_with(FinalizedBuffer::new);
         for &b in blocks {
             buf.add(b, vec![json!({"block": b})]);
         }
@@ -2390,5 +2400,44 @@ mod tests {
         );
         good.assert_async().await;
         bad.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn flush_finalized_respects_re_registered_larger_distance() {
+        // I3 regression: the per-buffer distance must come from the registry
+        // at flush time, not be cached inside `FinalizedBuffer` at first
+        // insert. The scary direction: a distance that is re-registered
+        // LARGER after the buffer exists must take effect — otherwise events
+        // flush too early relative to the newly-configured reorg-safe
+        // window, which is a silent correctness deviation from the manifest.
+        let mut server = mockito::Server::new_async().await;
+        // Expect zero hits: under the re-registered distance of 50, head=110
+        // is not enough to surface block 100 (110 - 50 = 60 < 100).
+        let mock = server.mock("POST", "/hook").expect(0).create_async().await;
+
+        let config = WebhookStreamConfig {
+            endpoint: format!("{}/hook", server.url()),
+            shared_secret: "s".to_string(),
+            networks: vec!["ethereum".to_string()],
+            events: vec![stream_event("Transfer")],
+            delivery: None,
+        };
+        let clients = webhook_clients(vec![config]);
+
+        // Seed under distance=10 (so block 100 would be ready at head 110).
+        seed_buffer(&clients, "ethereum", "Transfer", &[100], 10).await;
+
+        // Re-register a larger distance. Post-fix, this must take effect on
+        // the next flush.
+        clients.register_network_reorg_distance("ethereum".to_string(), 50);
+        let sent = clients.flush_finalized("ethereum", 110).await.unwrap();
+
+        assert_eq!(sent, 0, "flush must honor the newly-registered larger distance");
+        assert_eq!(
+            buffered_blocks(&clients, "ethereum").await,
+            vec![100],
+            "block 100 must remain buffered under the re-registered distance of 50"
+        );
+        mock.assert_async().await;
     }
 }

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -522,6 +522,7 @@ impl StreamsClients {
             );
             stream_metrics::record_finalized_buffer_overflow(stream_type, &event_message.network);
         }
+        Self::refresh_depth_gauge_under_lock(&map, &event_message.network);
     }
 
     fn should_send_for_config(
@@ -1170,6 +1171,7 @@ impl StreamsClients {
         // updates take effect on the next flush without needing to reset the
         // buffer map.
         let distance = self.reorg_safe_distance_for(network);
+        let flush_start = Instant::now();
         let mut ready_by_key: Vec<FinalizedDeliveryBuffer> = Vec::new();
         {
             let mut map = self.finalized_buffers.lock().await;
@@ -1182,6 +1184,7 @@ impl StreamsClients {
                     ready_by_key.push((key.clone(), ready));
                 }
             }
+            Self::refresh_depth_gauge_under_lock(&map, network);
         }
 
         // Continue-on-error across keys: a persistent publish failure on one
@@ -1202,10 +1205,48 @@ impl StreamsClients {
                 }
             }
         }
+        stream_metrics::record_finalized_flush_duration(
+            network,
+            flush_start.elapsed().as_secs_f64(),
+        );
         if let Some(e) = first_err {
             return Err(e);
         }
         Ok(total_sent)
+    }
+
+    /// Sum the buffer size per `(stream_type, network)` for `network` across
+    /// every entry in `map` and push the result into the depth gauge. Assumes
+    /// the caller holds `finalized_buffers` lock — emits no metric if
+    /// `network` has no buffer entries at all (leaving any stale gauge value
+    /// untouched would be misleading, so explicitly zero out on empty).
+    fn refresh_depth_gauge_under_lock(map: &HashMap<BufferKey, FinalizedBuffer>, network: &str) {
+        // Collect per-stream_type counts for this network. Any stream_type
+        // that has NO current entries for the network must still be zeroed
+        // out on the gauge, otherwise a gauge for a buffer that fully
+        // drained would get stuck at its last non-zero value.
+        let mut totals: HashMap<&'static str, u64> = HashMap::new();
+        for (key, buf) in map.iter() {
+            if key.network != network {
+                continue;
+            }
+            *totals.entry(key.stream_type).or_default() += buf.len() as u64;
+        }
+        // Zero out any stream_type that previously had a gauge emission for
+        // this network but is now empty. We only track `totals` keys — a
+        // stream_type never observed on this network has no prior emission
+        // and needs no zero write.
+        for known_stream_type in [
+            stream_type::SNS,
+            stream_type::WEBHOOK,
+            stream_type::RABBITMQ,
+            stream_type::KAFKA,
+            stream_type::REDIS,
+            stream_type::CLOUDFLARE_QUEUES,
+        ] {
+            let depth = totals.remove(known_stream_type).unwrap_or(0);
+            stream_metrics::set_finalized_buffer_depth(known_stream_type, network, depth as f64);
+        }
     }
 
     /// Remove buffered events for `network` whose source block falls in the
@@ -1220,6 +1261,7 @@ impl StreamsClients {
             }
             buffer.discard_range(fork_point, detection_point);
         }
+        Self::refresh_depth_gauge_under_lock(&map, network);
     }
 
     /// Re-publish a block's worth of previously-buffered events through the
@@ -2438,6 +2480,53 @@ mod tests {
             vec![100],
             "block 100 must remain buffered under the re-registered distance of 50"
         );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn finalized_buffer_depth_gauge_tracks_add_and_flush() {
+        // I4 regression: the finalized-buffer depth gauge must reflect the
+        // current in-memory buffer size per (stream_type, network) so
+        // operators can alert on stuck buffers. Pre-fix, only an overflow
+        // counter existed — useless for answering "is the buffer draining?".
+        use crate::metrics::definitions::STREAM_FINALIZED_BUFFER_DEPTH;
+
+        // Isolate this test from others by using a label combination unlikely
+        // to collide with other tests' metric emissions.
+        let network = "depth_gauge_test_network";
+
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("POST", "/hook").with_status(200).expect(1).create_async().await;
+        let config = WebhookStreamConfig {
+            endpoint: format!("{}/hook", server.url()),
+            shared_secret: "s".to_string(),
+            networks: vec![network.to_string()],
+            events: vec![stream_event("Transfer")],
+            delivery: None,
+        };
+        let clients = webhook_clients(vec![config]);
+
+        // Start: gauge should be 0 (no buffered events for this network).
+        let before =
+            STREAM_FINALIZED_BUFFER_DEPTH.with_label_values(&[stream_type::WEBHOOK, network]).get();
+        assert_eq!(before, 0.0, "depth gauge must start at zero");
+
+        // Seed a buffered event — the gauge should move to 1.
+        seed_buffer(&clients, network, "Transfer", &[100], 10).await;
+        // Trigger a gauge refresh through a production code path. We call
+        // flush_finalized at a head below threshold so nothing drains, but
+        // the depth gauge is refreshed as part of the flush.
+        let _ = clients.flush_finalized(network, 50).await.unwrap();
+        let after_seed =
+            STREAM_FINALIZED_BUFFER_DEPTH.with_label_values(&[stream_type::WEBHOOK, network]).get();
+        assert_eq!(after_seed, 1.0, "depth gauge must track buffered event count");
+
+        // Drain — gauge must drop back to zero.
+        let sent = clients.flush_finalized(network, 110).await.unwrap();
+        assert_eq!(sent, 1);
+        let after_flush =
+            STREAM_FINALIZED_BUFFER_DEPTH.with_label_values(&[stream_type::WEBHOOK, network]).get();
+        assert_eq!(after_flush, 0.0, "depth gauge must return to zero after a complete drain");
         mock.assert_async().await;
     }
 }

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -466,17 +466,20 @@ impl StreamsClients {
     }
 
     /// Returns `true` when the dispatch should be routed into the
-    /// `FinalizedBuffer` instead of publishing immediately. Reorg notifications
-    /// (`force_send_network_wide`) and trace events always bypass the buffer;
-    /// `block_number == 0` is a sentinel for synthetic messages that likewise
-    /// never buffer.
+    /// `FinalizedBuffer` instead of publishing immediately. Reorg
+    /// notifications (`force_send_network_wide`) and synthetic messages
+    /// (`block_number == 0`) bypass the buffer. Trace (native-transfer)
+    /// events DO buffer when the user opts into `Finalized` delivery —
+    /// `finalized_buffer_distance_for_network` already accounts for
+    /// `manifest.native_transfers.reorg_safe_distance`, and the flush path's
+    /// `filter_chunk_event_data_by_conditions` passes trace chunks through
+    /// unfiltered when no explicit stream_event is configured.
     fn should_buffer(
         delivery: Option<&crate::manifest::stream::StreamDeliveryMode>,
         event_message: &EventMessage,
-        is_trace_event: bool,
         force_send_network_wide: bool,
     ) -> bool {
-        if force_send_network_wide || is_trace_event {
+        if force_send_network_wide {
             return false;
         }
         if event_message.block_number == 0 {
@@ -873,7 +876,6 @@ impl StreamsClients {
                         if Self::should_buffer(
                             config.delivery.as_ref(),
                             event_message,
-                            is_trace_event,
                             force_send_network_wide,
                         ) {
                             self.buffer_event(stream_type::SNS, idx, event_message).await;
@@ -903,7 +905,6 @@ impl StreamsClients {
                         if Self::should_buffer(
                             config.delivery.as_ref(),
                             event_message,
-                            is_trace_event,
                             force_send_network_wide,
                         ) {
                             self.buffer_event(stream_type::WEBHOOK, idx, event_message).await;
@@ -933,7 +934,6 @@ impl StreamsClients {
                         if Self::should_buffer(
                             config.delivery.as_ref(),
                             event_message,
-                            is_trace_event,
                             force_send_network_wide,
                         ) {
                             self.buffer_event(stream_type::RABBITMQ, idx, event_message).await;
@@ -964,7 +964,6 @@ impl StreamsClients {
                         if Self::should_buffer(
                             config.delivery.as_ref(),
                             event_message,
-                            is_trace_event,
                             force_send_network_wide,
                         ) {
                             self.buffer_event(stream_type::KAFKA, idx, event_message).await;
@@ -994,7 +993,6 @@ impl StreamsClients {
                         if Self::should_buffer(
                             config.delivery.as_ref(),
                             event_message,
-                            is_trace_event,
                             force_send_network_wide,
                         ) {
                             self.buffer_event(stream_type::REDIS, idx, event_message).await;
@@ -1024,7 +1022,6 @@ impl StreamsClients {
                         if Self::should_buffer(
                             config.delivery.as_ref(),
                             event_message,
-                            is_trace_event,
                             force_send_network_wide,
                         ) {
                             self.buffer_event(stream_type::CLOUDFLARE_QUEUES, idx, event_message)
@@ -1798,6 +1795,57 @@ mod tests {
 
         assert!(result.is_ok());
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn stream_trace_event_with_finalized_delivery_buffers_instead_of_sending() {
+        // I2 regression: a NativeTransfer / trace event on a stream configured
+        // with `delivery: finalized` must be buffered, not delivered
+        // instantly. Pre-fix, `should_buffer` unconditionally bypassed the
+        // buffer when `is_trace_event == true`, so users opting into
+        // finalized delivery on native-transfer streams got instant delivery
+        // with no warning — a silent violation of the configured reorg
+        // safety expectation.
+        let mut server = mockito::Server::new_async().await;
+        // Expect ZERO hits: buffered means nothing should reach the endpoint
+        // until flush_finalized is invoked.
+        let mock = server.mock("POST", "/hook").expect(0).create_async().await;
+
+        let config = WebhookStreamConfig {
+            endpoint: format!("{}/hook", server.url()),
+            shared_secret: "s".to_string(),
+            networks: vec!["ethereum".to_string()],
+            events: vec![stream_event("Transfer")], // no NativeTransfer entry
+            delivery: Some(crate::manifest::stream::StreamDeliveryMode::Finalized),
+        };
+
+        let clients = webhook_clients(vec![config]);
+        // Simulate coordinator registering the network's reorg distance at
+        // startup. Without this, FinalizedBuffer::new would be created with 0
+        // and the next flush would leak the event instantly.
+        clients.register_network_reorg_distance("ethereum".to_string(), 10);
+
+        let msg = EventMessage {
+            event_name: "NativeTransfer".to_string(),
+            event_data: json!([{"from": "0x1", "to": "0x2", "value": "1000"}]),
+            event_signature_hash: B256::ZERO,
+            network: "ethereum".to_string(),
+            block_number: 100,
+        };
+
+        let sent = clients
+            .stream("id".to_string(), &msg, false, true) // is_trace_event = true
+            .await
+            .unwrap();
+
+        // Post-fix: buffered, not dispatched. Pre-fix: hit the endpoint.
+        assert_eq!(sent, 0, "finalized trace event must not dispatch instantly");
+        mock.assert_async().await;
+        assert_eq!(
+            buffered_blocks(&clients, "ethereum").await,
+            vec![100],
+            "event must be parked in the finalized buffer for later flush"
+        );
     }
 
     #[tokio::test]

--- a/core/src/streams/webhook.rs
+++ b/core/src/streams/webhook.rs
@@ -72,16 +72,16 @@ impl Webhook {
 /// with many distinct webhook URLs would blow Prometheus TSDB cardinality.
 /// Extracting `host[:port]` bounds the label set to the number of distinct
 /// destination hosts (typically a handful) while still letting operators
-/// identify which host is dropping events. Falls back to `"unknown"` if URL
-/// parsing fails — we'd rather lose the label than panic in a hot path.
-pub(crate) fn webhook_target_label(endpoint: &str) -> String {
+/// identify which host is dropping events.
+fn webhook_target_label(endpoint: &str) -> String {
+    const UNKNOWN: &str = "unknown";
     match reqwest::Url::parse(endpoint) {
         Ok(url) => match (url.host_str(), url.port()) {
             (Some(host), Some(port)) => format!("{host}:{port}"),
             (Some(host), None) => host.to_string(),
-            (None, _) => "unknown".to_string(),
+            (None, _) => UNKNOWN.to_string(),
         },
-        Err(_) => "unknown".to_string(),
+        Err(_) => UNKNOWN.to_string(),
     }
 }
 

--- a/core/src/streams/webhook.rs
+++ b/core/src/streams/webhook.rs
@@ -29,7 +29,11 @@ impl Webhook {
         shared_secret: &str,
         message: &Value,
     ) -> Result<(), WebhookError> {
-        publish_with_retry("webhook", endpoint, || {
+        // Use a bounded host[:port] label instead of the raw URL — the raw
+        // URL is unbounded and would explode Prometheus cardinality on
+        // `STREAM_PUBLISH_DROPPED_TOTAL` for multi-tenant webhook fanouts.
+        let target = webhook_target_label(endpoint);
+        publish_with_retry("webhook", &target, || {
             self.publish_once(id, endpoint, shared_secret, message)
         })
         .await
@@ -63,10 +67,51 @@ impl Webhook {
     }
 }
 
+/// Stable low-cardinality label for `STREAM_PUBLISH_DROPPED_TOTAL` on
+/// webhooks. The raw endpoint URL is unbounded — multi-tenant deployments
+/// with many distinct webhook URLs would blow Prometheus TSDB cardinality.
+/// Extracting `host[:port]` bounds the label set to the number of distinct
+/// destination hosts (typically a handful) while still letting operators
+/// identify which host is dropping events. Falls back to `"unknown"` if URL
+/// parsing fails — we'd rather lose the label than panic in a hot path.
+pub(crate) fn webhook_target_label(endpoint: &str) -> String {
+    match reqwest::Url::parse(endpoint) {
+        Ok(url) => match (url.host_str(), url.port()) {
+            (Some(host), Some(port)) => format!("{host}:{port}"),
+            (Some(host), None) => host.to_string(),
+            (None, _) => "unknown".to_string(),
+        },
+        Err(_) => "unknown".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn webhook_target_label_strips_path_query_and_scheme() {
+        // Raw URLs have unbounded path/query combinations; the label must
+        // reduce to a stable host[:port] so Prometheus cardinality is
+        // bounded by the number of distinct destination hosts.
+        assert_eq!(
+            webhook_target_label("https://api.example.com/hooks/xyz?token=abc"),
+            "api.example.com"
+        );
+        assert_eq!(webhook_target_label("http://127.0.0.1:8080/hook"), "127.0.0.1:8080");
+        // Non-standard default port preserved when explicit.
+        assert_eq!(
+            webhook_target_label("https://events.example.com:8443/path"),
+            "events.example.com:8443"
+        );
+    }
+
+    #[test]
+    fn webhook_target_label_falls_back_on_unparseable() {
+        assert_eq!(webhook_target_label("not a url"), "unknown");
+        assert_eq!(webhook_target_label(""), "unknown");
+    }
 
     #[tokio::test]
     async fn publish_sends_correct_headers() {

--- a/core/tests/e2e_hist_to_live_dup.rs
+++ b/core/tests/e2e_hist_to_live_dup.rs
@@ -18,8 +18,23 @@
 //!
 //! Requires Docker. Run via nextest so each test gets its own process:
 //!   cargo nextest run -q -p rindexer --test e2e_hist_to_live_dup
+//!
+//! # Isolation invariant
+//!
+//! This test mutates process-global state (`DATABASE_URL` env var,
+//! `_test_reset_shutdown_flag()` AtomicBool in `rindexer::system_state`).
+//! It MUST run in its own process. `.github/workflows/ci.yml` pins
+//! `cargo nextest run` everywhere including coverage, and nextest's default
+//! `run-as-child = true` fork-per-test guarantees isolation.
+//!
+//! `TestEnv::new` enforces the invariant at runtime via a per-process
+//! `AtomicBool`: constructing a second `TestEnv` in the same process panics.
+//! This surfaces a broken test harness immediately if someone either (a)
+//! adds a second `#[tokio::test]` to this file and runs under plain
+//! `cargo test`, or (b) removes the nextest requirement from CI.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use alloy::primitives::Address;
@@ -209,8 +224,21 @@ struct TestEnv {
     _anvil_container: testcontainers::ContainerAsync<GenericImage>,
 }
 
+/// Tripped when `TestEnv::new` sets `DATABASE_URL`. Constructing a second
+/// `TestEnv` in the same process panics — see the module-level "Isolation
+/// invariant" docs for rationale.
+static TEST_ENV_ALREADY_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
 impl TestEnv {
     async fn new() -> Self {
+        assert!(
+            !TEST_ENV_ALREADY_INITIALIZED.swap(true, Ordering::SeqCst),
+            "TestEnv::new called more than once in the same process — this test \
+             mutates process-global state (DATABASE_URL, shutdown flag) and MUST \
+             run under `cargo nextest run` so each test gets its own process. \
+             See the `// Isolation invariant` module docs."
+        );
+
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let pg_container =


### PR DESCRIPTION
Follow-up to #418. The post-merge code review surfaced one critical correctness bug, four behavioral / observability issues, and a fragile test pattern. This PR fixes them all, with each commit isolated to a single concern.

## The critical bug — silent cross-backend data loss

When a stream config has `delivery: finalized`, events are buffered per-backend until reorg-safe, then drained and published. The drain logic looped over every per-backend buffer and propagated the first publish error with `?`. That looks innocent — but the buffers had already been drained into memory by the time the loop ran. So if backend A's webhook was permanently broken (returned 500 to every retry), and backend B was healthy, the iteration order of a `HashMap` decided whether B's events ever reached its endpoint. When A's key came first, B's already-drained events were silently dropped — no `STREAM_PUBLISH_DROPPED_TOTAL` increment, no log line, no alert.

The fix continues across keys, records each backend's drops at the per-publisher retry layer (so observability is preserved), and surfaces only the first error after every key has had a chance to dispatch. The same pattern is now mirrored at the within-key level inside `dispatch_flushed`, so partial successes within a single backend's batch are also accounted for consistently.

## Three "silently does the wrong thing" behavioral bugs

**Native-transfer streams ignored `delivery: finalized`.** A user opting into reorg-safe delivery on a native-transfer stream got instant delivery instead, with no warning. The buffer-routing predicate had a blanket `is_trace_event` bypass that predated finalized delivery; meanwhile `finalized_buffer_distance_for_network` already accounted for the native-transfers `reorg_safe_distance`, so half the plumbing was set up for a feature that the routing layer silently disabled. Removing the bypass routes trace events through the same buffer/flush path as contract events. The flush-time filter already had an `EVENT_NAME` passthrough for unconfigured trace events, which the new test now drives end-to-end so a future refactor can't silently re-introduce the panic.

**`reorg_safe_distance` was pinned at first insert.** The buffer struct stored the distance as a field set when the first event arrived. Later calls to `register_network_reorg_distance` (e.g. from manifest reloads, or just call ordering at startup) couldn't change a buffer that already existed. A user increasing their reorg-safe window in config got no error, no warning — the buffer just kept flushing under the old, smaller distance. The fix removes the field and reads the registry at every flush. The two regression tests cover both directions: re-registering larger (events should stay parked longer than the original distance permitted) and re-registering smaller (events that were stuck should drain).

**Webhook target labels exploded Prometheus cardinality.** `STREAM_PUBLISH_DROPPED_TOTAL`'s `target` label was the raw endpoint URL. For multi-tenant deployments with many distinct webhook URLs (a documented usage pattern in this codebase), this produces unbounded cardinality and well-documented Prometheus TSDB pathology. The fix strips down to `host[:port]` — bounded by the count of distinct destination hosts (typically a handful), still enough for an operator to identify which host is dropping. As a side benefit, `Url::host_str()` strips URL userinfo, so credentials embedded in webhook URLs can no longer leak into the metric label.

## The observability gap

Pre-PR, the only signal for the finalized buffer was an overflow counter. On-call could see "the buffer breached the soft cap" but had no way to answer the actual operational question: "is the buffer draining?" The new `STREAM_FINALIZED_BUFFER_DEPTH` gauge (per stream_type × network) tracks the live in-memory size; the `STREAM_FINALIZED_FLUSH_DURATION` histogram tracks per-flush wall-clock time. Both are wired into the existing buffer mutation paths under the same lock that serializes the buffer state, so the gauge is consistent with what the next flush would observe. The gauge zero-out loop iterates every label in `stream_type::ALL` so a fully-drained buffer doesn't leak its last non-zero value (a Prometheus gauge gotcha — `set` is sticky until the next call).

Critically, the gauge updates when an event leaves the in-memory buffer, not when its downstream publish completes. The doc-comment now spells this out so on-call's mental model lines up with the implementation.

## The fragile test

`e2e_hist_to_live_dup` mutates `DATABASE_URL` and a process-global shutdown `AtomicBool`. CI already enforces nextest's per-test process isolation, but nothing in the test itself surfaced a violation if someone added a second `#[tokio::test]` to the file or accidentally ran it under plain `cargo test`. A runtime `AtomicBool` guard in `TestEnv::new` now panics on the second construction with a message that points at both the root cause (process-global state) and the resolution (run via nextest).

## What was deliberately skipped

The review surfaced two items the reviewer themselves marked "no fix needed" (`Url::parse` on hot path — microseconds; `AtomicBool` panic-loudly behavior on container-startup failure — intentional). One item (converting `stream_type` from string constants to a closed enum, removing the implicit-list drift between `stream_type::ALL` and the dispatch match) was marked "out of scope for this branch" — it's a substantial refactor across many call sites and would balloon this PR's footprint. Filed for a future cleanup.

The pre-existing `discard_range` BTreeMap optimization the reviewer flagged in passing is also out of scope — it's pre-existing code, not part of this PR's diff.

## Files changed

```
core/src/metrics/definitions.rs    |  38 +++
core/src/metrics/streams.rs        |  20 +-
core/src/streams/clients.rs        | 332 +++++++++++++++++++++++++++++--
core/src/streams/webhook.rs        |  47 +++-
core/tests/e2e_hist_to_live_dup.rs |  30 +++
5 files changed, 451 insertions(+), 16 deletions(-)
```

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -- -D warnings` (CI-equivalent — lib + bins)
- [x] `cargo test -p rindexer --lib` → 702 passed, 4 ignored
- [x] `cargo test -p rindexer --test e2e_finalized_delivery` → 4 passed
- [x] `cargo test --no-run -p rindexer --test e2e_hist_to_live_dup` → compiles (docker-gated; CI runs via nextest)
- [x] New regression test for every fix; the pre-existing tests for the merged feature all still pass
- [ ] CI green (will verify post-push)