### PR TITLE
fix: task_tracker underflow

### DIFF
--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -708,12 +708,7 @@ async fn live_indexing_for_contract_event_dependencies(
                     .lock()
                     .await = ordering_live_indexing_details;
 
-                update_progress_and_last_synced_task(
-                    Arc::clone(config),
-                    to_block,
-                    indexing_event_processed,
-                )
-                .await;
+                update_progress_and_last_synced_task(Arc::clone(config), to_block, || {}).await;
                 continue;
             }
 

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -708,7 +708,15 @@ async fn live_indexing_for_contract_event_dependencies(
                     .lock()
                     .await = ordering_live_indexing_details;
 
-                update_progress_and_last_synced_task(Arc::clone(config), to_block, || {}).await;
+                // No event task spawns on this skip path, but the checkpoint write below
+                // must still be tracked so graceful shutdown waits for it.
+                indexing_event_processing();
+                update_progress_and_last_synced_task(
+                    Arc::clone(config),
+                    to_block,
+                    indexing_event_processed,
+                )
+                .await;
                 continue;
             }
 

--- a/core/src/indexer/task_tracker.rs
+++ b/core/src/indexer/task_tracker.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use once_cell::sync::Lazy;
+use tracing::warn;
 
 use crate::metrics::indexing as metrics;
 
@@ -12,7 +13,15 @@ pub fn indexing_event_processing() {
 }
 
 pub fn indexing_event_processed() {
-    INDEXING_TASKS.fetch_sub(1, Ordering::SeqCst);
+    // Skip the decrement at 0 so the unsigned counter can't underflow;
+    if INDEXING_TASKS
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+        .is_err()
+    {
+        warn!("indexing_event_processed called with no active task, counter imbalance");
+        return;
+    }
+
     metrics::dec_active_tasks();
 }
 

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -5,6 +5,7 @@
 
 ### Bug fixes
 -------------------------------------------------
+- fix: graceful shutdown no longer loops forever ("N active indexing tasks pending" with a huge N) when live indexing skipped empty blocks via the logs-bloom check — the skip path underflowed the active task counter ([#432](https://github.com/joshstevens19/rindexer/pull/432))
 
 ### Features
 -------------------------------------------------


### PR DESCRIPTION
gm 

When shutting down gracefully, it goes on infinite loop due to bloom skipped live blocks decrementing the counter without starting a task.

```
12:39:37  INFO 18446744073709551609 active indexing tasks pending.. shutting them down gracefully
12:39:37  INFO 18446744073709551609 active indexing tasks pending.. shutting them down gracefully
```