### PR TITLE
Fix Postgres bytea array serialization

### DIFF
--- a/core/src/database/sql_type_wrapper.rs
+++ b/core/src/database/sql_type_wrapper.rs
@@ -23,6 +23,19 @@ fn ch_escape(s: &str) -> String {
     s.replace('\\', "\\\\").replace('\'', "\\'")
 }
 
+fn serialize_bytea_array<'a>(
+    values: impl IntoIterator<Item = &'a [u8]>,
+    ty: &PgType,
+    out: &mut BytesMut,
+) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
+    let values: Vec<&[u8]> = values.into_iter().collect();
+    if values.is_empty() {
+        Ok(IsNull::Yes)
+    } else {
+        values.to_sql(ty, out)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum EthereumSqlTypeWrapper {
     // Boolean
@@ -858,16 +871,9 @@ impl ToSql for EthereumSqlTypeWrapper {
                 }
             }
             EthereumSqlTypeWrapper::VecU256Bytes(values) => {
-                if values.is_empty() {
-                    Ok(IsNull::Yes)
-                } else {
-                    for value in values {
-                        let bytes: [u8; 32] = value.to_be_bytes();
-                        let bytes = Bytes::from(bytes);
-                        out.extend_from_slice(&bytes);
-                    }
-                    Ok(IsNull::No)
-                }
+                let bytes: Vec<[u8; 32]> =
+                    values.iter().map(|value| value.to_be_bytes::<32>()).collect();
+                serialize_bytea_array(bytes.iter().map(|value| value.as_slice()), ty, out)
             }
             EthereumSqlTypeWrapper::VecU256Numeric(values) => {
                 Self::serialize_numeric_u256_array(values, out, |v| (*v, false))
@@ -917,16 +923,9 @@ impl ToSql for EthereumSqlTypeWrapper {
                 }
             }
             EthereumSqlTypeWrapper::VecI256Bytes(values) => {
-                if values.is_empty() {
-                    Ok(IsNull::Yes)
-                } else {
-                    for value in values {
-                        let bytes: [u8; 32] = value.to_be_bytes();
-                        let bytes = Bytes::from(bytes);
-                        out.extend_from_slice(&bytes);
-                    }
-                    Ok(IsNull::No)
-                }
+                let bytes: Vec<[u8; 32]> =
+                    values.iter().map(|value| value.to_be_bytes::<32>()).collect();
+                serialize_bytea_array(bytes.iter().map(|value| value.as_slice()), ty, out)
             }
             EthereumSqlTypeWrapper::U512(value) => {
                 let value = value.to_string();
@@ -989,15 +988,7 @@ impl ToSql for EthereumSqlTypeWrapper {
                 }
             }
             EthereumSqlTypeWrapper::VecB256Bytes(values) => {
-                if values.is_empty() {
-                    Ok(IsNull::Yes)
-                } else {
-                    for value in values {
-                        let bytes = Bytes::from(value.0);
-                        out.extend_from_slice(&bytes);
-                    }
-                    Ok(IsNull::No)
-                }
+                serialize_bytea_array(values.iter().map(B256::as_slice), ty, out)
             }
             EthereumSqlTypeWrapper::B512(value) => {
                 let hex = format!("{value:?}");
@@ -1047,15 +1038,7 @@ impl ToSql for EthereumSqlTypeWrapper {
                 }
             }
             EthereumSqlTypeWrapper::VecAddressBytes(values) => {
-                if values.is_empty() {
-                    Ok(IsNull::Yes)
-                } else {
-                    for value in values {
-                        let bytes = Bytes::from(value.0);
-                        out.extend_from_slice(&bytes);
-                    }
-                    Ok(IsNull::No)
-                }
+                serialize_bytea_array(values.iter().map(|value| value.0.as_slice()), ty, out)
             }
             EthereumSqlTypeWrapper::Bool(value) => bool::to_sql(value, ty, out),
             EthereumSqlTypeWrapper::VecBool(values) => {
@@ -1117,14 +1100,7 @@ impl ToSql for EthereumSqlTypeWrapper {
                 Ok(IsNull::No)
             }
             EthereumSqlTypeWrapper::VecBytes(values) => {
-                if values.is_empty() {
-                    Ok(IsNull::Yes)
-                } else {
-                    for value in values {
-                        out.extend_from_slice(value);
-                    }
-                    Ok(IsNull::No)
-                }
+                serialize_bytea_array(values.iter().map(|value| value.as_ref()), ty, out)
             }
             EthereumSqlTypeWrapper::U32(value) => {
                 let int_value: i32 = *value as i32;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -71,7 +71,9 @@ pub use events::{RindexerEvent, RindexerEventStream};
 // export 3rd party dependencies
 pub use async_trait::async_trait;
 pub use colored::Colorize as RindexerColorize;
-pub use database::sql_type_wrapper::EthereumSqlTypeWrapper;
+pub use database::sql_type_wrapper::{
+    solidity_type_to_ethereum_sql_type_wrapper, EthereumSqlTypeWrapper,
+};
 pub use futures::FutureExt;
 pub use indexer::no_code::resolve_table_column_types;
 pub use lazy_static::lazy_static;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -71,9 +71,7 @@ pub use events::{RindexerEvent, RindexerEventStream};
 // export 3rd party dependencies
 pub use async_trait::async_trait;
 pub use colored::Colorize as RindexerColorize;
-pub use database::sql_type_wrapper::{
-    solidity_type_to_ethereum_sql_type_wrapper, EthereumSqlTypeWrapper,
-};
+pub use database::sql_type_wrapper::EthereumSqlTypeWrapper;
 pub use futures::FutureExt;
 pub use indexer::no_code::resolve_table_column_types;
 pub use lazy_static::lazy_static;

--- a/core/tests/e2e_reorg_streams.rs
+++ b/core/tests/e2e_reorg_streams.rs
@@ -283,6 +283,32 @@ async fn stream_reorg_reaches_rabbitmq() {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "kafka")]
+async fn create_kafka_topic(bootstrap: &str, topic: &str) {
+    use rdkafka::{
+        admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
+        client::DefaultClientContext,
+        ClientConfig,
+    };
+
+    let admin: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", bootstrap)
+        .create()
+        .expect("kafka admin client");
+
+    let results = admin
+        .create_topics(
+            &[NewTopic::new(topic, 1, TopicReplication::Fixed(1))],
+            &AdminOptions::new().operation_timeout(Some(Duration::from_secs(10))),
+        )
+        .await
+        .expect("create kafka topic");
+
+    for result in results {
+        result.expect("create kafka topic result");
+    }
+}
+
+#[cfg(feature = "kafka")]
 #[tokio::test]
 async fn stream_reorg_reaches_kafka() {
     use futures::StreamExt;
@@ -299,6 +325,7 @@ async fn stream_reorg_reaches_kafka() {
     let bootstrap = format!("127.0.0.1:{port}");
 
     let topic = "rindexer_reorg_topic";
+    create_kafka_topic(&bootstrap, topic).await;
 
     // Subscribe BEFORE producing with `earliest` offset reset so we don't miss the message.
     let consumer: StreamConsumer = ClientConfig::new()

--- a/core/tests/postgres_bytea_array.rs
+++ b/core/tests/postgres_bytea_array.rs
@@ -1,0 +1,53 @@
+//! PostgreSQL round-trip tests for byte array wrappers.
+//!
+//! Requires Docker:
+//!   cargo test -p rindexer --test postgres_bytea_array
+
+use alloy::primitives::Bytes;
+use rindexer::EthereumSqlTypeWrapper;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+#[tokio::test]
+async fn vec_bytes_inserts_into_postgres_bytea_array() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let pg_container = Postgres::default().start().await.expect("failed to start postgres");
+    let pg_port = pg_container.get_host_port_ipv4(5432).await.expect("failed to get postgres port");
+    let conn_str =
+        format!("host=127.0.0.1 port={pg_port} user=postgres password=postgres dbname=postgres");
+
+    let (client, connection) = tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
+        .await
+        .expect("failed to connect to postgres");
+    tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            eprintln!("postgres connection error: {err}");
+        }
+    });
+
+    client
+        .batch_execute("CREATE TABLE bytea_array_roundtrip (ids BYTEA[] NOT NULL)")
+        .await
+        .expect("failed to create test table");
+
+    let first = vec![1u8; 32];
+    let second = vec![2u8; 32];
+    let ids = EthereumSqlTypeWrapper::VecBytes(vec![
+        Bytes::copy_from_slice(&first),
+        Bytes::copy_from_slice(&second),
+    ]);
+
+    client
+        .execute("INSERT INTO bytea_array_roundtrip (ids) VALUES ($1)", &[&ids])
+        .await
+        .expect("failed to insert bytea array");
+
+    let row = client
+        .query_one("SELECT ids FROM bytea_array_roundtrip", &[])
+        .await
+        .expect("failed to query bytea array");
+    let stored_ids: Vec<Vec<u8>> = row.get("ids");
+
+    assert_eq!(stored_ids, vec![first, second]);
+}

--- a/core/tests/postgres_bytea_array.rs
+++ b/core/tests/postgres_bytea_array.rs
@@ -3,13 +3,15 @@
 //! Requires Docker:
 //!   cargo test -p rindexer --test postgres_bytea_array
 
-use alloy::primitives::Bytes;
-use rindexer::{EthereumSqlTypeWrapper, PgType, solidity_type_to_ethereum_sql_type_wrapper};
+use alloy::primitives::{Address, Bytes, B256, I256, U256};
+use futures::pin_mut;
+use rindexer::{EthereumSqlTypeWrapper, PgType};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
+use tokio_postgres::{binary_copy::BinaryCopyInWriter, types::ToSql, Client};
 
 #[tokio::test]
-async fn vec_bytes_inserts_into_postgres_bytea_array() {
+async fn bytea_array_wrappers_insert_and_copy_into_postgres_bytea_array() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let pg_container = Postgres::default().start().await.expect("failed to start postgres");
@@ -27,34 +29,110 @@ async fn vec_bytes_inserts_into_postgres_bytea_array() {
     });
 
     client
-        .batch_execute("CREATE TABLE bytea_array_roundtrip (ids BYTEA[] NOT NULL)")
+        .batch_execute(
+            "CREATE TABLE bytea_array_insert_roundtrip (ids BYTEA[] NOT NULL);
+             CREATE TABLE bytea_array_copy_roundtrip (ids BYTEA[] NOT NULL);",
+        )
         .await
-        .expect("failed to create test table");
+        .expect("failed to create test tables");
 
-    let first = vec![1u8; 32];
-    let second = vec![2u8; 32];
-    let mut mapped_ids = match solidity_type_to_ethereum_sql_type_wrapper("bytes32[]")
-        .expect("bytes32[] should map to a SQL wrapper")
-    {
-        EthereumSqlTypeWrapper::VecBytes(values) => values,
-        other => panic!("bytes32[] should map to VecBytes, got {other:?}"),
-    };
-    mapped_ids.push(Bytes::copy_from_slice(&first));
-    mapped_ids.push(Bytes::copy_from_slice(&second));
+    let u256_values = vec![U256::from(42u64), U256::from(99u64)];
+    let i256_values = vec![I256::try_from(42i64).unwrap(), I256::try_from(-99i64).unwrap()];
 
-    let ids = EthereumSqlTypeWrapper::VecBytes(mapped_ids);
-    assert_eq!(ids.to_type(), PgType::BYTEA_ARRAY);
+    let cases = vec![
+        (
+            "VecBytes",
+            EthereumSqlTypeWrapper::VecBytes(vec![
+                Bytes::copy_from_slice(&[1u8; 32]),
+                Bytes::copy_from_slice(&[2u8; 32]),
+            ]),
+            vec![vec![1u8; 32], vec![2u8; 32]],
+        ),
+        (
+            "VecAddressBytes",
+            EthereumSqlTypeWrapper::VecAddressBytes(vec![
+                Address::from([3u8; 20]),
+                Address::from([4u8; 20]),
+            ]),
+            vec![vec![3u8; 20], vec![4u8; 20]],
+        ),
+        (
+            "VecB256Bytes",
+            EthereumSqlTypeWrapper::VecB256Bytes(vec![
+                B256::from([5u8; 32]),
+                B256::from([6u8; 32]),
+            ]),
+            vec![vec![5u8; 32], vec![6u8; 32]],
+        ),
+        (
+            "VecU256Bytes",
+            EthereumSqlTypeWrapper::VecU256Bytes(u256_values.clone()),
+            u256_values.iter().map(|value| value.to_be_bytes::<32>().to_vec()).collect(),
+        ),
+        (
+            "VecI256Bytes",
+            EthereumSqlTypeWrapper::VecI256Bytes(i256_values.clone()),
+            i256_values.iter().map(|value| value.to_be_bytes::<32>().to_vec()).collect(),
+        ),
+    ];
+
+    for (name, wrapper, expected_ids) in cases {
+        assert_bytea_array_roundtrip(&client, name, &wrapper, expected_ids).await;
+    }
+}
+
+async fn assert_bytea_array_roundtrip(
+    client: &Client,
+    name: &str,
+    wrapper: &EthereumSqlTypeWrapper,
+    expected_ids: Vec<Vec<u8>>,
+) {
+    assert_eq!(wrapper.to_type(), PgType::BYTEA_ARRAY, "{name}");
 
     client
-        .execute("INSERT INTO bytea_array_roundtrip (ids) VALUES ($1)", &[&ids])
+        .batch_execute(
+            "TRUNCATE bytea_array_insert_roundtrip;
+             TRUNCATE bytea_array_copy_roundtrip;",
+        )
         .await
-        .expect("failed to insert bytea array");
+        .unwrap_or_else(|error| panic!("{name}: failed to truncate test tables: {error}"));
+
+    client
+        .execute("INSERT INTO bytea_array_insert_roundtrip (ids) VALUES ($1)", &[wrapper])
+        .await
+        .unwrap_or_else(|error| panic!("{name}: failed to insert bytea array: {error}"));
 
     let row = client
-        .query_one("SELECT ids FROM bytea_array_roundtrip", &[])
+        .query_one("SELECT ids FROM bytea_array_insert_roundtrip", &[])
         .await
-        .expect("failed to query bytea array");
+        .unwrap_or_else(|error| panic!("{name}: failed to query bytea array: {error}"));
     let stored_ids: Vec<Vec<u8>> = row.get("ids");
 
-    assert_eq!(stored_ids, vec![first, second]);
+    assert_eq!(stored_ids, expected_ids, "{name}: insert roundtrip");
+
+    let sink = client
+        .copy_in("COPY bytea_array_copy_roundtrip (ids) FROM STDIN WITH (FORMAT binary)")
+        .await
+        .unwrap_or_else(|error| panic!("{name}: failed to start bytea array copy: {error}"));
+    let writer = BinaryCopyInWriter::new(sink, &[PgType::BYTEA_ARRAY]);
+    pin_mut!(writer);
+
+    let row: [&(dyn ToSql + Sync); 1] = [wrapper];
+    writer
+        .as_mut()
+        .write(&row)
+        .await
+        .unwrap_or_else(|error| panic!("{name}: failed to copy bytea array: {error}"));
+    writer
+        .finish()
+        .await
+        .unwrap_or_else(|error| panic!("{name}: failed to finish bytea array copy: {error}"));
+
+    let row = client
+        .query_one("SELECT ids FROM bytea_array_copy_roundtrip", &[])
+        .await
+        .unwrap_or_else(|error| panic!("{name}: failed to query copied bytea array: {error}"));
+    let stored_ids: Vec<Vec<u8>> = row.get("ids");
+
+    assert_eq!(stored_ids, expected_ids, "{name}: copy roundtrip");
 }

--- a/core/tests/postgres_bytea_array.rs
+++ b/core/tests/postgres_bytea_array.rs
@@ -4,7 +4,7 @@
 //!   cargo test -p rindexer --test postgres_bytea_array
 
 use alloy::primitives::Bytes;
-use rindexer::EthereumSqlTypeWrapper;
+use rindexer::{EthereumSqlTypeWrapper, PgType, solidity_type_to_ethereum_sql_type_wrapper};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 
@@ -33,10 +33,17 @@ async fn vec_bytes_inserts_into_postgres_bytea_array() {
 
     let first = vec![1u8; 32];
     let second = vec![2u8; 32];
-    let ids = EthereumSqlTypeWrapper::VecBytes(vec![
-        Bytes::copy_from_slice(&first),
-        Bytes::copy_from_slice(&second),
-    ]);
+    let mut mapped_ids = match solidity_type_to_ethereum_sql_type_wrapper("bytes32[]")
+        .expect("bytes32[] should map to a SQL wrapper")
+    {
+        EthereumSqlTypeWrapper::VecBytes(values) => values,
+        other => panic!("bytes32[] should map to VecBytes, got {other:?}"),
+    };
+    mapped_ids.push(Bytes::copy_from_slice(&first));
+    mapped_ids.push(Bytes::copy_from_slice(&second));
+
+    let ids = EthereumSqlTypeWrapper::VecBytes(mapped_ids);
+    assert_eq!(ids.to_type(), PgType::BYTEA_ARRAY);
 
     client
         .execute("INSERT INTO bytea_array_roundtrip (ids) VALUES ($1)", &[&ids])

--- a/core/tests/postgres_bytea_array.rs
+++ b/core/tests/postgres_bytea_array.rs
@@ -8,10 +8,75 @@ use futures::pin_mut;
 use rindexer::{EthereumSqlTypeWrapper, PgType};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
-use tokio_postgres::{binary_copy::BinaryCopyInWriter, types::ToSql, Client};
+use tokio_postgres::{binary_copy::BinaryCopyInWriter, types::ToSql};
 
 #[tokio::test]
-async fn bytea_array_wrappers_insert_and_copy_into_postgres_bytea_array() {
+async fn vec_bytes_insert_and_copy_into_postgres_bytea_array() {
+    assert_bytea_array_roundtrip(
+        "VecBytes",
+        EthereumSqlTypeWrapper::VecBytes(vec![
+            Bytes::copy_from_slice(&[1u8; 32]),
+            Bytes::copy_from_slice(&[2u8; 32]),
+        ]),
+        vec![vec![1u8; 32], vec![2u8; 32]],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn vec_address_bytes_insert_and_copy_into_postgres_bytea_array() {
+    assert_bytea_array_roundtrip(
+        "VecAddressBytes",
+        EthereumSqlTypeWrapper::VecAddressBytes(vec![
+            Address::from([3u8; 20]),
+            Address::from([4u8; 20]),
+        ]),
+        vec![vec![3u8; 20], vec![4u8; 20]],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn vec_b256_bytes_insert_and_copy_into_postgres_bytea_array() {
+    assert_bytea_array_roundtrip(
+        "VecB256Bytes",
+        EthereumSqlTypeWrapper::VecB256Bytes(vec![B256::from([5u8; 32]), B256::from([6u8; 32])]),
+        vec![vec![5u8; 32], vec![6u8; 32]],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn vec_u256_bytes_insert_and_copy_into_postgres_bytea_array() {
+    let values = vec![U256::from(42u64), U256::from(99u64)];
+    let expected_ids = values.iter().map(|value| value.to_be_bytes::<32>().to_vec()).collect();
+
+    assert_bytea_array_roundtrip(
+        "VecU256Bytes",
+        EthereumSqlTypeWrapper::VecU256Bytes(values),
+        expected_ids,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn vec_i256_bytes_insert_and_copy_into_postgres_bytea_array() {
+    let values = vec![I256::try_from(42i64).unwrap(), I256::try_from(-99i64).unwrap()];
+    let expected_ids = values.iter().map(|value| value.to_be_bytes::<32>().to_vec()).collect();
+
+    assert_bytea_array_roundtrip(
+        "VecI256Bytes",
+        EthereumSqlTypeWrapper::VecI256Bytes(values),
+        expected_ids,
+    )
+    .await;
+}
+
+async fn assert_bytea_array_roundtrip(
+    name: &str,
+    wrapper: EthereumSqlTypeWrapper,
+    expected_ids: Vec<Vec<u8>>,
+) {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let pg_container = Postgres::default().start().await.expect("failed to start postgres");
@@ -28,77 +93,18 @@ async fn bytea_array_wrappers_insert_and_copy_into_postgres_bytea_array() {
         }
     });
 
+    assert_eq!(wrapper.to_type(), PgType::BYTEA_ARRAY, "{name}");
+
     client
         .batch_execute(
             "CREATE TABLE bytea_array_insert_roundtrip (ids BYTEA[] NOT NULL);
              CREATE TABLE bytea_array_copy_roundtrip (ids BYTEA[] NOT NULL);",
         )
         .await
-        .expect("failed to create test tables");
-
-    let u256_values = vec![U256::from(42u64), U256::from(99u64)];
-    let i256_values = vec![I256::try_from(42i64).unwrap(), I256::try_from(-99i64).unwrap()];
-
-    let cases = vec![
-        (
-            "VecBytes",
-            EthereumSqlTypeWrapper::VecBytes(vec![
-                Bytes::copy_from_slice(&[1u8; 32]),
-                Bytes::copy_from_slice(&[2u8; 32]),
-            ]),
-            vec![vec![1u8; 32], vec![2u8; 32]],
-        ),
-        (
-            "VecAddressBytes",
-            EthereumSqlTypeWrapper::VecAddressBytes(vec![
-                Address::from([3u8; 20]),
-                Address::from([4u8; 20]),
-            ]),
-            vec![vec![3u8; 20], vec![4u8; 20]],
-        ),
-        (
-            "VecB256Bytes",
-            EthereumSqlTypeWrapper::VecB256Bytes(vec![
-                B256::from([5u8; 32]),
-                B256::from([6u8; 32]),
-            ]),
-            vec![vec![5u8; 32], vec![6u8; 32]],
-        ),
-        (
-            "VecU256Bytes",
-            EthereumSqlTypeWrapper::VecU256Bytes(u256_values.clone()),
-            u256_values.iter().map(|value| value.to_be_bytes::<32>().to_vec()).collect(),
-        ),
-        (
-            "VecI256Bytes",
-            EthereumSqlTypeWrapper::VecI256Bytes(i256_values.clone()),
-            i256_values.iter().map(|value| value.to_be_bytes::<32>().to_vec()).collect(),
-        ),
-    ];
-
-    for (name, wrapper, expected_ids) in cases {
-        assert_bytea_array_roundtrip(&client, name, &wrapper, expected_ids).await;
-    }
-}
-
-async fn assert_bytea_array_roundtrip(
-    client: &Client,
-    name: &str,
-    wrapper: &EthereumSqlTypeWrapper,
-    expected_ids: Vec<Vec<u8>>,
-) {
-    assert_eq!(wrapper.to_type(), PgType::BYTEA_ARRAY, "{name}");
+        .unwrap_or_else(|error| panic!("{name}: failed to create test tables: {error}"));
 
     client
-        .batch_execute(
-            "TRUNCATE bytea_array_insert_roundtrip;
-             TRUNCATE bytea_array_copy_roundtrip;",
-        )
-        .await
-        .unwrap_or_else(|error| panic!("{name}: failed to truncate test tables: {error}"));
-
-    client
-        .execute("INSERT INTO bytea_array_insert_roundtrip (ids) VALUES ($1)", &[wrapper])
+        .execute("INSERT INTO bytea_array_insert_roundtrip (ids) VALUES ($1)", &[&wrapper])
         .await
         .unwrap_or_else(|error| panic!("{name}: failed to insert bytea array: {error}"));
 
@@ -117,7 +123,7 @@ async fn assert_bytea_array_roundtrip(
     let writer = BinaryCopyInWriter::new(sink, &[PgType::BYTEA_ARRAY]);
     pin_mut!(writer);
 
-    let row: [&(dyn ToSql + Sync); 1] = [wrapper];
+    let row: [&(dyn ToSql + Sync); 1] = [&wrapper];
     writer
         .as_mut()
         .write(&row)


### PR DESCRIPTION
## Summary

Fix PostgreSQL serialization for EVM byte-array wrappers that map to `BYTEA[]`.

Fixes #438.

The previous implementation treated array-valued byte wrappers as if the Postgres output buffer could contain only the concatenated element payloads. That is fine for scalar `BYTEA`, but not for binary `BYTEA[]`: Postgres expects the array envelope, element type OID, bounds, and per-element lengths. For Solidity fields such as `bytes32[]`, the old encoding could be decoded by Postgres as a malformed array.

## Change

- Add a shared `BYTEA[]` serializer that delegates the array wire format to `tokio-postgres` by converting values to `Vec<&[u8]>`.
  - https://github.com/joshstevens19/rindexer/blob/269c97f6f794093e37eb94fe918db3ad20b46945/core/src/database/sql_type_wrapper.rs#L26-L36
- Route all byte-array wrapper variants through that serializer:
  - `VecU256Bytes`
  - `VecI256Bytes`
  - `VecB256Bytes`
  - `VecAddressBytes`
  - `VecBytes`
  - https://github.com/joshstevens19/rindexer/blob/269c97f6f794093e37eb94fe918db3ad20b46945/core/src/database/sql_type_wrapper.rs#L873-L928
  - https://github.com/joshstevens19/rindexer/blob/269c97f6f794093e37eb94fe918db3ad20b46945/core/src/database/sql_type_wrapper.rs#L990-L1042
  - https://github.com/joshstevens19/rindexer/blob/269c97f6f794093e37eb94fe918db3ad20b46945/core/src/database/sql_type_wrapper.rs#L1102-L1104
- Preserve the existing empty-array behavior, where empty wrapper values encode as SQL `NULL`, so this remains a narrow serialization fix.

## Validation

- Add Postgres-backed regression tests for all five affected wrappers.
- Each test verifies both parameterized `INSERT` and binary `COPY` into a real `BYTEA[]` column.
  - https://github.com/joshstevens19/rindexer/blob/269c97f6f794093e37eb94fe918db3ad20b46945/core/tests/postgres_bytea_array.rs#L13-L144
- Verified the split regression tests fail independently on upstream `master` and pass on this branch.

Commands run locally:

```bash
cargo fmt --check
cargo test -p rindexer --test postgres_bytea_array -- --nocapture
cargo test --workspace -- --test-threads=1
```
