### PR TITLE
fix: add missing watch field to StartDetails in generated code and docs

### DIFF
--- a/core/src/generator/build.rs
+++ b/core/src/generator/build.rs
@@ -579,6 +579,7 @@ serde = {{ version = "1.0", features = ["derive"] }}
                                 override_port: port,
                             },
                             cron_scheduler_handle: None,
+                            watch: false,
                         })
                         .await;
 

--- a/core/src/generator/build.rs
+++ b/core/src/generator/build.rs
@@ -603,3 +603,59 @@ serde = {{ version = "1.0", features = ["derive"] }}
     generate_rindexer_typings_and_handlers(&manifest_location)
         .map_err(GenerateRustProjectError::GenerateError)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_file_location_appends_rs_extension() {
+        let output = Path::new("/some/output");
+        let result = generate_file_location(output, "networks");
+        assert_eq!(result, PathBuf::from("/some/output/networks.rs"));
+    }
+
+    #[test]
+    fn generate_file_location_handles_nested_location() {
+        let output = Path::new("/some/output");
+        let result = generate_file_location(output, "my_indexer/events/transfer");
+        assert_eq!(result, PathBuf::from("/some/output/my_indexer/events/transfer.rs"));
+    }
+
+    #[test]
+    fn write_global_replaces_existing_file() {
+        let dir = tempfile::tempdir().expect("could not create temp dir");
+        let stale_path = dir.path().join("global_contracts.rs");
+        fs::write(&stale_path, "// stale content").expect("could not write stale file");
+        assert!(stale_path.exists());
+
+        write_global(dir.path(), &[], &[]).expect("write_global failed");
+
+        let content = fs::read_to_string(&stale_path).expect("global_contracts.rs was not created");
+        assert!(!content.contains("stale content"), "old file content should have been replaced");
+    }
+
+    #[test]
+    fn write_networks_creates_file_with_network_name() {
+        let dir = tempfile::tempdir().expect("could not create temp dir");
+        let network = Network {
+            name: "ethereum".to_string(),
+            chain_id: 1,
+            rpc: "https://eth.example.com".to_string(),
+            block_poll_frequency: None,
+            compute_units_per_second: None,
+            max_block_range: None,
+            get_logs_settings: None,
+            disable_logs_bloom_checks: None,
+            multicall3_address: None,
+            reth: None,
+            reorg_handling: None,
+        };
+
+        write_networks(dir.path(), &[network]).expect("write_networks failed");
+
+        let written = fs::read_to_string(dir.path().join("networks.rs"))
+            .expect("networks.rs was not created");
+        assert!(written.contains("ethereum"), "expected network name in generated file");
+    }
+}

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -7,7 +7,7 @@
 ### Bug fixes
 -------------------------------------------------
 - fix: Handle int/uint array types (e.g. `uint256[]`) in `parse_solidity_integer_type` to prevent ParseIntError during codegen
-
+- fix: add missing watch field to StartDetails in generated code and docs
 - fix: ClickHouse hash serialization so String are stored as proper strings instead of corrupted scientific-notation values.
 - fix: native-transfer indexing no longer panics on trace batches containing only block entries (empty blocks).
 - fix: **Live-indexing heartbeat log replaced** — the previous `"No new blocks published in the last 5 minutes"` info log fired spuriously whenever the RPC provider returned a cached tip (every ~half block-time) and could not distinguish a healthy cache hit from a genuinely stuck RPC. It is replaced with a new tip-advance heartbeat that emits either `"Indexing alive - chain tip X"` (info) when the tip has advanced within the interval, or `"RPC tip has not advanced past block X in the last 5 minutes"` (warn) when the tip is genuinely stuck. Log-based alerts that grepped the old message must be updated to match the new warn text.

--- a/documentation/docs/pages/docs/start-building/rust-project-deep-dive/indexers.mdx
+++ b/documentation/docs/pages/docs/start-building/rust-project-deep-dive/indexers.mdx
@@ -1072,6 +1072,8 @@ async fn main() {
                     enabled: enable_graphql,
                     override_port: port,
                 },
+                cron_scheduler_handle: None,
+                watch: false,
             })
             .await;
 
@@ -1179,6 +1181,8 @@ async fn main() {
                     enabled: false,
                     override_port: None,
                 },
+                cron_scheduler_handle: None,
+                watch: false,
             })
             .await;
 


### PR DESCRIPTION
  ## Summary
  - The `watch: bool` field was added to `StartDetails` (as part of hot-reload support) but the code template in `build.rs` that generates user Rust projects was not updated, any project scaffolded  after that change would fail to compile with a missing struct field error.
  - Fixed the two `StartDetails` examples in `indexers.mdx` that were also missing both watch and `cron_scheduler_handle`, these would have failed to compile if copy-pasted by users.
  - Hot-reload is documented as unsupported for Rust projects, so `watch: false` is the correct hardcoded value in both the generator template and the docs.

## Test Plan
  - Run `rindexer new rust` to scaffold a new Rust project and verify it compiles without errors
  - Confirm the generated `main.rs` contains `watch: false` in the `StartDetails` initializer