### PR TITLE
fix: clear stale to-block cap so live indexing cannot deadlock

### DIFF
--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -613,6 +613,15 @@ async fn live_indexing_stream(
                         continue;
                     }
 
+                    // a shrunk to-block cap at or below last_seen can never be fetched
+                    // again, so keeping it would pin this loop in the no-new-blocks
+                    // branch forever; drop it as stale
+                    if log_response_to_large_to_block
+                        .is_some_and(|cap| cap <= last_seen_block_number)
+                    {
+                        log_response_to_large_to_block = None;
+                    }
+
                     let latest_block_number = log_response_to_large_to_block
                         .unwrap_or(U64::from(latest_block.header.number));
 
@@ -717,6 +726,9 @@ async fn live_indexing_stream(
                                 current_filter =
                                     current_filter.set_from_block(to_block + U64::from(1));
                                 last_seen_block_number = to_block;
+                                // the capped range completed without a fetch; clear it like
+                                // the successful get_logs path does
+                                log_response_to_large_to_block = None;
                             } else {
                                 current_filter = current_filter.set_to_block(to_block);
 


### PR DESCRIPTION
When a live get_logs fetch errors, the loop caps the next range via log_response_to_large_to_block. The cap was only cleared after a successful get_logs, but the logs-bloom skip path also completes the capped range and advances last_seen_block_number. Once last_seen reached the cap, the loop pinned latest_block_number to the cap, permanently took the no-new-blocks branch, and never fetched again: the stream froze silently, logging only the 5-minute idle line with the same block number.

Clear the cap on the bloom-skip completion path, and defensively drop any cap at or below last_seen at the read site so no completion path can pin the loop again.