### PR TITLE
Chore: sync upstream v0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "clickhouse_factory_indexing"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-tests"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -12714,7 +12714,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_factory_contract"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -12723,7 +12723,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_rust_playground"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -12934,7 +12934,7 @@ dependencies = [
 
 [[package]]
 name = "rust_clickhouse"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -16922,7 +16922,7 @@ checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "xtask"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/core/src/adaptive_concurrency.rs
+++ b/core/src/adaptive_concurrency.rs
@@ -3,6 +3,7 @@
 //! This module provides centralized rate limiting and adaptive scaling for RPC requests.
 //! It's used by both the RPC layer (layer_extensions.rs) and the indexer (tables.rs).
 
+use crate::metrics::rpc as rpc_metrics;
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -67,6 +68,17 @@ impl AdaptiveConcurrency {
     /// Get total rate limit count
     pub fn rate_limit_count(&self) -> u64 {
         self.rate_limit_count.load(Ordering::Relaxed)
+    }
+
+    /// Publish current controller state to Prometheus gauges. Called after every
+    /// state transition so alerts see backoff/scale-down in near real time.
+    fn publish_metrics(&self) {
+        rpc_metrics::set_adaptive_state(
+            self.current.load(Ordering::Relaxed),
+            self.batch_size.load(Ordering::Relaxed),
+            self.backoff_ms.load(Ordering::Relaxed),
+        );
+        rpc_metrics::set_rate_limit_events(self.rate_limit_count.load(Ordering::Relaxed));
     }
 
     /// Wait for the backoff delay if one is active.
@@ -144,6 +156,8 @@ impl AdaptiveConcurrency {
                 }
             }
         }
+
+        self.publish_metrics();
     }
 
     /// Record a rate limit error - scale down aggressively and increase backoff
@@ -198,6 +212,8 @@ impl AdaptiveConcurrency {
                 self.min, self.min_batch_size, new_backoff, count
             );
         }
+
+        self.publish_metrics();
     }
 
     /// Record a general error - scale down slightly
@@ -219,7 +235,33 @@ impl AdaptiveConcurrency {
                 );
             }
         }
+
+        self.publish_metrics();
     }
+}
+
+/// True if the error means the provider is rate-limiting us *or* is
+/// temporarily unavailable (HTTP 429/503, Alchemy `-32001`, etc.). Both warrant
+/// backing off rather than hammering the node. Matches specific tokens (e.g.
+/// `"http error 503"`, not bare `"503"`) so block numbers don't false-positive.
+pub fn is_rate_limited_or_unavailable(error_message: &str) -> bool {
+    let msg = error_message.to_lowercase();
+
+    // Classic rate-limit / throttle signals.
+    msg.contains("429")
+        || msg.contains("rate limit")
+        || msg.contains("rate-limit")
+        || msg.contains("rate exceeded")
+        || msg.contains("too many requests")
+        || msg.contains("quota")
+        || msg.contains("throttle")
+        // Temporary unavailability / overload — back off the same way.
+        || msg.contains("http error 503")
+        || msg.contains("status: 503")
+        || msg.contains("service unavailable")
+        || msg.contains("temporarily unavailable")
+        || msg.contains("unable to complete request")
+        || msg.contains("-32001")
 }
 
 /// Global adaptive concurrency controller for RPC batches. Used by the RPC

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1285,6 +1285,15 @@ async fn live_indexing_stream(
                         }
                     }
 
+                    // a shrunk to-block cap at or below last_seen can never be fetched
+                    // again, so keeping it would pin this loop in the no-new-blocks
+                    // branch forever; drop it as stale
+                    if log_response_to_large_to_block
+                        .is_some_and(|cap| cap <= last_seen_block_number)
+                    {
+                        log_response_to_large_to_block = None;
+                    }
+
                     let latest_block_number = log_response_to_large_to_block
                         .unwrap_or(U64::from(latest_block.header.number));
 
@@ -1390,6 +1399,9 @@ async fn live_indexing_stream(
                                 current_filter =
                                     current_filter.set_from_block(to_block + U64::from(1));
                                 last_seen_block_number = to_block;
+                                // the capped range completed without a fetch; clear it like
+                                // the successful get_logs path does
+                                log_response_to_large_to_block = None;
                             } else {
                                 current_filter = current_filter.set_to_block(to_block);
 

--- a/core/src/indexer/fetch_logs.rs
+++ b/core/src/indexer/fetch_logs.rs
@@ -1,4 +1,6 @@
-use crate::adaptive_concurrency::{AdaptiveConcurrency, ADAPTIVE_CONCURRENCY};
+use crate::adaptive_concurrency::{
+    is_rate_limited_or_unavailable, AdaptiveConcurrency, ADAPTIVE_CONCURRENCY,
+};
 use crate::blockclock::BlockClock;
 use crate::database::clickhouse::client::ClickhouseClient;
 use crate::event::callback_registry::{EventCallbackRegistry, TraceCallbackRegistry};
@@ -522,6 +524,29 @@ async fn fetch_historic_logs_stream<P: ChainProvider>(
             }
         }
         Err(err) => {
+            // Rate-limit / unavailability errors aren't block-range problems, so don't
+            // shrink: back off and retry the same range (bounded by the snapshot, so valid).
+            if classify_fetch_error(&err) == FetchErrorKind::RateLimit {
+                ADAPTIVE_CONCURRENCY.record_rate_limit();
+                let backoff_ms = ADAPTIVE_CONCURRENCY.current_backoff_ms();
+                warn!(
+                    "{} - {} - Provider rate-limited/unavailable fetching logs in range {} - {}; backing off {}ms before retrying: {:?}",
+                    info_log_name,
+                    IndexingEventProgressStatus::syncing_log(),
+                    from_block,
+                    to_block,
+                    backoff_ms,
+                    err
+                );
+                if backoff_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                }
+                return Some(ProcessHistoricLogsStreamResult {
+                    next: current_filter.set_from_block(from_block).set_to_block(to_block),
+                    max_block_range_limitation,
+                });
+            }
+
             // This is fundamental to the rindexer flow. We intentionally fetch a large block range
             // to get information on what the ideal block range should be.
             if let Some(retry_result) = retry_with_block_range(
@@ -559,6 +584,7 @@ async fn fetch_historic_logs_stream<P: ChainProvider>(
                 });
             }
 
+            ADAPTIVE_CONCURRENCY.record_error();
             let halved_to_block = halved_block_number(to_block, from_block);
 
             // Handle deserialization, networking, and other non-rpc related errors.
@@ -875,12 +901,13 @@ async fn parallel_worker(
     // goes out of scope here, keeping the cleanup path single-sourced.
 }
 
-/// Classification of a recoverable fetch error. Rate-limit errors warrant
-/// the aggressive -50% scale-down + backoff in `record_rate_limit`; other
-/// errors only warrant the gentler -10% in `record_error`. Raw HTTP 429s are
-/// intercepted at the RPC layer (`layer_extensions.rs`), but provider-specific
-/// throttle phrasings ("too many requests", "quota exceeded", etc.) can reach
-/// the worker as generic errors — this is the safety net for those.
+/// Classification of a recoverable fetch error. `RateLimit` triggers the
+/// aggressive -50% scale-down + backoff in `record_rate_limit`; `Other` only the
+/// gentler -10% in `record_error`. Raw HTTP 429s are intercepted at the RPC layer
+/// (`layer_extensions.rs`), but provider-specific throttle phrasings ("too many
+/// requests", "quota exceeded", etc.) and temporary-unavailability errors
+/// (`503`/`-32001`/"service unavailable") can reach the worker as generic errors
+/// — `is_rate_limited_or_unavailable` is the shared safety net for those.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FetchErrorKind {
     RateLimit,
@@ -888,14 +915,7 @@ enum FetchErrorKind {
 }
 
 fn classify_fetch_error(err: &ProviderError) -> FetchErrorKind {
-    let s = err.to_string().to_lowercase();
-    if s.contains("429")
-        || s.contains("rate limit")
-        || s.contains("rate-limit")
-        || s.contains("too many requests")
-        || s.contains("quota")
-        || s.contains("throttle")
-    {
+    if is_rate_limited_or_unavailable(&err.to_string()) {
         FetchErrorKind::RateLimit
     } else {
         FetchErrorKind::Other
@@ -1611,7 +1631,40 @@ async fn live_indexing_stream(
                                         }
                                     }
                                     Err(err) => {
-                                        if let Some(retry_result) = retry_with_block_range(
+                                        // Don't shrink the range for rate-limit/unavailability
+                                        // errors: at the head (from == to) halving to from+2 fetches
+                                        // ahead of head -> -32000 -> tight zero-delay loop. Back off
+                                        // instead.
+                                        if classify_fetch_error(&err) == FetchErrorKind::RateLimit {
+                                            ADAPTIVE_CONCURRENCY.record_rate_limit();
+                                            let backoff_ms =
+                                                ADAPTIVE_CONCURRENCY.current_backoff_ms();
+
+                                            warn!(
+                                                "{} - {} - Provider rate-limited/unavailable fetching logs in range {} - {}; backing off {}ms before retrying: {:?}",
+                                                info_log_name,
+                                                IndexingEventProgressStatus::live_log(),
+                                                from_block,
+                                                to_block,
+                                                backoff_ms,
+                                                err
+                                            );
+
+                                            if backoff_ms > 0 {
+                                                tokio::time::sleep(Duration::from_millis(
+                                                    backoff_ms,
+                                                ))
+                                                .await;
+                                            }
+
+                                            // Retry against the freshly-polled tip (from_block
+                                            // untouched, no blocks skipped). Must be None, not
+                                            // Some(to_block): with reorg_safe_distance > 0 a pinned
+                                            // value ratchets down each retry and, once below
+                                            // from_block, wedges live indexing (only reset on a
+                                            // successful send, which never happens here).
+                                            log_response_to_large_to_block = None;
+                                        } else if let Some(retry_result) = retry_with_block_range(
                                             info_log_name,
                                             &err,
                                             from_block,
@@ -1632,6 +1685,7 @@ async fn live_indexing_stream(
 
                                             log_response_to_large_to_block = Some(retry_result.to);
                                         } else {
+                                            ADAPTIVE_CONCURRENCY.record_error();
                                             let halved_to_block =
                                                 halved_block_number(to_block, from_block);
 
@@ -2356,6 +2410,14 @@ mod tests {
             "Too Many Requests",
             "monthly quota exceeded",
             "request throttled by upstream",
+            // Temporary-unavailability signals — treated the same as rate limits
+            // so we back off instead of hammering the node (see the Alchemy
+            // outage incident).
+            "HTTP error 503 with body: service unavailable",
+            "Service Unavailable",
+            "node temporarily unavailable",
+            r#"ErrorResp(ErrorPayload { code: -32001, message: "Unable to complete request at this time." })"#,
+            "Max retries exceeded HTTP error 503",
         ] {
             let err = ProviderError::CustomError(msg.to_string());
             assert_eq!(
@@ -2373,6 +2435,9 @@ mod tests {
             "response is too big",
             "error decoding response body",
             "connection reset",
+            // Block numbers containing "503" must not be mistaken for an HTTP
+            // 503 — we match "http error 503"/"status: 503", not a bare "503".
+            "invalid block range params: 50312000 - 50312500",
         ] {
             let err = ProviderError::CustomError(msg.to_string());
             assert_eq!(

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -153,7 +153,7 @@ use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-use crate::adaptive_concurrency::ADAPTIVE_CONCURRENCY;
+use crate::adaptive_concurrency::{is_rate_limited_or_unavailable, ADAPTIVE_CONCURRENCY};
 use crate::database::batch_operations::{
     BatchOperationAction, BatchOperationColumnBehavior, BatchOperationSqlType, BatchOperationType,
     DynamicColumnDefinition,
@@ -677,11 +677,7 @@ async fn prefetch_view_calls(
                         ADAPTIVE_CONCURRENCY.record_success();
                     }
                     Err(e) => {
-                        let err_str = e.to_string().to_lowercase();
-                        if err_str.contains("429")
-                            || err_str.contains("rate limit")
-                            || err_str.contains("too many")
-                        {
+                        if is_rate_limited_or_unavailable(&e.to_string()) {
                             ADAPTIVE_CONCURRENCY.record_rate_limit();
                         } else {
                             ADAPTIVE_CONCURRENCY.record_error();
@@ -889,11 +885,7 @@ async fn prefetch_static_calls_via_multicall(
                         ADAPTIVE_CONCURRENCY.record_success();
                     }
                     Err(e) => {
-                        let err_str = e.to_string().to_lowercase();
-                        if err_str.contains("429")
-                            || err_str.contains("rate limit")
-                            || err_str.contains("too many")
-                        {
+                        if is_rate_limited_or_unavailable(&e.to_string()) {
                             ADAPTIVE_CONCURRENCY.record_rate_limit();
                         } else {
                             ADAPTIVE_CONCURRENCY.record_error();
@@ -1327,11 +1319,7 @@ async fn prefetch_block_timestamps(
                         Some((network_clone, blocks))
                     }
                     Err(e) => {
-                        let err_str = e.to_string().to_lowercase();
-                        if err_str.contains("429")
-                            || err_str.contains("rate limit")
-                            || err_str.contains("too many")
-                        {
+                        if is_rate_limited_or_unavailable(&e.to_string()) {
                             ADAPTIVE_CONCURRENCY.record_rate_limit();
                         } else {
                             ADAPTIVE_CONCURRENCY.record_error();

--- a/core/src/layer_extensions.rs
+++ b/core/src/layer_extensions.rs
@@ -1,8 +1,13 @@
-use crate::{adaptive_concurrency::ADAPTIVE_CONCURRENCY, rindexer_error, rindexer_info};
+use crate::{
+    adaptive_concurrency::{is_rate_limited_or_unavailable, ADAPTIVE_CONCURRENCY},
+    metrics::rpc as rpc_metrics,
+    rindexer_error, rindexer_info,
+};
 use alloy::{
     rpc::json_rpc::{RequestPacket, ResponsePacket},
     transports::TransportError,
 };
+use alloy_chains::Chain;
 use std::{
     future::Future,
     pin::Pin,
@@ -15,12 +20,14 @@ use tower::{Layer, Service};
 #[derive(Clone)]
 pub struct RpcLoggingLayer {
     chain_id: u64,
+    /// Chain name used as the `network` metric label (matches `provider.rs`).
+    network: String,
     rpc_url: String,
 }
 
 impl RpcLoggingLayer {
     pub fn new(chain_id: u64, rpc_url: String) -> Self {
-        Self { chain_id, rpc_url }
+        Self { chain_id, network: Chain::from(chain_id).to_string(), rpc_url }
     }
 }
 
@@ -28,7 +35,12 @@ impl<S> Layer<S> for RpcLoggingLayer {
     type Service = RpcLoggingService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        RpcLoggingService { inner, chain_id: self.chain_id, rpc_url: self.rpc_url.clone() }
+        RpcLoggingService {
+            inner,
+            chain_id: self.chain_id,
+            network: self.network.clone(),
+            rpc_url: self.rpc_url.clone(),
+        }
     }
 }
 
@@ -36,6 +48,7 @@ impl<S> Layer<S> for RpcLoggingLayer {
 pub struct RpcLoggingService<S> {
     inner: S,
     chain_id: u64,
+    network: String,
     rpc_url: String,
 }
 
@@ -55,6 +68,7 @@ where
     fn call(&mut self, req: RequestPacket) -> Self::Future {
         let start_time = Instant::now();
         let chain_id = self.chain_id;
+        let network = self.network.clone();
         let rpc_url = self.rpc_url.clone();
 
         let method_name = match &req {
@@ -87,6 +101,7 @@ where
                     let duration = start_time.elapsed();
 
                     if duration.as_secs() >= 10 {
+                        rpc_metrics::record_slow_call(&network, &method_name);
                         rindexer_info!(
                             "SLOW RPC call - chain_id: {}, method: {}, duration: {:?}, url: {}",
                             chain_id,
@@ -106,12 +121,23 @@ where
 
                     if !is_known_error {
                         if error_str.contains("timeout") || error_str.contains("timed out") {
+                            rpc_metrics::record_rpc_error_kind(
+                                &network,
+                                &method_name,
+                                rpc_metrics::error_kind::TIMEOUT,
+                            );
                             rindexer_error!("RPC TIMEOUT (free public nodes do this a lot consider a using a paid node) - chain_id: {}, method: {}, duration: {:?}, url: {}, error: {:?}",
                                            chain_id, method_name, duration, rpc_url, err);
-                        } else if error_str.contains("429") || error_str.contains("rate limit") {
-                            // Notify adaptive concurrency to scale down
+                        } else if is_rate_limited_or_unavailable(&error_str) {
+                            // Scale down + grow backoff. The pre-request wait above then
+                            // throttles every later call (incl. the retry layer's own retries).
                             ADAPTIVE_CONCURRENCY.record_rate_limit();
-                            rindexer_info!("RPC RATE LIMITED (free public nodes do this a lot consider using a paid node) - chain_id: {}, method: {}, duration: {:?}, url: {}, backoff: {}ms, batch_size: {}, rate_limit_count: {}",
+                            rpc_metrics::record_rpc_error_kind(
+                                &network,
+                                &method_name,
+                                rpc_metrics::error_kind::RATE_LIMITED,
+                            );
+                            rindexer_info!("RPC RATE LIMITED / UNAVAILABLE (free public nodes do this a lot consider using a paid node) - chain_id: {}, method: {}, duration: {:?}, url: {}, backoff: {}ms, batch_size: {}, rate_limit_count: {}",
                                           chain_id, method_name, duration, rpc_url,
                                           ADAPTIVE_CONCURRENCY.current_backoff_ms(),
                                           ADAPTIVE_CONCURRENCY.current_batch_size(),
@@ -120,9 +146,19 @@ where
                             || error_str.contains("network")
                             || error_str.contains("sending request")
                         {
+                            rpc_metrics::record_rpc_error_kind(
+                                &network,
+                                &method_name,
+                                rpc_metrics::error_kind::CONNECTION,
+                            );
                             rindexer_error!("RPC CONNECTION ERROR (free public nodes do this a lot consider a using a paid node) - chain_id: {}, method: {}, duration: {:?}, url: {}, error: {:?}",
                                            chain_id, method_name, duration, rpc_url, err);
                         } else {
+                            rpc_metrics::record_rpc_error_kind(
+                                &network,
+                                &method_name,
+                                rpc_metrics::error_kind::OTHER,
+                            );
                             rindexer_error!("RPC ERROR (free public nodes do this a lot consider a using a paid node) - chain_id: {}, method: {}, duration: {:?}, url: {}, error: {:?}",
                                            chain_id, method_name, duration, rpc_url, err);
                         }

--- a/core/src/metrics/definitions.rs
+++ b/core/src/metrics/definitions.rs
@@ -109,6 +109,63 @@ pub static RPC_REQUESTS_IN_FLIGHT: Lazy<GaugeVec> = Lazy::new(|| {
     .expect("failed to register RPC_REQUESTS_IN_FLIGHT")
 });
 
+/// RPC errors by category (kind: rate_limited/timeout/connection/other), observed
+/// at the transport layer so it covers every method. `rate_limited` includes
+/// 429/503/`-32001`. Counts each attempt, so it rises with retry volume.
+/// Labels: network, method, kind.
+pub static RPC_ERRORS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "rindexer_rpc_errors_total",
+        "RPC errors by category, observed at the transport layer",
+        &["network", "method", "kind"]
+    )
+    .expect("failed to register RPC_ERRORS_TOTAL")
+});
+
+/// RPC calls that completed but took >= 10s. Labels: network, method.
+pub static RPC_SLOW_CALLS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "rindexer_rpc_slow_calls_total",
+        "RPC calls that completed but took >= 10 seconds",
+        &["network", "method"]
+    )
+    .expect("failed to register RPC_SLOW_CALLS_TOTAL")
+});
+
+/// Running total of adaptive-concurrency rate-limit/unavailability events (global).
+pub static RPC_RATE_LIMIT_EVENTS_TOTAL: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!(
+        "rindexer_rpc_rate_limit_events_total",
+        "Total adaptive-concurrency rate-limit/unavailability events"
+    )
+    .expect("failed to register RPC_RATE_LIMIT_EVENTS_TOTAL")
+});
+
+/// Adaptive backoff before each RPC request, ms (global). 0 healthy, ramps to
+/// 30000 during an incident — the clearest "provider degraded" signal.
+pub static RPC_ADAPTIVE_BACKOFF_MS: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!(
+        "rindexer_rpc_adaptive_backoff_ms",
+        "Current adaptive backoff applied before RPC requests, in milliseconds"
+    )
+    .expect("failed to register RPC_ADAPTIVE_BACKOFF_MS")
+});
+
+/// Current adaptive concurrency limit (global). Scales down on rate limits.
+pub static RPC_ADAPTIVE_CONCURRENCY: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!(
+        "rindexer_rpc_adaptive_concurrency",
+        "Current adaptive concurrency limit for RPC batches"
+    )
+    .expect("failed to register RPC_ADAPTIVE_CONCURRENCY")
+});
+
+/// Current adaptive RPC batch size (global). Scales down on rate limits.
+pub static RPC_ADAPTIVE_BATCH_SIZE: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!("rindexer_rpc_adaptive_batch_size", "Current adaptive RPC batch size")
+        .expect("failed to register RPC_ADAPTIVE_BATCH_SIZE")
+});
+
 // =============================================================================
 // Database Metrics
 // =============================================================================

--- a/core/src/metrics/rpc.rs
+++ b/core/src/metrics/rpc.rs
@@ -1,7 +1,42 @@
 //! RPC-specific metrics helpers.
 
-use super::definitions::{RPC_REQUESTS_IN_FLIGHT, RPC_REQUESTS_TOTAL, RPC_REQUEST_DURATION};
+use super::definitions::{
+    RPC_ADAPTIVE_BACKOFF_MS, RPC_ADAPTIVE_BATCH_SIZE, RPC_ADAPTIVE_CONCURRENCY, RPC_ERRORS_TOTAL,
+    RPC_RATE_LIMIT_EVENTS_TOTAL, RPC_REQUESTS_IN_FLIGHT, RPC_REQUESTS_TOTAL, RPC_REQUEST_DURATION,
+    RPC_SLOW_CALLS_TOTAL,
+};
 use super::timer::TimerGuard;
+
+/// Error categories for [`record_rpc_error_kind`]. `RATE_LIMITED` covers
+/// throttling and temporary-unavailability (HTTP 429/503, `-32001`).
+pub mod error_kind {
+    pub const RATE_LIMITED: &str = "rate_limited";
+    pub const TIMEOUT: &str = "timeout";
+    pub const CONNECTION: &str = "connection";
+    pub const OTHER: &str = "other";
+}
+
+/// Record an RPC error by category.
+pub fn record_rpc_error_kind(network: &str, method: &str, kind: &str) {
+    RPC_ERRORS_TOTAL.with_label_values(&[network, method, kind]).inc();
+}
+
+/// Record an RPC call that completed but exceeded the slow-call threshold (>= 10s).
+pub fn record_slow_call(network: &str, method: &str) {
+    RPC_SLOW_CALLS_TOTAL.with_label_values(&[network, method]).inc();
+}
+
+/// Publish the adaptive-concurrency controller state as gauges (global controller).
+pub fn set_adaptive_state(concurrency: usize, batch_size: usize, backoff_ms: u64) {
+    RPC_ADAPTIVE_CONCURRENCY.set(concurrency as f64);
+    RPC_ADAPTIVE_BATCH_SIZE.set(batch_size as f64);
+    RPC_ADAPTIVE_BACKOFF_MS.set(backoff_ms as f64);
+}
+
+/// Publish the running total of rate-limit/unavailability events.
+pub fn set_rate_limit_events(total: u64) {
+    RPC_RATE_LIMIT_EVENTS_TOTAL.set(total as f64);
+}
 
 /// Record a completed RPC request.
 pub fn record_rpc_request(network: &str, method: &str, success: bool, duration_secs: f64) {

--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -1122,6 +1122,13 @@ pub enum RetryClientError {
     RethNodeStartError(String, String),
 }
 
+/// Max retries the alloy `RetryBackoffLayer` makes per request. Its backoff is
+/// effectively flat, so a huge cap turns an outage into a self-logging retry
+/// loop (an Alchemy 503 outage once produced 10k+ log lines in 25 min). Kept
+/// bounded; the `adaptive_concurrency` controller owns the real exponential
+/// backoff for sustained outages.
+const MAX_RPC_RATE_LIMIT_RETRIES: u32 = 10;
+
 #[allow(clippy::too_many_arguments)]
 pub async fn create_client(
     rpc_url: &str,
@@ -1137,8 +1144,11 @@ pub async fn create_client(
 
     let (client, provider) = if rpc_url.ends_with(".ipc") {
         let ipc = IpcConnect::new(rpc_url.to_string());
-        let retry_layer =
-            RetryBackoffLayer::new(5000, 1000, compute_units_per_second.unwrap_or(660));
+        let retry_layer = RetryBackoffLayer::new(
+            MAX_RPC_RATE_LIMIT_RETRIES,
+            1000,
+            compute_units_per_second.unwrap_or(660),
+        );
         let logging_layer = RpcLoggingLayer::new(chain_id, rpc_url.to_string());
 
         let rpc_client =
@@ -1165,8 +1175,11 @@ pub async fn create_client(
 
         let logging_layer = RpcLoggingLayer::new(chain_id, rpc_url.to_string());
         let http = Http::with_client(client_with_auth, rpc_url);
-        let retry_layer =
-            RetryBackoffLayer::new(5000, 1000, compute_units_per_second.unwrap_or(660));
+        let retry_layer = RetryBackoffLayer::new(
+            MAX_RPC_RATE_LIMIT_RETRIES,
+            1000,
+            compute_units_per_second.unwrap_or(660),
+        );
         let rpc_client =
             RpcClient::builder().layer(retry_layer).layer(logging_layer).transport(http, false);
         let provider =


### PR DESCRIPTION
Merges joshstevens19/rindexer master (v0.41.0) into our fork. Includes the Kafka reorg-stream test stabilization (#442) that was failing CI, the Postgres bytea array fix (#439), and reorg reversal SQL quoting (#442). Full --all-features suite passes locally (795 passed).