### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "clickhouse_factory_indexing"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-tests"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -12714,7 +12714,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_factory_contract"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -12723,7 +12723,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_rust_playground"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -12934,7 +12934,7 @@ dependencies = [
 
 [[package]]
 name = "rust_clickhouse"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -16922,7 +16922,7 @@ checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "xtask"
-version = "0.41.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -159,7 +159,7 @@ pub async fn handle_add_contract_command(
 
         print_success_message(&format!(
             "Downloaded ABI for: {} in {}",
-            contract_name, &abi_path_relative
+            contract_name, abi_path_relative
         ));
 
         let success_message = format!(

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -200,9 +200,9 @@ pub fn handle_new_command(
     let reth_mode_text = if final_reth_config.is_some() { " with Reth support" } else { "" };
 
     let success_message = if project_type == ProjectType::Rust {
-        format!("rindexer rust project created{} with a rETH transfer events YAML template.\n cd ./{} \n- use rindexer codegen commands to regenerate the code\n- run `rindexer start all` to start rindexer\n- run `rindexer add contract` to add new contracts to your project", reth_mode_text, &project_name)
+        format!("rindexer rust project created{} with a rETH transfer events YAML template.\n cd ./{} \n- use rindexer codegen commands to regenerate the code\n- run `rindexer start all` to start rindexer\n- run `rindexer add contract` to add new contracts to your project", reth_mode_text, project_name)
     } else {
-        format!("rindexer no-code project created{} with a rETH transfer events YAML template.\n cd ./{} \n- run `rindexer start all` to start rindexer\n- run `rindexer add contract` to add new contracts to your project", reth_mode_text, &project_name)
+        format!("rindexer no-code project created{} with a rETH transfer events YAML template.\n cd ./{} \n- run `rindexer start all` to start rindexer\n- run `rindexer add contract` to add new contracts to your project", reth_mode_text, project_name)
     };
 
     // for later to avoid cloning

--- a/core/src/chat/template.rs
+++ b/core/src/chat/template.rs
@@ -50,11 +50,8 @@ impl Template {
         let keys: Vec<&str> = path.split('.').collect();
         let mut current = data;
         for key in keys {
-            if let Some(value) = current.get(key) {
-                current = value;
-            } else {
-                return None;
-            }
+            let value = current.get(key)?;
+            current = value;
         }
         Some(current.to_string().replace('"', ""))
     }

--- a/core/src/database/generate.rs
+++ b/core/src/database/generate.rs
@@ -510,7 +510,7 @@ pub fn generate_internal_factory_event_table_name(
         "{}_{}_{}",
         schema_name,
         camel_to_snake(&params.event_name),
-        &params.input_names.iter().map(|v| camel_to_snake(v)).collect::<Vec<String>>().join("-")
+        params.input_names.iter().map(|v| camel_to_snake(v)).collect::<Vec<String>>().join("-")
     );
 
     compact_table_name_if_needed(table_name)
@@ -525,7 +525,7 @@ pub fn generate_internal_factory_event_table_name_no_shorten(
         "{}_{}_{}",
         schema_name,
         camel_to_snake(&params.event_name),
-        &params.input_names.iter().map(|v| camel_to_snake(v)).collect::<Vec<String>>().join("_")
+        params.input_names.iter().map(|v| camel_to_snake(v)).collect::<Vec<String>>().join("_")
     )
 }
 

--- a/core/src/database/postgres/client.rs
+++ b/core/src/database/postgres/client.rs
@@ -356,8 +356,8 @@ impl PostgresClient {
         for row in prepared_data.iter() {
             if let Err(e) = writer.as_mut().write(row).await {
                 error!("Error writing binary data, aborting early: {}", e);
-                writer.finish().await?;
-                return Err(e)?;
+                writer.as_mut().finish().await?;
+                Err(e)?;
             };
         }
 

--- a/core/src/database/postgres/relationship.rs
+++ b/core/src/database/postgres/relationship.rs
@@ -406,12 +406,12 @@ pub async fn create_relationships(
                     if abi_parameter.abi_item.type_ != linked_abi_parameter.abi_item.type_ {
                         return Err(CreateRelationshipError::TypeMismatch(format!(
                             "Type mismatch between {}.{} ({}) and {}.{} ({})",
-                            &foreign_key.contract_name,
-                            &foreign_key.event_input_name,
-                            &abi_parameter.abi_item.type_,
-                            &linked_key.contract_name,
-                            &linked_key.event_input_name,
-                            &linked_abi_parameter.abi_item.type_
+                            foreign_key.contract_name,
+                            foreign_key.event_input_name,
+                            abi_parameter.abi_item.type_,
+                            linked_key.contract_name,
+                            linked_key.event_input_name,
+                            linked_abi_parameter.abi_item.type_
                         )));
                     }
 

--- a/core/src/event/filter/mod.rs
+++ b/core/src/event/filter/mod.rs
@@ -61,10 +61,8 @@ fn get_nested_value(data: &Value, path: &str) -> Option<Value> {
     let keys: Vec<&str> = path.split('.').collect();
     let mut current = data;
     for key in keys {
-        match current.get(key) {
-            Some(value) => current = value,
-            None => return None,
-        }
+        let value = current.get(key)?;
+        current = value;
     }
     Some(current.clone())
 }

--- a/core/src/generator/events_bindings.rs
+++ b/core/src/generator/events_bindings.rs
@@ -207,7 +207,7 @@ fn generate_csv_instance(
     // create_csv_file_for_event creates directories at code-gen time as a convenience
     event_info.create_csv_file_for_event(project_path, &contract.name, csv_path_str)?;
 
-    let csv_file_name = format!("{}-{}.csv", &contract.name, event_info.name).to_lowercase();
+    let csv_file_name = format!("{}-{}.csv", contract.name, event_info.name).to_lowercase();
     let relative_csv_file = csv_relative.join(&contract.name).join(&csv_file_name);
 
     let headers: Vec<String> =
@@ -609,7 +609,7 @@ impl<TExtensions> {event_type_name}<TExtensions> where TExtensions: 'static + Se
         abigen_file_name = abigen_contract_file_name(contract),
         abigen_name = abigen_contract_name(contract),
         structs = generate_structs(project_path, contract)?,
-        event_type_name = &event_type_name,
+        event_type_name = event_type_name,
         event_context_database = if storage.postgres_enabled() {
             "pub database: Arc<PostgresClient>,"
         } else if storage.clickhouse_enabled() {

--- a/core/src/generator/trace_bindings.rs
+++ b/core/src/generator/trace_bindings.rs
@@ -663,7 +663,7 @@ impl<TExtensions> {event_type_name}<TExtensions> where TExtensions: 'static + Se
         abigen_file_name = trace_abigen_contract_file_name(contract_name),
         abigen_name = trace_abigen_contract_name(contract_name),
         structs = trace_generate_structs(contract_name)?,
-        event_type_name = &event_type_name,
+        event_type_name = event_type_name,
         event_context_database =
             if storage.postgres_enabled() { "pub database: Arc<PostgresClient>," } else { "" },
         event_context_csv =

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -4388,11 +4388,8 @@ async fn execute_view_call_for_cron_internal(
                 // Fallback for string type: some tokens (MKR) return bytes32 for symbol()/name()
                 // Try to decode as bytes32 and convert to string
                 if result_bytes.len() == 32 {
-                    if let Some(s) = try_bytes32_as_string(&result_bytes) {
-                        DynSolValue::String(s)
-                    } else {
-                        return None;
-                    }
+                    let s = try_bytes32_as_string(&result_bytes)?;
+                    DynSolValue::String(s)
                 } else {
                     return None;
                 }

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -2284,7 +2284,7 @@ mod tests {
 
         // Both event buckets for block 101 are gone; block 100 survives in both.
         let map = clients.finalized_buffers.lock().await;
-        for (_key, buf) in map.iter() {
+        for buf in map.values() {
             assert!(buf.buffer.contains_key(&100), "block 100 must survive");
             assert!(!buf.buffer.contains_key(&101), "block 101 must be discarded");
         }


### PR DESCRIPTION
## Summary
- remove redundant formatting borrows flagged by newer Clippy
- simplify Option paths and map iteration using Clippy-preferred forms
- keep postgres binary-copy cleanup compiling after the needless-return fix
- normalize stale workspace package versions in Cargo.lock

## Testing
- cargo fmt --all -- --check
- CFLAGS="-I/opt/homebrew/opt/openssl@3/include" LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib" OPENSSL_DIR=/opt/homebrew/opt/openssl@3 cargo clippy --workspace --all-targets -- -D warnings

Changelog: not updated; internal lint-only cleanup with no user-visible behavior change.