### PR TITLE
fix(reorg): quote reserved-word identifiers in reversal SQL; stabilize Kafka reorg stream test

### DIFF
--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -226,6 +226,19 @@ struct ReversalSnapshot {
     set_clauses: Vec<String>,
 }
 
+/// Quote a SQL identifier for Postgres (double quotes), escaping any embedded
+/// quotes. Required because user-defined event/derived columns can collide with
+/// SQL reserved words (e.g. `to`, `from`).
+fn quote_pg_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Quote a SQL identifier for ClickHouse (backticks), escaping any embedded
+/// backticks. Mirrors `quote_pg_ident` for the ClickHouse backend.
+fn quote_ch_ident(name: &str) -> String {
+    format!("`{}`", name.replace('`', "\\`"))
+}
+
 impl ReorgTask {
     /// Returns ` AND network = '<network>'` when not cross-chain, empty string otherwise.
     fn network_filter(&self, cross_chain: bool) -> String {
@@ -250,7 +263,10 @@ impl ReorgTask {
 
         for dt in &self.derived_tables {
             for op in &dt.rollback_ops {
-                let mut agg_columns: Vec<String> = Vec::new();
+                // (is_counter, source event column) per reversible column. The
+                // SELECT aggregate is assembled per-backend so each can quote
+                // identifiers with its own convention.
+                let mut agg_specs: Vec<(bool, String)> = Vec::new();
                 let mut set_clauses: Vec<String> = Vec::new();
 
                 for col in &op.columns {
@@ -264,12 +280,7 @@ impl ReorgTask {
                         continue;
                     };
 
-                    let agg_expr = if col.action.is_counter_action() {
-                        format!("COUNT(*) AS {}_agg", col.event_column)
-                    } else {
-                        format!("SUM({}) AS {}_agg", col.event_column, col.event_column)
-                    };
-                    agg_columns.push(agg_expr);
+                    agg_specs.push((col.action.is_counter_action(), col.event_column.clone()));
 
                     let op_symbol = match reversed {
                         SetAction::Add | SetAction::Increment => "+",
@@ -280,17 +291,19 @@ impl ReorgTask {
                             col.derived_column,
                         ),
                     };
+                    // Aggregate aliases (`<col>_agg`) are synthesized names kept
+                    // unquoted so the ClickHouse set-clause token rewriter can parse them.
                     set_clauses.push(format!(
                         "{} = dt.{} {} snap.{}_agg",
                         col.derived_column, col.derived_column, op_symbol, col.event_column
                     ));
                 }
 
-                if set_clauses.is_empty() || agg_columns.is_empty() {
+                if set_clauses.is_empty() || agg_specs.is_empty() {
                     continue;
                 }
 
-                let group_cols: Vec<&str> =
+                let where_ev_cols: Vec<&str> =
                     op.where_columns.iter().map(|(_, ev_col)| ev_col.as_str()).collect();
 
                 let network_filter = self.network_filter(dt.cross_chain);
@@ -310,23 +323,44 @@ impl ReorgTask {
                 );
                 snap_idx += 1;
 
-                // Build the SELECT portion independently so PG and CH can wrap it
-                // in their own CREATE TABLE syntax without fragile string stripping.
-                let select_sql = format!(
-                    "SELECT {}, {} FROM {} WHERE block_number >= {} AND block_number <= {}{}{} GROUP BY {}",
-                    group_cols.join(", "),
-                    agg_columns.join(", "),
-                    op.event_table,
-                    self.fork_point,
-                    self.detection_point,
-                    network_filter,
-                    condition_filter,
-                    group_cols.join(", "),
-                );
+                // Build the SELECT per-backend. Group/where and aggregate-source
+                // columns are user-controlled identifiers that may collide with SQL
+                // reserved words (e.g. `to`, `from`), so each backend quotes them with
+                // its own convention (Postgres double quotes, ClickHouse backticks).
+                let build_select = |quote: &dyn Fn(&str) -> String| {
+                    let group =
+                        where_ev_cols.iter().map(|c| quote(c)).collect::<Vec<_>>().join(", ");
+                    let aggs = agg_specs
+                        .iter()
+                        .map(|(is_counter, ev)| {
+                            if *is_counter {
+                                format!("COUNT(*) AS {}_agg", ev)
+                            } else {
+                                format!("SUM({}) AS {}_agg", quote(ev), ev)
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!(
+                        "SELECT {}, {} FROM {} WHERE block_number >= {} AND block_number <= {}{}{} GROUP BY {}",
+                        group,
+                        aggs,
+                        op.event_table,
+                        self.fork_point,
+                        self.detection_point,
+                        network_filter,
+                        condition_filter,
+                        group,
+                    )
+                };
 
                 if let Some(pg) = pg {
                     let pg_temp = format!("{}_pg", temp_base);
-                    let pg_create = format!("CREATE TEMP TABLE {} AS {}", pg_temp, select_sql);
+                    let pg_create = format!(
+                        "CREATE TEMP TABLE {} AS {}",
+                        pg_temp,
+                        build_select(&quote_pg_ident)
+                    );
                     pg.batch_execute(&pg_create).await.with_context(|| {
                         format!(
                             "Failed to create PG reorg reversal snapshot for {}",
@@ -352,13 +386,13 @@ impl ReorgTask {
                     // aggregates via joinGet(). ClickHouse mutations don't
                     // support correlated subqueries the way Postgres does, so
                     // we cannot use `(SELECT ... WHERE snap.k = dt.k LIMIT 1)`.
-                    let ch_snap_keys: Vec<&str> =
-                        op.where_columns.iter().map(|(_, ev_col)| ev_col.as_str()).collect();
+                    let ch_snap_keys: Vec<String> =
+                        where_ev_cols.iter().map(|ev_col| quote_ch_ident(ev_col)).collect();
                     let ch_create = format!(
                         "CREATE TABLE IF NOT EXISTS {} ENGINE = Join(ANY, LEFT, {}) AS {}",
                         ch_temp,
                         ch_snap_keys.join(", "),
-                        select_sql,
+                        build_select(&quote_ch_ident),
                     );
                     ch.execute(&ch_create).await.with_context(|| {
                         format!(
@@ -393,7 +427,9 @@ impl ReorgTask {
             let where_join: Vec<String> = snap
                 .where_columns
                 .iter()
-                .map(|(dt_col, ev_col)| format!("dt.{} = snap.{}", dt_col, ev_col))
+                .map(|(dt_col, ev_col)| {
+                    format!("dt.{} = snap.{}", quote_pg_ident(dt_col), quote_pg_ident(ev_col))
+                })
                 .collect();
 
             let network_join = if snap.cross_chain {
@@ -433,8 +469,11 @@ impl ReorgTask {
                     // ClickHouse ALTER TABLE ... UPDATE with per-row aggregate lookups
                     // against a Join-engine snapshot table. joinGet() is the mutation-
                     // safe equivalent of PG's correlated subquery.
-                    let dt_keys: Vec<&str> =
-                        snap.where_columns.iter().map(|(dt_col, _)| dt_col.as_str()).collect();
+                    let dt_keys: Vec<String> = snap
+                        .where_columns
+                        .iter()
+                        .map(|(dt_col, _)| quote_ch_ident(dt_col))
+                        .collect();
                     let join_get_keys = dt_keys.join(", ");
 
                     // Build CH set clauses by replacing known "snap.X_agg" tokens with
@@ -477,7 +516,12 @@ impl ReorgTask {
                         .where_columns
                         .iter()
                         .map(|(dt_col, ev_col)| {
-                            format!("{} IN (SELECT {} FROM {})", dt_col, ev_col, snap.temp_table)
+                            format!(
+                                "{} IN (SELECT {} FROM {})",
+                                quote_ch_ident(dt_col),
+                                quote_ch_ident(ev_col),
+                                snap.temp_table
+                            )
                         })
                         .collect();
                     let ch_scope = if ch_exists_filter.is_empty() {

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -2155,6 +2155,116 @@ async fn test_reorg_reversal_add() {
 }
 
 // ---------------------------------------------------------------------------
+// Test: Reversal works when the grouping/where column is a SQL reserved word
+// (e.g. `to` from an ERC20 Transfer). Regression for unquoted identifiers in
+// the reorg reversal SQL producing `syntax error at or near "to"`.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_reorg_reversal_reserved_word_column() {
+    let env = TestEnv::new().await;
+    let pg = env.pg_client().await;
+    env.setup_base_tables(&pg).await;
+
+    // Event table grows a `to` column — a Postgres reserved word — mirroring an
+    // ERC20 Transfer recipient used as the aggregation key.
+    pg.batch_execute("ALTER TABLE test_schema.ping_pong_ping ADD COLUMN \"to\" CHAR(42);")
+        .await
+        .unwrap();
+
+    // Derived table keyed on the recipient.
+    pg.batch_execute(
+        "CREATE TABLE IF NOT EXISTS test_schema.holder_balances (
+             network VARCHAR(50) NOT NULL,
+             holder CHAR(42) NOT NULL,
+             total_received NUMERIC NOT NULL DEFAULT 0,
+             rindexer_block_number BIGINT NOT NULL,
+             PRIMARY KEY (network, holder)
+         );",
+    )
+    .await
+    .unwrap();
+
+    let (contract, _) = deploy_ping_pong(&env.http, &env.rpc_url, env.deployer).await;
+    let block1 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 1).await;
+    let block2 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 2).await;
+    let block3 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 3).await;
+
+    let network = "dev";
+    let holder = format!("{:#x}", env.deployer);
+    let zero_tx = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+    // +100, +50, +30 across blocks 1..3, all to the same recipient.
+    for (amount, block) in [(100u64, block1), (50, block2), (30, block3)] {
+        env.insert_event(&pg, network, amount, block, zero_tx).await;
+    }
+    pg.batch_execute(&format!("UPDATE test_schema.ping_pong_ping SET \"to\" = '{}';", holder))
+        .await
+        .unwrap();
+    env.insert_block_hashes(&pg, network, block1, block3).await;
+
+    // Derived state: total_received = 100 + 50 + 30 = 180.
+    pg.execute(
+        "INSERT INTO test_schema.holder_balances (network, holder, total_received, rindexer_block_number) \
+         VALUES ($1, $2, $3, $4)",
+        &[&network, &holder.as_str(), &rust_decimal::Decimal::from(180u64), &(block3 as i64)],
+    )
+    .await
+    .unwrap();
+
+    trigger_reorg(&env.http, &env.rpc_url, 2).await; // invalidates block2, block3
+
+    let task = ReorgTask {
+        network: network.to_string(),
+        fork_point: block2,
+        detection_point: block3,
+        event_tables: vec![EventTableInfo::try_new(
+            "test_schema".to_string(),
+            "ping_pong_ping".to_string(),
+            "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
+        )
+        .unwrap()],
+        derived_tables: vec![DerivedTableInfo {
+            full_table_name: "test_schema.holder_balances".to_string(),
+            cross_chain: false,
+            rollback_ops: vec![DerivedTableRollbackOp {
+                event_table: "test_schema.ping_pong_ping".to_string(),
+                where_columns: vec![("holder".to_string(), "to".to_string())],
+                columns: vec![DerivedColumnRollback {
+                    derived_column: "total_received".to_string(),
+                    event_column: "id".to_string(),
+                    action: SetAction::Add,
+                }],
+                condition: None,
+            }],
+            journal_columns: vec![],
+        }],
+        canonical_blocks: vec![],
+    };
+
+    let rindexer_pg = env.rindexer_pg().await;
+    let mut task_window = BlockChainWindow::try_new(256).unwrap();
+
+    task.execute(&mut task_window, Some(&rindexer_pg), None, None)
+        .await
+        .expect("reserved-word reversal reorg task failed");
+
+    // 180 - (50 + 30) = 100 after reversing blocks 2 and 3.
+    let total: rust_decimal::Decimal = pg
+        .query_one(
+            "SELECT total_received FROM test_schema.holder_balances WHERE network = $1 AND holder = $2",
+            &[&network, &holder.as_str()],
+        )
+        .await
+        .expect("holder row should still exist after reversal")
+        .get(0);
+    assert_eq!(total, rust_decimal::Decimal::from(100u64), "total should be 180 - 80 = 100");
+}
+
+// ---------------------------------------------------------------------------
 // Test: Subtract action is reversed (added back) during reorg
 // ---------------------------------------------------------------------------
 

--- a/core/tests/e2e_reorg_streams.rs
+++ b/core/tests/e2e_reorg_streams.rs
@@ -367,12 +367,25 @@ async fn stream_reorg_reaches_kafka() {
     let streamed = publish_reorg(&clients).await;
     assert_eq!(streamed, 1);
 
+    // Even with the topic explicitly created up front, a consumer can briefly
+    // observe transient metadata errors (e.g. UnknownTopicOrPartition) before
+    // partition leadership/metadata settles. Keep polling within the timeout
+    // rather than treating the first error event as fatal.
     let mut stream = consumer.stream();
-    let msg = tokio::time::timeout(Duration::from_secs(30), stream.next())
-        .await
-        .expect("kafka consumer timed out")
-        .expect("no message")
-        .expect("kafka delivery error");
+    let msg = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match stream.next().await {
+                Some(Ok(m)) => break m,
+                Some(Err(e)) => {
+                    eprintln!("transient kafka consume error, retrying: {e}");
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+                None => panic!("kafka stream ended before delivering a message"),
+            }
+        }
+    })
+    .await
+    .expect("kafka consumer timed out");
 
     let body = msg.payload().expect("message payload");
     let payload: Value = serde_json::from_slice(body).expect("kafka payload JSON");

--- a/core/tests/e2e_reorg_streams.rs
+++ b/core/tests/e2e_reorg_streams.rs
@@ -283,6 +283,32 @@ async fn stream_reorg_reaches_rabbitmq() {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "kafka")]
+async fn create_kafka_topic(bootstrap: &str, topic: &str) {
+    use rdkafka::{
+        admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
+        client::DefaultClientContext,
+        ClientConfig,
+    };
+
+    let admin: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", bootstrap)
+        .create()
+        .expect("kafka admin client");
+
+    let results = admin
+        .create_topics(
+            &[NewTopic::new(topic, 1, TopicReplication::Fixed(1))],
+            &AdminOptions::new().operation_timeout(Some(Duration::from_secs(10))),
+        )
+        .await
+        .expect("create kafka topic");
+
+    for result in results {
+        result.expect("create kafka topic result");
+    }
+}
+
+#[cfg(feature = "kafka")]
 #[tokio::test]
 async fn stream_reorg_reaches_kafka() {
     use futures::StreamExt;
@@ -299,6 +325,7 @@ async fn stream_reorg_reaches_kafka() {
     let bootstrap = format!("127.0.0.1:{port}");
 
     let topic = "rindexer_reorg_topic";
+    create_kafka_topic(&bootstrap, topic).await;
 
     // Subscribe BEFORE producing with `earliest` offset reset so we don't miss the message.
     let consumer: StreamConsumer = ClientConfig::new()


### PR DESCRIPTION
## Summary

Two independent fixes surfaced while investigating reorg-test CI failures:

### 1. `fix(reorg)`: quote identifiers in reversal SQL (real correctness bug)
The reorg derived-table reversal interpolated user-defined column names **unquoted** into the generated SQL. A derived table keyed on a reserved word — e.g. an ERC20 aggregation with `where: { holder: "$to" }` — produced `SELECT to … GROUP BY to`, which Postgres rejects with `syntax error at or near "to"`. The rollback then failed every retry and the live-reorg recovery test timed out.

- Identifiers are now quoted per backend (Postgres double-quotes, ClickHouse backticks) across the snapshot `SELECT`/`GROUP BY`, the PG apply-phase join, and the CH `Join` keys / `joinGet` / exists-filter.
- The pre-existing `quote_identifier` helper relies on a 7-word reserved list that omits `to`/`from`, so it would not have caught this — hence always-quoting here.
- `set_clauses` are intentionally left unquoted: the ClickHouse set-clause rewriter parses bare `dt.`/`snap.` tokens.
- New regression test `test_reorg_reversal_reserved_word_column` (real Postgres via testcontainers) reproduces the exact error and passes after the fix. Full `e2e_reorg` suite is green, including the ClickHouse reversal path.

### 2. `test(streams)`: stabilize the flaky Kafka reorg-stream test
`stream_reorg_reaches_kafka` intermittently failed with `UnknownTopicOrPartition`. The test relied on lazy topic auto-creation and a consumer that treated the first stream item as fatal.

- Pre-create the topic via `AdminClient` before subscribing/producing (mirrors the RabbitMQ test declaring its topology up front).
- A freshly-created topic can still briefly surface transient metadata errors to the consumer, so the consume loop now tolerates them and keeps polling within the timeout instead of panicking on the first error event.

## Testing
- `cargo nextest run -p rindexer --test e2e_reorg` — 30/30 pass (incl. `test_reorg_clickhouse_add_reversal`)
- `cargo nextest run -p rindexer --features kafka --test e2e_reorg_streams stream_reorg_reaches_kafka` — pass
- fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
