### PR TITLE
fix(reorg): quote reserved-word identifiers in reversal SQL; stabilize Kafka reorg stream test

### DIFF
--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -223,7 +223,31 @@ struct ReversalSnapshot {
     cross_chain: bool,
     network: String,
     where_columns: Vec<(String, String)>,
-    set_clauses: Vec<String>,
+    set_ops: Vec<ReversalSetOp>,
+}
+
+/// A single reversal SET assignment, kept structured (rather than as a
+/// pre-rendered SQL string) so each backend can quote the derived column with
+/// its own convention. `derived_column` is reversed by `op_symbol` against the
+/// snapshot aggregate exposed under `agg_alias`.
+#[derive(Clone)]
+struct ReversalSetOp {
+    derived_column: String,
+    op_symbol: &'static str,
+    agg_alias: String,
+}
+
+/// Quote a SQL identifier for Postgres (double quotes), escaping any embedded
+/// quotes. Required because user-defined event/derived columns can collide with
+/// SQL reserved words (e.g. `to`, `from`).
+fn quote_pg_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Quote a SQL identifier for ClickHouse (backticks), escaping any embedded
+/// backticks. Mirrors `quote_pg_ident` for the ClickHouse backend.
+fn quote_ch_ident(name: &str) -> String {
+    format!("`{}`", name.replace('`', "\\`"))
 }
 
 impl ReorgTask {
@@ -250,10 +274,13 @@ impl ReorgTask {
 
         for dt in &self.derived_tables {
             for op in &dt.rollback_ops {
-                let mut agg_columns: Vec<String> = Vec::new();
-                let mut set_clauses: Vec<String> = Vec::new();
+                // (is_counter, source event column, agg alias) per reversible
+                // column. The SELECT aggregate is assembled per-backend so each
+                // can quote identifiers with its own convention.
+                let mut agg_specs: Vec<(bool, String, String)> = Vec::new();
+                let mut set_ops: Vec<ReversalSetOp> = Vec::new();
 
-                for col in &op.columns {
+                for (col_idx, col) in op.columns.iter().enumerate() {
                     let Some(reversed) = col.action.reverse() else {
                         tracing::warn!(
                             table = %dt.full_table_name,
@@ -264,13 +291,6 @@ impl ReorgTask {
                         continue;
                     };
 
-                    let agg_expr = if col.action.is_counter_action() {
-                        format!("COUNT(*) AS {}_agg", col.event_column)
-                    } else {
-                        format!("SUM({}) AS {}_agg", col.event_column, col.event_column)
-                    };
-                    agg_columns.push(agg_expr);
-
                     let op_symbol = match reversed {
                         SetAction::Add | SetAction::Increment => "+",
                         SetAction::Subtract | SetAction::Decrement => "-",
@@ -280,17 +300,28 @@ impl ReorgTask {
                             col.derived_column,
                         ),
                     };
-                    set_clauses.push(format!(
-                        "{} = dt.{} {} snap.{}_agg",
-                        col.derived_column, col.derived_column, op_symbol, col.event_column
+
+                    // Aggregate aliases are synthesized internal identifiers — never
+                    // derived from user column names — so they are always valid SQL
+                    // identifiers and keep user-controlled text out of alias positions.
+                    let agg_alias = format!("_rindexer_agg_{}", col_idx);
+                    agg_specs.push((
+                        col.action.is_counter_action(),
+                        col.event_column.clone(),
+                        agg_alias.clone(),
                     ));
+                    set_ops.push(ReversalSetOp {
+                        derived_column: col.derived_column.clone(),
+                        op_symbol,
+                        agg_alias,
+                    });
                 }
 
-                if set_clauses.is_empty() || agg_columns.is_empty() {
+                if set_ops.is_empty() || agg_specs.is_empty() {
                     continue;
                 }
 
-                let group_cols: Vec<&str> =
+                let where_ev_cols: Vec<&str> =
                     op.where_columns.iter().map(|(_, ev_col)| ev_col.as_str()).collect();
 
                 let network_filter = self.network_filter(dt.cross_chain);
@@ -310,23 +341,44 @@ impl ReorgTask {
                 );
                 snap_idx += 1;
 
-                // Build the SELECT portion independently so PG and CH can wrap it
-                // in their own CREATE TABLE syntax without fragile string stripping.
-                let select_sql = format!(
-                    "SELECT {}, {} FROM {} WHERE block_number >= {} AND block_number <= {}{}{} GROUP BY {}",
-                    group_cols.join(", "),
-                    agg_columns.join(", "),
-                    op.event_table,
-                    self.fork_point,
-                    self.detection_point,
-                    network_filter,
-                    condition_filter,
-                    group_cols.join(", "),
-                );
+                // Build the SELECT per-backend. Group/where and aggregate-source
+                // columns are user-controlled identifiers that may collide with SQL
+                // reserved words (e.g. `to`, `from`), so each backend quotes them with
+                // its own convention (Postgres double quotes, ClickHouse backticks).
+                let build_select = |quote: &dyn Fn(&str) -> String| {
+                    let group =
+                        where_ev_cols.iter().map(|c| quote(c)).collect::<Vec<_>>().join(", ");
+                    let aggs = agg_specs
+                        .iter()
+                        .map(|(is_counter, ev, alias)| {
+                            if *is_counter {
+                                format!("COUNT(*) AS {}", alias)
+                            } else {
+                                format!("SUM({}) AS {}", quote(ev), alias)
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!(
+                        "SELECT {}, {} FROM {} WHERE block_number >= {} AND block_number <= {}{}{} GROUP BY {}",
+                        group,
+                        aggs,
+                        op.event_table,
+                        self.fork_point,
+                        self.detection_point,
+                        network_filter,
+                        condition_filter,
+                        group,
+                    )
+                };
 
                 if let Some(pg) = pg {
                     let pg_temp = format!("{}_pg", temp_base);
-                    let pg_create = format!("CREATE TEMP TABLE {} AS {}", pg_temp, select_sql);
+                    let pg_create = format!(
+                        "CREATE TEMP TABLE {} AS {}",
+                        pg_temp,
+                        build_select(&quote_pg_ident)
+                    );
                     pg.batch_execute(&pg_create).await.with_context(|| {
                         format!(
                             "Failed to create PG reorg reversal snapshot for {}",
@@ -341,7 +393,7 @@ impl ReorgTask {
                         cross_chain: dt.cross_chain,
                         network: self.network.clone(),
                         where_columns: op.where_columns.clone(),
-                        set_clauses: set_clauses.clone(),
+                        set_ops: set_ops.clone(),
                     });
                 }
 
@@ -352,13 +404,13 @@ impl ReorgTask {
                     // aggregates via joinGet(). ClickHouse mutations don't
                     // support correlated subqueries the way Postgres does, so
                     // we cannot use `(SELECT ... WHERE snap.k = dt.k LIMIT 1)`.
-                    let ch_snap_keys: Vec<&str> =
-                        op.where_columns.iter().map(|(_, ev_col)| ev_col.as_str()).collect();
+                    let ch_snap_keys: Vec<String> =
+                        where_ev_cols.iter().map(|ev_col| quote_ch_ident(ev_col)).collect();
                     let ch_create = format!(
                         "CREATE TABLE IF NOT EXISTS {} ENGINE = Join(ANY, LEFT, {}) AS {}",
                         ch_temp,
                         ch_snap_keys.join(", "),
-                        select_sql,
+                        build_select(&quote_ch_ident),
                     );
                     ch.execute(&ch_create).await.with_context(|| {
                         format!(
@@ -374,7 +426,7 @@ impl ReorgTask {
                         cross_chain: dt.cross_chain,
                         network: self.network.clone(),
                         where_columns: op.where_columns.clone(),
-                        set_clauses,
+                        set_ops,
                     });
                 }
             }
@@ -393,7 +445,9 @@ impl ReorgTask {
             let where_join: Vec<String> = snap
                 .where_columns
                 .iter()
-                .map(|(dt_col, ev_col)| format!("dt.{} = snap.{}", dt_col, ev_col))
+                .map(|(dt_col, ev_col)| {
+                    format!("dt.{} = snap.{}", quote_pg_ident(dt_col), quote_pg_ident(ev_col))
+                })
                 .collect();
 
             let network_join = if snap.cross_chain {
@@ -405,10 +459,18 @@ impl ReorgTask {
             match snap.backend {
                 SnapshotBackend::Postgres => {
                     let Some(pg) = pg else { continue };
+                    let pg_set_clauses: Vec<String> = snap
+                        .set_ops
+                        .iter()
+                        .map(|s| {
+                            let col = quote_pg_ident(&s.derived_column);
+                            format!("{} = dt.{} {} snap.{}", col, col, s.op_symbol, s.agg_alias)
+                        })
+                        .collect();
                     let update_sql = format!(
                         "UPDATE {} AS dt SET {} FROM {} AS snap WHERE {}{}",
                         snap.derived_table,
-                        snap.set_clauses.join(", "),
+                        pg_set_clauses.join(", "),
                         snap.temp_table,
                         where_join.join(" AND "),
                         network_join,
@@ -433,36 +495,25 @@ impl ReorgTask {
                     // ClickHouse ALTER TABLE ... UPDATE with per-row aggregate lookups
                     // against a Join-engine snapshot table. joinGet() is the mutation-
                     // safe equivalent of PG's correlated subquery.
-                    let dt_keys: Vec<&str> =
-                        snap.where_columns.iter().map(|(dt_col, _)| dt_col.as_str()).collect();
+                    let dt_keys: Vec<String> = snap
+                        .where_columns
+                        .iter()
+                        .map(|(dt_col, _)| quote_ch_ident(dt_col))
+                        .collect();
                     let join_get_keys = dt_keys.join(", ");
 
-                    // Build CH set clauses by replacing known "snap.X_agg" tokens with
-                    // joinGet('snap_table', 'X_agg', dt_key1, dt_key2, ...) calls.
+                    // Build CH set clauses directly from the structured ops: the
+                    // per-row aggregate is looked up via joinGet() against the
+                    // Join-engine snapshot, keyed by the derived-table where columns.
                     let ch_set_clauses: Vec<String> = snap
-                        .set_clauses
+                        .set_ops
                         .iter()
-                        .map(|clause| {
-                            let result = clause.replace("dt.", "");
-                            let snap_prefix = "snap.";
-                            let mut offset = 0;
-                            let mut new_result = String::with_capacity(result.len());
-                            while let Some(pos) = result[offset..].find(snap_prefix) {
-                                let abs_pos = offset + pos;
-                                new_result.push_str(&result[offset..abs_pos]);
-                                let rest = &result[abs_pos + snap_prefix.len()..];
-                                let end = rest
-                                    .find(|c: char| !c.is_alphanumeric() && c != '_')
-                                    .unwrap_or(rest.len());
-                                let col_name = &rest[..end];
-                                new_result.push_str(&format!(
-                                    "joinGet('{}', '{}', {})",
-                                    snap.temp_table, col_name, join_get_keys
-                                ));
-                                offset = abs_pos + snap_prefix.len() + end;
-                            }
-                            new_result.push_str(&result[offset..]);
-                            new_result
+                        .map(|s| {
+                            let col = quote_ch_ident(&s.derived_column);
+                            format!(
+                                "{} = {} {} joinGet('{}', '{}', {})",
+                                col, col, s.op_symbol, snap.temp_table, s.agg_alias, join_get_keys
+                            )
                         })
                         .collect();
 
@@ -477,7 +528,12 @@ impl ReorgTask {
                         .where_columns
                         .iter()
                         .map(|(dt_col, ev_col)| {
-                            format!("{} IN (SELECT {} FROM {})", dt_col, ev_col, snap.temp_table)
+                            format!(
+                                "{} IN (SELECT {} FROM {})",
+                                quote_ch_ident(dt_col),
+                                quote_ch_ident(ev_col),
+                                snap.temp_table
+                            )
                         })
                         .collect();
                     let ch_scope = if ch_exists_filter.is_empty() {

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -2155,6 +2155,118 @@ async fn test_reorg_reversal_add() {
 }
 
 // ---------------------------------------------------------------------------
+// Test: Reversal works when the grouping/where column is a SQL reserved word
+// (e.g. `to` from an ERC20 Transfer). Regression for unquoted identifiers in
+// the reorg reversal SQL producing `syntax error at or near "to"`.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_reorg_reversal_reserved_word_column() {
+    let env = TestEnv::new().await;
+    let pg = env.pg_client().await;
+    env.setup_base_tables(&pg).await;
+
+    // Event table grows a `to` column — a Postgres reserved word — mirroring an
+    // ERC20 Transfer recipient used as the aggregation key.
+    pg.batch_execute("ALTER TABLE test_schema.ping_pong_ping ADD COLUMN \"to\" CHAR(42);")
+        .await
+        .unwrap();
+
+    // Derived table keyed on the recipient. The aggregate column is itself named
+    // with a reserved word (`to`) to exercise quoting of the UPDATE SET target as
+    // well as the aggregation/group key.
+    pg.batch_execute(
+        "CREATE TABLE IF NOT EXISTS test_schema.holder_balances (
+             network VARCHAR(50) NOT NULL,
+             holder CHAR(42) NOT NULL,
+             \"to\" NUMERIC NOT NULL DEFAULT 0,
+             rindexer_block_number BIGINT NOT NULL,
+             PRIMARY KEY (network, holder)
+         );",
+    )
+    .await
+    .unwrap();
+
+    let (contract, _) = deploy_ping_pong(&env.http, &env.rpc_url, env.deployer).await;
+    let block1 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 1).await;
+    let block2 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 2).await;
+    let block3 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 3).await;
+
+    let network = "dev";
+    let holder = format!("{:#x}", env.deployer);
+    let zero_tx = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+    // +100, +50, +30 across blocks 1..3, all to the same recipient.
+    for (amount, block) in [(100u64, block1), (50, block2), (30, block3)] {
+        env.insert_event(&pg, network, amount, block, zero_tx).await;
+    }
+    pg.batch_execute(&format!("UPDATE test_schema.ping_pong_ping SET \"to\" = '{}';", holder))
+        .await
+        .unwrap();
+    env.insert_block_hashes(&pg, network, block1, block3).await;
+
+    // Derived state: "to" = 100 + 50 + 30 = 180.
+    pg.execute(
+        "INSERT INTO test_schema.holder_balances (network, holder, \"to\", rindexer_block_number) \
+         VALUES ($1, $2, $3, $4)",
+        &[&network, &holder.as_str(), &rust_decimal::Decimal::from(180u64), &(block3 as i64)],
+    )
+    .await
+    .unwrap();
+
+    trigger_reorg(&env.http, &env.rpc_url, 2).await; // invalidates block2, block3
+
+    let task = ReorgTask {
+        network: network.to_string(),
+        fork_point: block2,
+        detection_point: block3,
+        event_tables: vec![EventTableInfo::try_new(
+            "test_schema".to_string(),
+            "ping_pong_ping".to_string(),
+            "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
+        )
+        .unwrap()],
+        derived_tables: vec![DerivedTableInfo {
+            full_table_name: "test_schema.holder_balances".to_string(),
+            cross_chain: false,
+            rollback_ops: vec![DerivedTableRollbackOp {
+                event_table: "test_schema.ping_pong_ping".to_string(),
+                where_columns: vec![("holder".to_string(), "to".to_string())],
+                columns: vec![DerivedColumnRollback {
+                    derived_column: "to".to_string(),
+                    event_column: "id".to_string(),
+                    action: SetAction::Add,
+                }],
+                condition: None,
+            }],
+            journal_columns: vec![],
+        }],
+        canonical_blocks: vec![],
+    };
+
+    let rindexer_pg = env.rindexer_pg().await;
+    let mut task_window = BlockChainWindow::try_new(256).unwrap();
+
+    task.execute(&mut task_window, Some(&rindexer_pg), None, None)
+        .await
+        .expect("reserved-word reversal reorg task failed");
+
+    // 180 - (50 + 30) = 100 after reversing blocks 2 and 3.
+    let total: rust_decimal::Decimal = pg
+        .query_one(
+            "SELECT \"to\" FROM test_schema.holder_balances WHERE network = $1 AND holder = $2",
+            &[&network, &holder.as_str()],
+        )
+        .await
+        .expect("holder row should still exist after reversal")
+        .get(0);
+    assert_eq!(total, rust_decimal::Decimal::from(100u64), "total should be 180 - 80 = 100");
+}
+
+// ---------------------------------------------------------------------------
 // Test: Subtract action is reversed (added back) during reorg
 // ---------------------------------------------------------------------------
 
@@ -3245,6 +3357,142 @@ async fn test_reorg_clickhouse_add_reversal() {
 
     // PG: only the block1 event should remain
     assert_eq!(env.event_count(&pg).await, 1, "PG: only Ping(100) at block1 should remain");
+}
+
+// ---------------------------------------------------------------------------
+// Test: ClickHouse reversal works when the aggregation key AND the derived SET
+// column are SQL reserved words (`to`). Exercises the backtick-quoted Join
+// engine key, joinGet(), IN-subquery and ALTER UPDATE SET on the CH path.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_reorg_reversal_reserved_word_column_clickhouse() {
+    let env = TestEnv::new().await;
+    let pg = env.pg_client().await;
+    env.setup_base_tables(&pg).await;
+
+    let ch = env.rindexer_ch().await;
+    env.setup_ch_tables(&ch).await;
+
+    let user = format!("{:#x}", env.deployer);
+
+    // Reserved-word `to` event column (the aggregation key) on both backends.
+    pg.batch_execute("ALTER TABLE test_schema.ping_pong_ping ADD COLUMN \"to\" CHAR(42);")
+        .await
+        .unwrap();
+    ch.execute(&format!(
+        "ALTER TABLE test_schema.ping_pong_ping ADD COLUMN `to` FixedString(42) DEFAULT '{user}'"
+    ))
+    .await
+    .unwrap();
+
+    // Derived table whose aggregate column is itself named `to` (reserved).
+    pg.batch_execute(
+        "CREATE TABLE IF NOT EXISTS test_schema.holder_balances (
+             network VARCHAR(50) NOT NULL,
+             user_address CHAR(42) NOT NULL,
+             \"to\" NUMERIC NOT NULL DEFAULT 0,
+             rindexer_block_number BIGINT NOT NULL,
+             PRIMARY KEY (network, user_address)
+         );",
+    )
+    .await
+    .unwrap();
+    ch.execute(
+        "CREATE TABLE IF NOT EXISTS test_schema.holder_balances (
+             network String,
+             user_address FixedString(42),
+             `to` UInt256,
+             rindexer_block_number UInt64
+         ) ENGINE = ReplacingMergeTree
+         ORDER BY (network, user_address)",
+    )
+    .await
+    .unwrap();
+
+    let (contract, _) = deploy_ping_pong(&env.http, &env.rpc_url, env.deployer).await;
+    let block1 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 1).await;
+    let block2 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 2).await;
+    let block3 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 3).await;
+
+    let network = "dev";
+    let zero_tx = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+    // +100, +50, +30 across blocks 1..3 (CH rows get `to` = user via column default).
+    for (amount, block) in [(100u64, block1), (50, block2), (30, block3)] {
+        env.insert_event(&pg, network, amount, block, zero_tx).await;
+        env.insert_ch_event(&ch, network, amount, block, zero_tx).await;
+    }
+    pg.batch_execute(&format!("UPDATE test_schema.ping_pong_ping SET \"to\" = '{user}';"))
+        .await
+        .unwrap();
+    env.insert_block_hashes(&pg, network, block1, block3).await;
+    env.insert_ch_block_hashes(&ch, network, block1, block3).await;
+
+    // Derived state: "to" = 100 + 50 + 30 = 180 in both backends.
+    pg.execute(
+        "INSERT INTO test_schema.holder_balances (network, user_address, \"to\", rindexer_block_number) \
+         VALUES ($1, $2, $3, $4)",
+        &[&network, &user.as_str(), &rust_decimal::Decimal::from(180u64), &(block3 as i64)],
+    )
+    .await
+    .unwrap();
+    ch.execute(&format!(
+        "INSERT INTO test_schema.holder_balances (network, user_address, `to`, rindexer_block_number) \
+         VALUES ('{network}', '{user}', 180, {block3})"
+    ))
+    .await
+    .unwrap();
+
+    trigger_reorg(&env.http, &env.rpc_url, 2).await; // invalidates block2, block3
+
+    let task = ReorgTask {
+        network: network.to_string(),
+        fork_point: block2,
+        detection_point: block3,
+        event_tables: vec![EventTableInfo::try_new(
+            "test_schema".to_string(),
+            "ping_pong_ping".to_string(),
+            "test_schema_ping".to_string(),
+            "test_indexer".to_string(),
+            "PingPong".to_string(),
+            "Ping".to_string(),
+        )
+        .unwrap()],
+        derived_tables: vec![DerivedTableInfo {
+            full_table_name: "test_schema.holder_balances".to_string(),
+            cross_chain: false,
+            rollback_ops: vec![DerivedTableRollbackOp {
+                event_table: "test_schema.ping_pong_ping".to_string(),
+                where_columns: vec![("user_address".to_string(), "to".to_string())],
+                columns: vec![DerivedColumnRollback {
+                    derived_column: "to".to_string(),
+                    event_column: "id".to_string(),
+                    action: SetAction::Add,
+                }],
+                condition: None,
+            }],
+            journal_columns: vec![],
+        }],
+        canonical_blocks: vec![],
+    };
+
+    let rindexer_pg = env.rindexer_pg().await;
+    let mut task_window = BlockChainWindow::try_new(256).unwrap();
+
+    task.execute(&mut task_window, Some(&rindexer_pg), Some(&ch), None)
+        .await
+        .expect("clickhouse reserved-word reversal reorg task failed");
+
+    // CH: "to" was 180, reversing blocks 2 and 3 subtracts 50 + 30 -> 100.
+    let ch_total: u64 = ch
+        .query_one(&format!(
+            "SELECT toUInt64(`to`) FROM test_schema.holder_balances FINAL \
+             WHERE network = '{network}' AND user_address = '{user}'"
+        ))
+        .await
+        .expect("CH holder row should still exist after reversal");
+    assert_eq!(ch_total, 100, "CH \"to\" should be 180 - 80 = 100");
 }
 
 // ---------------------------------------------------------------------------

--- a/core/tests/e2e_reorg_streams.rs
+++ b/core/tests/e2e_reorg_streams.rs
@@ -367,12 +367,25 @@ async fn stream_reorg_reaches_kafka() {
     let streamed = publish_reorg(&clients).await;
     assert_eq!(streamed, 1);
 
+    // Even with the topic explicitly created up front, a consumer can briefly
+    // observe transient metadata errors (e.g. UnknownTopicOrPartition) before
+    // partition leadership/metadata settles. Keep polling within the timeout
+    // rather than treating the first error event as fatal.
     let mut stream = consumer.stream();
-    let msg = tokio::time::timeout(Duration::from_secs(30), stream.next())
-        .await
-        .expect("kafka consumer timed out")
-        .expect("no message")
-        .expect("kafka delivery error");
+    let msg = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match stream.next().await {
+                Some(Ok(m)) => break m,
+                Some(Err(e)) => {
+                    eprintln!("transient kafka consume error, retrying: {e}");
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+                None => panic!("kafka stream ended before delivering a message"),
+            }
+        }
+    })
+    .await
+    .expect("kafka consumer timed out");
 
     let body = msg.payload().expect("message payload");
     let payload: Value = serde_json::from_slice(body).expect("kafka payload JSON");


### PR DESCRIPTION
## Summary

Two independent fixes surfaced while investigating reorg-test CI failures. Rebased on `master` after #439 merged, so the Kafka topic-creation commit (now upstream via #439) is dropped from this branch; this PR builds the resilient consume loop on top of it.

### 1. `fix(reorg)`: quote identifiers in reversal SQL (real correctness bug)
Reorg derived-table reversal interpolated user-defined column names **unquoted** into generated SQL. A derived table keyed on a reserved word — e.g. an ERC20 aggregation with `where: { holder: "$to" }` — produced `SELECT to … GROUP BY to`, which Postgres rejects with `syntax error at or near "to"`. The rollback then failed every retry and live-reorg recovery timed out.

- User-controlled identifiers are now quoted per backend (Postgres double-quotes, ClickHouse backticks) across the snapshot `SELECT`/`GROUP BY`, the aggregate source, the PG apply-phase join + SET, and the CH `Join` keys / `joinGet` / exists-filter / SET.
- `set_clauses` were refactored from pre-rendered SQL strings into structured `ReversalSetOp`s, so each backend builds (and quotes) its own SET — this also removed the fragile ClickHouse set-clause string-rewriter.
- Aggregate aliases are now synthesized internal identifiers (`_rindexer_agg_N`) rather than derived from user column names, keeping user text out of SQL alias positions.
- The pre-existing `quote_identifier` helper relies on a 7-word reserved list omitting `to`/`from`, so it would not have caught this — hence always-quoting here.

Covered by new regression tests against real Postgres and ClickHouse (testcontainers): `test_reorg_reversal_reserved_word_column` (PG) and `test_reorg_reversal_reserved_word_column_clickhouse` (CH), both keying on the reserved word `to` for the aggregation key and the derived SET column.

### 2. `test(streams)`: stabilize the flaky Kafka reorg-stream test
`stream_reorg_reaches_kafka` intermittently failed with `UnknownTopicOrPartition`. Topic pre-creation (added in #439) is necessary but insufficient: a freshly-created topic can still briefly surface transient metadata errors to the consumer, which previously treated the first stream item as fatal. The consume loop now tolerates transient errors and keeps polling within the timeout instead of panicking on the first error event.

## Testing
- `cargo nextest run -p rindexer --test e2e_reorg` — full reorg suite green, including the new PG + CH reserved-word tests
- `cargo nextest run -p rindexer --features kafka --test e2e_reorg_streams stream_reorg_reaches_kafka` — pass
- fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
