### PR TITLE
Skip reth on Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,9 @@ jobs:
           target="${{ matrix.target }}"
           flags=()
 
-          if [[ "$target" != *msvc* && "$target" != "aarch64-unknown-linux-gnu" ]]; then
+          if [[ "$target" == *msvc* ]]; then
+            echo "Building Windows without the reth feature"
+          elif [[ "$target" != "aarch64-unknown-linux-gnu" ]]; then
             flags+=(--features jemalloc,reth)
           else
             flags+=(--features reth)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ curl -L https://rindexer.xyz/install.sh | bash
 If you’re on Windows, you will need to install and use Git BASH or WSL, as your terminal,
 since rindexer installation does not support Powershell or Cmd.
 
+Native Windows release binaries are built without Reth/ExEx support. If you need Reth mode,
+use Linux, macOS, Docker, or WSL/Linux instead of the native Windows artifact.
+
 ## Use rindexer
 
 Once installed you can run `rindexer --help` in your terminal to see all the commands available to you.

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,6 +13,9 @@ curl -L https://rindexer.xyz/install.sh | bash
 If you’re on Windows, you will need to install and use Git BASH or WSL, as your terminal,
 since rindexer installation does not support Powershell or Cmd.
 
+Native Windows release binaries are built without Reth/ExEx support. If you need Reth mode,
+use Linux, macOS, Docker, or WSL/Linux instead of the native Windows artifact.
+
 ## Use rindexer
 
 Once installed you can run `rindexer --help` in your terminal to see all the commands available to you.

--- a/documentation/docs/pages/docs/advanced/using-reth-exex.md
+++ b/documentation/docs/pages/docs/advanced/using-reth-exex.md
@@ -2,6 +2,8 @@
 
 Reth Execution Extensions (ExEx) is a powerful framework introduced by Reth for building high-performance off-chain infrastructure as post-execution hooks. rindexer leverages ExEx to provide superior indexing performance and native reorg handling.
 
+> Native Windows rindexer CLI releases are built without Reth/ExEx support because upstream Reth no longer provides Windows build/release support. Use Linux, macOS, Docker, or WSL/Linux for Reth mode.
+
 ## What is ExEx?
 
 ExEx provides a reorg-aware stream called `ExExNotification` which includes:

--- a/documentation/docs/pages/docs/introduction/installation.mdx
+++ b/documentation/docs/pages/docs/introduction/installation.mdx
@@ -16,6 +16,9 @@ rindexer operates as a CLI toolset to make it easy to create new rindexer projec
 :::warning
 If you’re on Windows, you will need to install and use Git BASH or WSL, as your terminal,
 since rindexer installation does not support Powershell or Cmd.
+
+Native Windows release binaries are built without Reth/ExEx support. If you need Reth mode,
+use Linux, macOS, Docker, or WSL/Linux instead of the native Windows artifact.
 :::
 
 :::code-group

--- a/documentation/docs/pages/docs/references/cli.mdx
+++ b/documentation/docs/pages/docs/references/cli.mdx
@@ -64,6 +64,8 @@ Examples:
   rindexer new rust --reth -- --datadir /custom/path --http true
 ```
 
+`--reth` requires a CLI binary built with the `reth` feature. Official native Windows release binaries are built without that feature, so use Linux, macOS, Docker, or WSL/Linux for Reth mode.
+
 ## start
 
 Start various services like indexers, GraphQL APIs or both together. This will start the services based on the rindexer.yaml file. A health monitoring server is automatically started alongside these services.

--- a/documentation/docs/pages/docs/start-building/create-new-project/index.mdx
+++ b/documentation/docs/pages/docs/start-building/create-new-project/index.mdx
@@ -17,5 +17,6 @@ An advanced mode that integrates directly with Reth nodes using Execution Extens
 **Requirements:**
 - Running Reth archive node
 - Advanced knowledge of Ethereum infrastructure
+- Linux, macOS, Docker, or WSL/Linux. Native Windows CLI releases do not include Reth/ExEx support.
 
 [Create a Reth Project →](/docs/start-building/create-new-project/reth-mode)

--- a/documentation/docs/pages/docs/start-building/create-new-project/reth-mode.mdx
+++ b/documentation/docs/pages/docs/start-building/create-new-project/reth-mode.mdx
@@ -4,6 +4,10 @@
 Reth mode requires running a Reth archive node and is intended for advanced users. If you're just getting started, you should be using [Standard Mode](/docs/start-building/create-new-project/standard) instead.
 :::
 
+:::warning
+The native Windows CLI release is built without the `reth` feature because upstream Reth no longer provides Windows build/release support. Use Linux, macOS, Docker, or WSL/Linux for Reth mode.
+:::
+
 :::info
 Make sure you have the CLI installed before starting a new project.
 You can find the installation instructions [here](/docs/introduction/installation).
@@ -42,6 +46,8 @@ rindexer new no-code --reth -- --datadir /custom/path --http true
 
 :::info
 Starting rust projects with Reth mode will add the `reth` feature to your project, which automatically installs the dependencies for Reth. The user does not need to install Reth separately.
+
+The CLI binary itself must also be built with the `reth` feature. Official native Windows release binaries are built without this feature.
 :::
 
 ### Example New with Reth

--- a/documentation/docs/pages/index.mdx
+++ b/documentation/docs/pages/index.mdx
@@ -14,6 +14,9 @@ curl -L https://rindexer.xyz/install.sh | bash
 :::warning
 If you’re on Windows, you will need to install and use Git BASH or WSL, as your terminal,
 since rindexer installation does not support Powershell or Cmd.
+
+Native Windows release binaries are built without Reth/ExEx support. If you need Reth mode,
+use Linux, macOS, Docker, or WSL/Linux instead of the native Windows artifact.
 :::
   <HomePage.Description>A no-code or framework to build blazing fast EVM indexers - built in rust.</HomePage.Description>
   <HomePage.Buttons>

--- a/documentation/docs/public/install.sh
+++ b/documentation/docs/public/install.sh
@@ -165,6 +165,9 @@ fi
 if [ -f "$BIN_PATH" ]; then
     chmod +x "$BIN_PATH"
     log "Binary found and permissions set at $BIN_PATH"
+    if [[ "$PLATFORM" == "win32" ]]; then
+        log "Note: native Windows binaries are built without Reth/ExEx support. Use Linux, macOS, Docker, or WSL/Linux for Reth mode."
+    fi
 else
     error_log "Error: Binary not found at $BIN_PATH"
     exit 1


### PR DESCRIPTION
Fixes issue #446.

## Summary

- Stop enabling the `reth` feature for `x86_64-pc-windows-msvc` release builds.
- Preserve the existing non-Windows build paths:
  - Linux/macOS continue to build with `jemalloc,reth`.
  - `aarch64-unknown-linux-gnu` continues to build with `reth`.
- Document that native Windows CLI release binaries do not include Reth/ExEx support, and point Reth users to Linux, macOS, Docker, or WSL/Linux.
- Add a Windows install-time note so users do not discover the limitation only after creating a Reth project.

## Context

The v0.41.0 Windows release job fails after the Reth v2 dependency bump in #422 because the Windows/MSVC artifact still enables `--features reth`. Reth v2 now pulls build paths that are not viable in the current native Windows release job, and upstream Reth removed Windows build/release support in https://github.com/paradigmxyz/reth/commit/755ea5762bda6a1aace0f9f73128cd7e709a723b.

This keeps the Windows CLI artifact available for standard mode while avoiding a larger workaround for an upstream-unsupported Reth-on-Windows release path.

## Validation

- `git diff --check`
- `bash -n documentation/docs/public/install.sh`
- Local release flag matrix: Windows/MSVC -> no features; Linux/macOS -> `jemalloc,reth`; Linux ARM -> `reth`
- `cargo check -p rindexer_cli`
- `cargo build --release -p rindexer_cli`
- `./target/release/rindexer_cli --version`
- `./target/release/rindexer_cli help`
