### PR TITLE
fix: adapt generated code to address clippy warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "clickhouse_factory_indexing"
-version = "0.40.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -4255,7 +4255,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e-tests"
-version = "0.40.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -12208,7 +12208,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_factory_contract"
-version = "0.40.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -12218,7 +12218,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_rust_playground"
-version = "0.40.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -12434,7 +12434,7 @@ dependencies = [
 
 [[package]]
 name = "rust_clickhouse"
-version = "0.40.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -16259,7 +16259,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.40.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/core/src/generator/events_bindings.rs
+++ b/core/src/generator/events_bindings.rs
@@ -519,7 +519,7 @@ impl<TExtensions> {event_type_name}<TExtensions> where TExtensions: 'static + Se
           let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -554,7 +554,7 @@ impl<TExtensions> {event_type_name}<TExtensions> where TExtensions: 'static + Se
                                                     .networks
                                                     .iter()
                                                     .find(|n| n.name == c.network)
-                                                    .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                                                    .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }}
                 }})
                 .collect(),

--- a/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory.rs
+++ b/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory.rs
@@ -291,7 +291,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -326,7 +326,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory_pool_created_pool.rs
+++ b/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory_pool_created_pool.rs
@@ -292,7 +292,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -327,7 +327,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory_pool_created_token_0_token_1.rs
+++ b/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory_pool_created_token_0_token_1.rs
@@ -293,7 +293,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -328,7 +328,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_pool.rs
+++ b/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_pool.rs
@@ -370,7 +370,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -405,7 +405,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_pool_token.rs
+++ b/examples/clickhouse_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_pool_token.rs
@@ -275,7 +275,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -310,7 +310,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory.rs
+++ b/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory.rs
@@ -314,7 +314,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -349,7 +349,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory_pool_created_pool.rs
+++ b/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory_pool_created_pool.rs
@@ -316,7 +316,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -351,7 +351,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory_pool_created_token_0_token_1.rs
+++ b/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_factory_pool_created_token_0_token_1.rs
@@ -317,7 +317,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -352,7 +352,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_pool.rs
+++ b/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_pool.rs
@@ -398,7 +398,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -433,7 +433,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_pool_token.rs
+++ b/examples/rindexer_factory_indexing/src/rindexer_lib/typings/rindexer_factory_contract/events/uniswap_v3_pool_token.rs
@@ -299,7 +299,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -334,7 +334,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/erc_20_filter.rs
+++ b/examples/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/erc_20_filter.rs
@@ -419,7 +419,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -454,7 +454,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/rocket_pool_eth.rs
+++ b/examples/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/rocket_pool_eth.rs
@@ -435,7 +435,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -470,7 +470,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/uniswap_v3_pool_filter.rs
+++ b/examples/rindexer_rust_playground/src/rindexer_lib/typings/rindexer_playground/events/uniswap_v3_pool_filter.rs
@@ -393,7 +393,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -428,7 +428,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),

--- a/examples/rust_clickhouse/src/rindexer_lib/typings/clickhouse_indexer/events/rocket_pool.rs
+++ b/examples/rust_clickhouse/src/rindexer_lib/typings/clickhouse_indexer/events/rocket_pool.rs
@@ -314,7 +314,7 @@ where
         let index_event_in_order = contract_details
             .index_event_in_order
             .as_ref()
-            .map_or(false, |vec| vec.contains(&event_name.to_string()));
+            .is_some_and(|vec| vec.contains(&event_name.to_string()));
 
         // Expect providers to have been initialized, but it's an async init so this should
         // be fast but for correctness we must await each future.
@@ -349,7 +349,7 @@ where
                             .networks
                             .iter()
                             .find(|n| n.name == c.network)
-                            .map_or(false, |n| n.disable_logs_bloom_checks.unwrap_or_default()),
+                            .is_some_and(|n| n.disable_logs_bloom_checks.unwrap_or_default()),
                     }
                 })
                 .collect(),


### PR DESCRIPTION
Summary:
From Rust 1.95.0, `map_or` creates a warning that `is_some_and` should be preferred over it.

Our generated code uses it in 2 places, causing clippy warnings.

This PR replaces the generated code and regenerates examples accordingly.