### PR TITLE
Stabilize Kafka reorg stream test

### DIFF
--- a/core/tests/e2e_reorg_streams.rs
+++ b/core/tests/e2e_reorg_streams.rs
@@ -283,6 +283,32 @@ async fn stream_reorg_reaches_rabbitmq() {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "kafka")]
+async fn create_kafka_topic(bootstrap: &str, topic: &str) {
+    use rdkafka::{
+        admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
+        client::DefaultClientContext,
+        ClientConfig,
+    };
+
+    let admin: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", bootstrap)
+        .create()
+        .expect("kafka admin client");
+
+    let results = admin
+        .create_topics(
+            &[NewTopic::new(topic, 1, TopicReplication::Fixed(1))],
+            &AdminOptions::new().operation_timeout(Some(Duration::from_secs(10))),
+        )
+        .await
+        .expect("create kafka topic");
+
+    for result in results {
+        result.expect("create kafka topic result");
+    }
+}
+
+#[cfg(feature = "kafka")]
 #[tokio::test]
 async fn stream_reorg_reaches_kafka() {
     use futures::StreamExt;
@@ -299,6 +325,7 @@ async fn stream_reorg_reaches_kafka() {
     let bootstrap = format!("127.0.0.1:{port}");
 
     let topic = "rindexer_reorg_topic";
+    create_kafka_topic(&bootstrap, topic).await;
 
     // Subscribe BEFORE producing with `earliest` offset reset so we don't miss the message.
     let consumer: StreamConsumer = ClientConfig::new()


### PR DESCRIPTION
## Summary
- Explicitly create the Kafka topic in the Kafka reorg stream integration test before subscribing.
- Keep the change scoped to the test harness; production stream behavior remains unchanged.

## Why
The test was relying on Kafka auto-topic creation. In ephemeral Kafka containers that is racy: the consumer can subscribe or poll before the broker has materialized the topic, which intermittently returns `UnknownTopicOrPartition`. Creating the topic with the Kafka admin client makes the fixture deterministic and preserves the existing test intent.

## Validation
- `cargo fmt --check`
- 10x: `cargo nextest run -p rindexer --all-features --test e2e_reorg_streams stream_reorg_reaches_kafka`
- 5x: `cargo test -p rindexer --features kafka --test e2e_reorg_streams stream_reorg_reaches_kafka`
- Fresh branch sanity: `cargo nextest run -p rindexer --all-features --test e2e_reorg_streams stream_reorg_reaches_kafka`