### PR TITLE
fix(indexer): treat RPC 503/-32001 as rate limits and bound retry storms

### DIFF
--- a/core/src/adaptive_concurrency.rs
+++ b/core/src/adaptive_concurrency.rs
@@ -222,6 +222,30 @@ impl AdaptiveConcurrency {
     }
 }
 
+/// True if the error means the provider is rate-limiting us *or* is
+/// temporarily unavailable (HTTP 429/503, Alchemy `-32001`, etc.). Both warrant
+/// backing off rather than hammering the node. Matches specific tokens (e.g.
+/// `"http error 503"`, not bare `"503"`) so block numbers don't false-positive.
+pub fn is_rate_limited_or_unavailable(error_message: &str) -> bool {
+    let msg = error_message.to_lowercase();
+
+    // Classic rate-limit / throttle signals.
+    msg.contains("429")
+        || msg.contains("rate limit")
+        || msg.contains("rate-limit")
+        || msg.contains("rate exceeded")
+        || msg.contains("too many requests")
+        || msg.contains("quota")
+        || msg.contains("throttle")
+        // Temporary unavailability / overload — back off the same way.
+        || msg.contains("http error 503")
+        || msg.contains("status: 503")
+        || msg.contains("service unavailable")
+        || msg.contains("temporarily unavailable")
+        || msg.contains("unable to complete request")
+        || msg.contains("-32001")
+}
+
 /// Global adaptive concurrency controller for RPC batches. Used by the RPC
 /// layer, indexer, and parallel fetch workers.
 ///

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1,4 +1,6 @@
-use crate::adaptive_concurrency::{AdaptiveConcurrency, ADAPTIVE_CONCURRENCY};
+use crate::adaptive_concurrency::{
+    is_rate_limited_or_unavailable, AdaptiveConcurrency, ADAPTIVE_CONCURRENCY,
+};
 use crate::blockclock::BlockClock;
 use crate::database::clickhouse::client::ClickhouseClient;
 use crate::event::callback_registry::{EventCallbackRegistry, TraceCallbackRegistry};
@@ -522,6 +524,29 @@ async fn fetch_historic_logs_stream<P: ChainProvider>(
             }
         }
         Err(err) => {
+            // Rate-limit / unavailability errors aren't block-range problems, so don't
+            // shrink: back off and retry the same range (bounded by the snapshot, so valid).
+            if classify_fetch_error(&err) == FetchErrorKind::RateLimit {
+                ADAPTIVE_CONCURRENCY.record_rate_limit();
+                let backoff_ms = ADAPTIVE_CONCURRENCY.current_backoff_ms();
+                warn!(
+                    "{} - {} - Provider rate-limited/unavailable fetching logs in range {} - {}; backing off {}ms before retrying: {:?}",
+                    info_log_name,
+                    IndexingEventProgressStatus::syncing_log(),
+                    from_block,
+                    to_block,
+                    backoff_ms,
+                    err
+                );
+                if backoff_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                }
+                return Some(ProcessHistoricLogsStreamResult {
+                    next: current_filter.set_from_block(from_block).set_to_block(to_block),
+                    max_block_range_limitation,
+                });
+            }
+
             // This is fundamental to the rindexer flow. We intentionally fetch a large block range
             // to get information on what the ideal block range should be.
             if let Some(retry_result) = retry_with_block_range(
@@ -559,6 +584,7 @@ async fn fetch_historic_logs_stream<P: ChainProvider>(
                 });
             }
 
+            ADAPTIVE_CONCURRENCY.record_error();
             let halved_to_block = halved_block_number(to_block, from_block);
 
             // Handle deserialization, networking, and other non-rpc related errors.
@@ -875,12 +901,11 @@ async fn parallel_worker(
     // goes out of scope here, keeping the cleanup path single-sourced.
 }
 
-/// Classification of a recoverable fetch error. Rate-limit errors warrant
-/// the aggressive -50% scale-down + backoff in `record_rate_limit`; other
-/// errors only warrant the gentler -10% in `record_error`. Raw HTTP 429s are
-/// intercepted at the RPC layer (`layer_extensions.rs`), but provider-specific
-/// throttle phrasings ("too many requests", "quota exceeded", etc.) can reach
-/// the worker as generic errors — this is the safety net for those.
+/// Classification of a recoverable fetch error. `RateLimit` triggers the
+/// aggressive -50% scale-down + backoff (`record_rate_limit`); `Other` only the
+/// gentler -10% (`record_error`). Backstops the RPC layer for throttle/
+/// availability errors that reach the app as JSON-RPC error responses (e.g.
+/// Alchemy `-32001`) rather than the HTTP `Err` path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FetchErrorKind {
     RateLimit,
@@ -888,14 +913,7 @@ enum FetchErrorKind {
 }
 
 fn classify_fetch_error(err: &ProviderError) -> FetchErrorKind {
-    let s = err.to_string().to_lowercase();
-    if s.contains("429")
-        || s.contains("rate limit")
-        || s.contains("rate-limit")
-        || s.contains("too many requests")
-        || s.contains("quota")
-        || s.contains("throttle")
-    {
+    if is_rate_limited_or_unavailable(&err.to_string()) {
         FetchErrorKind::RateLimit
     } else {
         FetchErrorKind::Other
@@ -1599,7 +1617,40 @@ async fn live_indexing_stream(
                                         }
                                     }
                                     Err(err) => {
-                                        if let Some(retry_result) = retry_with_block_range(
+                                        // Don't shrink the range for rate-limit/unavailability
+                                        // errors: at the head (from == to) halving to from+2 fetches
+                                        // ahead of head -> -32000 -> tight zero-delay loop. Back off
+                                        // instead.
+                                        if classify_fetch_error(&err) == FetchErrorKind::RateLimit {
+                                            ADAPTIVE_CONCURRENCY.record_rate_limit();
+                                            let backoff_ms =
+                                                ADAPTIVE_CONCURRENCY.current_backoff_ms();
+
+                                            warn!(
+                                                "{} - {} - Provider rate-limited/unavailable fetching logs in range {} - {}; backing off {}ms before retrying: {:?}",
+                                                info_log_name,
+                                                IndexingEventProgressStatus::live_log(),
+                                                from_block,
+                                                to_block,
+                                                backoff_ms,
+                                                err
+                                            );
+
+                                            if backoff_ms > 0 {
+                                                tokio::time::sleep(Duration::from_millis(
+                                                    backoff_ms,
+                                                ))
+                                                .await;
+                                            }
+
+                                            // Retry against the freshly-polled tip (from_block
+                                            // untouched, no blocks skipped). Must be None, not
+                                            // Some(to_block): with reorg_safe_distance > 0 a pinned
+                                            // value ratchets down each retry and, once below
+                                            // from_block, wedges live indexing (only reset on a
+                                            // successful send, which never happens here).
+                                            log_response_to_large_to_block = None;
+                                        } else if let Some(retry_result) = retry_with_block_range(
                                             info_log_name,
                                             &err,
                                             from_block,
@@ -1620,6 +1671,7 @@ async fn live_indexing_stream(
 
                                             log_response_to_large_to_block = Some(retry_result.to);
                                         } else {
+                                            ADAPTIVE_CONCURRENCY.record_error();
                                             let halved_to_block =
                                                 halved_block_number(to_block, from_block);
 
@@ -2344,6 +2396,14 @@ mod tests {
             "Too Many Requests",
             "monthly quota exceeded",
             "request throttled by upstream",
+            // Temporary-unavailability signals — treated the same as rate limits
+            // so we back off instead of hammering the node (see the Alchemy
+            // outage incident).
+            "HTTP error 503 with body: service unavailable",
+            "Service Unavailable",
+            "node temporarily unavailable",
+            r#"ErrorResp(ErrorPayload { code: -32001, message: "Unable to complete request at this time." })"#,
+            "Max retries exceeded HTTP error 503",
         ] {
             let err = ProviderError::CustomError(msg.to_string());
             assert_eq!(
@@ -2361,6 +2421,9 @@ mod tests {
             "response is too big",
             "error decoding response body",
             "connection reset",
+            // Block numbers containing "503" must not be mistaken for an HTTP
+            // 503 — we match "http error 503"/"status: 503", not a bare "503".
+            "invalid block range params: 50312000 - 50312500",
         ] {
             let err = ProviderError::CustomError(msg.to_string());
             assert_eq!(

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -153,7 +153,7 @@ use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-use crate::adaptive_concurrency::ADAPTIVE_CONCURRENCY;
+use crate::adaptive_concurrency::{is_rate_limited_or_unavailable, ADAPTIVE_CONCURRENCY};
 use crate::database::batch_operations::{
     BatchOperationAction, BatchOperationColumnBehavior, BatchOperationSqlType, BatchOperationType,
     DynamicColumnDefinition,
@@ -677,11 +677,7 @@ async fn prefetch_view_calls(
                         ADAPTIVE_CONCURRENCY.record_success();
                     }
                     Err(e) => {
-                        let err_str = e.to_string().to_lowercase();
-                        if err_str.contains("429")
-                            || err_str.contains("rate limit")
-                            || err_str.contains("too many")
-                        {
+                        if is_rate_limited_or_unavailable(&e.to_string()) {
                             ADAPTIVE_CONCURRENCY.record_rate_limit();
                         } else {
                             ADAPTIVE_CONCURRENCY.record_error();
@@ -889,11 +885,7 @@ async fn prefetch_static_calls_via_multicall(
                         ADAPTIVE_CONCURRENCY.record_success();
                     }
                     Err(e) => {
-                        let err_str = e.to_string().to_lowercase();
-                        if err_str.contains("429")
-                            || err_str.contains("rate limit")
-                            || err_str.contains("too many")
-                        {
+                        if is_rate_limited_or_unavailable(&e.to_string()) {
                             ADAPTIVE_CONCURRENCY.record_rate_limit();
                         } else {
                             ADAPTIVE_CONCURRENCY.record_error();
@@ -1327,11 +1319,7 @@ async fn prefetch_block_timestamps(
                         Some((network_clone, blocks))
                     }
                     Err(e) => {
-                        let err_str = e.to_string().to_lowercase();
-                        if err_str.contains("429")
-                            || err_str.contains("rate limit")
-                            || err_str.contains("too many")
-                        {
+                        if is_rate_limited_or_unavailable(&e.to_string()) {
                             ADAPTIVE_CONCURRENCY.record_rate_limit();
                         } else {
                             ADAPTIVE_CONCURRENCY.record_error();

--- a/core/src/layer_extensions.rs
+++ b/core/src/layer_extensions.rs
@@ -1,4 +1,7 @@
-use crate::{adaptive_concurrency::ADAPTIVE_CONCURRENCY, rindexer_error, rindexer_info};
+use crate::{
+    adaptive_concurrency::{is_rate_limited_or_unavailable, ADAPTIVE_CONCURRENCY},
+    rindexer_error, rindexer_info,
+};
 use alloy::{
     rpc::json_rpc::{RequestPacket, ResponsePacket},
     transports::TransportError,
@@ -108,10 +111,11 @@ where
                         if error_str.contains("timeout") || error_str.contains("timed out") {
                             rindexer_error!("RPC TIMEOUT (free public nodes do this a lot consider a using a paid node) - chain_id: {}, method: {}, duration: {:?}, url: {}, error: {:?}",
                                            chain_id, method_name, duration, rpc_url, err);
-                        } else if error_str.contains("429") || error_str.contains("rate limit") {
-                            // Notify adaptive concurrency to scale down
+                        } else if is_rate_limited_or_unavailable(&error_str) {
+                            // Scale down + grow backoff. The pre-request wait above then
+                            // throttles every later call (incl. the retry layer's own retries).
                             ADAPTIVE_CONCURRENCY.record_rate_limit();
-                            rindexer_info!("RPC RATE LIMITED (free public nodes do this a lot consider using a paid node) - chain_id: {}, method: {}, duration: {:?}, url: {}, backoff: {}ms, batch_size: {}, rate_limit_count: {}",
+                            rindexer_info!("RPC RATE LIMITED / UNAVAILABLE (free public nodes do this a lot consider using a paid node) - chain_id: {}, method: {}, duration: {:?}, url: {}, backoff: {}ms, batch_size: {}, rate_limit_count: {}",
                                           chain_id, method_name, duration, rpc_url,
                                           ADAPTIVE_CONCURRENCY.current_backoff_ms(),
                                           ADAPTIVE_CONCURRENCY.current_batch_size(),

--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -1122,6 +1122,13 @@ pub enum RetryClientError {
     RethNodeStartError(String, String),
 }
 
+/// Max retries the alloy `RetryBackoffLayer` makes per request. Its backoff is
+/// effectively flat, so a huge cap turns an outage into a self-logging retry
+/// loop (an Alchemy 503 outage once produced 10k+ log lines in 25 min). Kept
+/// bounded; the `adaptive_concurrency` controller owns the real exponential
+/// backoff for sustained outages.
+const MAX_RPC_RATE_LIMIT_RETRIES: u32 = 10;
+
 #[allow(clippy::too_many_arguments)]
 pub async fn create_client(
     rpc_url: &str,
@@ -1137,8 +1144,11 @@ pub async fn create_client(
 
     let (client, provider) = if rpc_url.ends_with(".ipc") {
         let ipc = IpcConnect::new(rpc_url.to_string());
-        let retry_layer =
-            RetryBackoffLayer::new(5000, 1000, compute_units_per_second.unwrap_or(660));
+        let retry_layer = RetryBackoffLayer::new(
+            MAX_RPC_RATE_LIMIT_RETRIES,
+            1000,
+            compute_units_per_second.unwrap_or(660),
+        );
         let logging_layer = RpcLoggingLayer::new(chain_id, rpc_url.to_string());
 
         let rpc_client =
@@ -1165,8 +1175,11 @@ pub async fn create_client(
 
         let logging_layer = RpcLoggingLayer::new(chain_id, rpc_url.to_string());
         let http = Http::with_client(client_with_auth, rpc_url);
-        let retry_layer =
-            RetryBackoffLayer::new(5000, 1000, compute_units_per_second.unwrap_or(660));
+        let retry_layer = RetryBackoffLayer::new(
+            MAX_RPC_RATE_LIMIT_RETRIES,
+            1000,
+            compute_units_per_second.unwrap_or(660),
+        );
         let rpc_client =
             RpcClient::builder().layer(retry_layer).layer(logging_layer).transport(http, false);
         let provider =


### PR DESCRIPTION
## Description

During an Alchemy outage, rindexer generated **10k+ ERROR log lines in ~25 minutes** while retrying `eth_getLogs` at a high rate. The provider returned HTTP `503` and `-32001 "Unable to complete request at this time"`; the indexer kept hammering it at full concurrency until a slow request eventually succeeded.

## Root cause

Two retry layers, each with a gap:

1. **RPC layer** — alloy's `RetryBackoffLayer` was configured with `max_retries = 5000` and a flat (non-exponential) backoff, so an outage became a tight, self-logging retry loop.
2. **Error classification** — only `429`/`"rate limit"` engaged the adaptive backoff
   (`record_rate_limit`). `503`, `-32001`, and "Unable to complete request" fell through
   to the generic error path, so concurrency was never scaled down and the backoff never
   grew.
3. **Live retry loop** — on an unrecognized error it halved the block range and retried
   with **no delay**. At the chain head (`from == to`) this produced `from+2`, which is
   ahead of head → `-32000 "invalid block range params"` → a tight zero-delay loop.

## Changes

- Add `is_rate_limited_or_unavailable()` — one shared classifier treating throttle **and**
  temporary-unavailability errors (`429`/`503`/`-32001`/"service unavailable"/…) the same.
  Token matching is specific (`"http error 503"`, not bare `"503"`) to avoid colliding with
  block numbers.
- Wire it into **every** classifier: the RPC logging layer (all methods), the three
  `fetch_logs` retry sites (live/historic/parallel `eth_getLogs`), and the three `tables.rs`
  batch sites (block/receipt/multicall). These errors now trigger the genuinely exponential
  adaptive backoff (500ms→30s) and concurrency scale-down.
- Live & historic paths: on a rate-limit/unavailability error, **back off and retry without
  shrinking the range** (shrinking is pointless when the node is unhealthy and caused the
  `-32000` loop). The live path clears the shrink target rather than pinning it, avoiding a
  wedge when `reorg_safe_distance > 0`.
- Bound alloy `RetryBackoffLayer` retries `5000 → 10` (`MAX_RPC_RATE_LIMIT_RETRIES`); the
  app-level adaptive controller owns the slow backoff for sustained outages.

## Effect

A 503/-32001 outage now logs at INFO/WARN (not per-attempt ERROR), scales concurrency down,
and paces retries by the global backoff (~1 per 30s) instead of hammering — collapsing the
~10k-lines/25-min storm by well over an order of magnitude, while still recovering
automatically when the provider returns.

## Testing

- Extended `classify_fetch_error` unit tests with 503/`-32001`/"Max retries exceeded" cases
  and a false-positive guard (block number containing `503`).
- `cargo fmt`, `cargo clippy -p rindexer`, and `cargo test -p rindexer --lib` (721 tests) all pass.
