### PR TITLE
feat: HyperSync support as alternative log data source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,19 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     needs: [fmt, clippy]
+    env:
+      # The workspace is built twice (default features, then all features
+      # including reth), linking every integration-test binary against the
+      # full dependency tree of debug artifacts. At full debuginfo that
+      # brushes the runner's free disk, and ld dies with SIGBUS when its
+      # memory-mapped output hits a full disk. Line tables keep file:line in
+      # test backtraces at a fraction of the size.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
+      # Reclaim ~15-20GB of preinstalled toolchains this job never uses —
+      # headroom for the same disk cliff the debuginfo setting backs away from.
+      - name: Free disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/CodeQL
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,6 +61,21 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev pkg-config
 
+      # The container-backed tests docker-run these images lazily, so the first
+      # test needing one pays for the pull inside its own timeout — and Docker
+      # Hub throttles anonymous pulls from the runners' shared IPs, which has
+      # eaten a test's entire 180s budget before it logged a single line. Pull
+      # up front, with retries, where slowness is visible and costs nothing.
+      - name: Pre-pull Docker images
+        run: |
+          for image in postgres:16 clickhouse/clickhouse-server:24.8; do
+            for i in 1 2 3; do
+              docker pull "$image" && break
+              echo "pull $image attempt $i failed; retrying..." >&2
+              sleep $((i * 10))
+            done
+          done
+
       - name: Build rindexer binary
         run: cargo build --release -p rindexer_cli --features jemalloc,reth
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "clickhouse_factory_indexing"
-version = "0.42.1"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-tests"
-version = "0.42.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -13252,7 +13252,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_factory_contract"
-version = "0.42.1"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -13261,7 +13261,7 @@ dependencies = [
 
 [[package]]
 name = "rindexer_rust_playground"
-version = "0.42.1"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -13472,7 +13472,7 @@ dependencies = [
 
 [[package]]
 name = "rust_clickhouse"
-version = "0.42.1"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "rindexer",
@@ -17515,7 +17515,7 @@ checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "xtask"
-version = "0.42.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -1597,6 +1598,223 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ddb80a4848e03b1655af496d5ac2563a779e5742fcb48f2ca2e089c9cd2197"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+ "lz4_flex 0.12.1",
+ "zstd 0.13.3",
+]
+
+[[package]]
+name = "arrow-json"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84a905f41fedfcd7679813c89a61dc369c0f932b27aa8dcc6aa051cc781a97d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.14.0",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+
+[[package]]
+name = "arrow-select"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +2035,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3017,6 +3244,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "capnp"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8c2ce958193219f203a6887788231a1aaa0b22ed012d67436ea3b87a9645c4"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3565,6 +3801,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3602,6 +3858,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "convert_case"
@@ -4161,6 +4426,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
+ "convert_case 0.6.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4173,7 +4439,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
@@ -4514,6 +4780,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
 
 [[package]]
 name = "ena"
@@ -5060,6 +5332,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom 7.1.3",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "evmap"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5093,10 +5376,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fastrange-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90a1392cd6ec5ebe42ccaf251f2b7ba6be654c377f05c913f3898bfb2172512"
 
 [[package]]
 name = "fastrlp"
@@ -5235,6 +5533,16 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustc_version 0.4.1",
+]
 
 [[package]]
 name = "flate2"
@@ -5830,6 +6138,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbag"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6389,6 +6709,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypersync-client"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8450d07de068c803ff19dbc4f0088688017e4cf37841792539b6147d14b3c9"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "anyhow",
+ "arrayvec",
+ "arrow",
+ "bincode 1.3.3",
+ "capnp",
+ "faster-hex",
+ "fastrange-rs",
+ "futures",
+ "hypersync-format",
+ "hypersync-net-types",
+ "hypersync-schema",
+ "log",
+ "nohash-hasher",
+ "num_cpus",
+ "parquet",
+ "rand 0.8.6",
+ "rayon",
+ "reqwest 0.12.28",
+ "reqwest-eventsource",
+ "ruint",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "uuid 1.23.1",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "hypersync-format"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5a308029c5ea9c5dcd4bc1c76bbbec76ff25044fab79cba29dbc46b177f34e"
+dependencies = [
+ "alloy-primitives",
+ "arrayvec",
+ "derive_more 1.0.0",
+ "faster-hex",
+ "nohash-hasher",
+ "sbbf-rs-safe",
+ "serde",
+ "thiserror 1.0.69",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "hypersync-net-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e98ff4e71862d242d9d884ce128e6e6b0a4faa380b57589556707af3fd7e5ee"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "capnp",
+ "hypersync-format",
+ "schemars 1.2.1",
+ "serde",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "hypersync-schema"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8662dc7bb7316776517c4cf4230f8dfd264db4df07d86eede061612356eadb"
+dependencies = [
+ "anyhow",
+ "arrow",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6721,6 +7124,12 @@ checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "interprocess"
@@ -7304,6 +7713,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7545,6 +8011,9 @@ name = "lz4_flex"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "mach2"
@@ -7951,6 +8420,12 @@ dependencies = [
  "memoffset 0.7.1",
  "pin-utils",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -8406,6 +8881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8512,6 +8996,42 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parquet"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e832c6aa20310fc6de7ea5a3f4e20d34fd83e3b43229d32b81ffe5c14d74692"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "lz4_flex 0.12.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -9817,6 +10337,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom 7.1.3",
+ "pin-project-lite",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -12646,6 +13182,7 @@ dependencies = [
  "foundry-compilers",
  "futures",
  "hex",
+ "hypersync-client",
  "lapin",
  "lazy_static",
  "lru 0.18.0",
@@ -13251,6 +13788,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sbbf-rs"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5525db49c7719816ac719ea8ffd0d0b4586db1a3f5d3e7751593230dacc642fd"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "fastrange-rs",
+]
+
+[[package]]
+name = "sbbf-rs-safe"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9902ffeb2cff3f8c072c60c7d526ac9560fc9a66fe1dfc3c240eba5e2151ba3c"
+dependencies = [
+ "sbbf-rs",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13303,8 +13859,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13523,6 +14092,12 @@ name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -14715,6 +15290,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
 name = "tikv-jemalloc-ctl"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15519,6 +16105,12 @@ dependencies = [
  "tokio",
  "turnkey_api_key_stamper",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typeid"

--- a/cli/src/commands/foundry.rs
+++ b/cli/src/commands/foundry.rs
@@ -1544,6 +1544,7 @@ fn default_network(chain_id: u64, name: String) -> Network {
         reth: None,
         multicall3_address: None,
         reorg_handling: None,
+        hypersync: None,
     }
 }
 

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -235,6 +235,7 @@ pub fn handle_new_command(
             reth: final_reth_config,
             multicall3_address: None,
             reorg_handling: None,
+            hypersync: None,
         }],
         contracts: vec![Contract {
             name: "RocketPoolETH".to_string(),

--- a/cli/src/commands/phantom.rs
+++ b/cli/src/commands/phantom.rs
@@ -550,6 +550,7 @@ async fn handle_phantom_deploy(
                         reth: None,
                         multicall3_address: None,
                         reorg_handling: None,
+                        hypersync: None,
                     });
                 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,6 +39,7 @@ clickhouse = { version = "0.15.0", features = ["rustls-tls"] }
 dotenvy = "0.15"
 futures = "0.3"
 hex = { workspace = true }
+hypersync-client = "1.4.0"
 lapin = "4"
 lazy_static = "1.5.0"
 lru = "0.18"

--- a/core/src/generator/build.rs
+++ b/core/src/generator/build.rs
@@ -650,6 +650,7 @@ mod tests {
             multicall3_address: None,
             reth: None,
             reorg_handling: None,
+            hypersync: None,
         };
 
         write_networks(dir.path(), &[network]).expect("write_networks failed");

--- a/core/src/generator/networks_bindings.rs
+++ b/core/src/generator/networks_bindings.rs
@@ -150,6 +150,7 @@ fn generate_network_hypersync_provider_code(network: &Network) -> Code {
                             url: {url},
                             api_token: {api_token},
                             max_block_range: {hypersync_max_block_range},
+                            stream_concurrency: {stream_concurrency},
                         }};
                         let rpc_provider = {fn_name}_cache().await;
                         create_hypersync_provider(&hypersync_config, "{network_name}", {chain_id}, {network_max_block_range}, rpc_provider)
@@ -169,6 +170,11 @@ fn generate_network_hypersync_provider_code(network: &Network) -> Code {
         api_token = env_or_literal_expr(&hypersync.api_token),
         hypersync_max_block_range = if let Some(max_block_range) = hypersync.max_block_range {
             format!("Some(U64::from({max_block_range}))")
+        } else {
+            "None".to_string()
+        },
+        stream_concurrency = if let Some(stream_concurrency) = hypersync.stream_concurrency {
+            format!("Some({stream_concurrency})")
         } else {
             "None".to_string()
         },
@@ -354,6 +360,7 @@ mod tests {
             url: None,
             api_token: Some("HYPERSYNC_API_TOKEN".to_string()),
             max_block_range: None,
+            stream_concurrency: None,
         });
         let networks = vec![hypersync_network, test_network("base", 8453)];
         let code = generate_networks_code(&networks).to_string();

--- a/core/src/generator/networks_bindings.rs
+++ b/core/src/generator/networks_bindings.rs
@@ -151,6 +151,9 @@ fn generate_network_hypersync_provider_code(network: &Network) -> Code {
                             api_token: {api_token},
                             max_block_range: {hypersync_max_block_range},
                             stream_concurrency: {stream_concurrency},
+                            batch_size: {batch_size},
+                            max_batch_size: {max_batch_size},
+                            response_bytes_target: {response_bytes_target},
                         }};
                         let rpc_provider = {fn_name}_cache().await;
                         create_hypersync_provider(&hypersync_config, "{network_name}", {chain_id}, {network_max_block_range}, rpc_provider)
@@ -175,6 +178,22 @@ fn generate_network_hypersync_provider_code(network: &Network) -> Code {
         },
         stream_concurrency = if let Some(stream_concurrency) = hypersync.stream_concurrency {
             format!("Some({stream_concurrency})")
+        } else {
+            "None".to_string()
+        },
+        batch_size = if let Some(batch_size) = hypersync.batch_size {
+            format!("Some({batch_size})")
+        } else {
+            "None".to_string()
+        },
+        max_batch_size = if let Some(max_batch_size) = hypersync.max_batch_size {
+            format!("Some({max_batch_size})")
+        } else {
+            "None".to_string()
+        },
+        response_bytes_target = if let Some(response_bytes_target) = hypersync.response_bytes_target
+        {
+            format!("Some({response_bytes_target})")
         } else {
             "None".to_string()
         },
@@ -357,10 +376,8 @@ mod tests {
 
         let mut hypersync_network = test_network("ethereum", 1);
         hypersync_network.hypersync = Some(HypersyncConfig {
-            url: None,
             api_token: Some("HYPERSYNC_API_TOKEN".to_string()),
-            max_block_range: None,
-            stream_concurrency: None,
+            ..Default::default()
         });
         let networks = vec![hypersync_network, test_network("base", 8453)];
         let code = generate_networks_code(&networks).to_string();

--- a/core/src/generator/networks_bindings.rs
+++ b/core/src/generator/networks_bindings.rs
@@ -119,17 +119,89 @@ fn generate_network_provider_code(network: &Network) -> Code {
     ))
 }
 
+/// Emits an optional-string expression which resolves an environment variable name at
+/// runtime, falling back to the literal value — the same pattern used for rpc urls so
+/// secrets are never embedded into generated code.
+fn env_or_literal_expr(value: &Option<String>) -> String {
+    match value {
+        Some(value) => {
+            format!(r#"Some(public_read_env_value("{value}").unwrap_or("{value}".to_string()))"#)
+        }
+        None => "None".to_string(),
+    }
+}
+
+/// Generates the hypersync-wrapped indexing provider for a network with `hypersync`
+/// enabled. The plain rpc provider functions remain untouched so handler code can still
+/// make direct rpc calls through them.
+fn generate_network_hypersync_provider_code(network: &Network) -> Code {
+    let Some(hypersync) = &network.hypersync else {
+        return Code::blank();
+    };
+
+    Code::new(format!(
+        r#"
+            static {provider_name}_HYPERSYNC: OnceCell<Arc<dyn ChainProvider>> = OnceCell::const_new();
+
+            pub async fn {fn_name}_hypersync() -> Arc<dyn ChainProvider> {{
+                {provider_name}_HYPERSYNC
+                    .get_or_init(|| async {{
+                        let hypersync_config = HypersyncConfig {{
+                            url: {url},
+                            api_token: {api_token},
+                            max_block_range: {hypersync_max_block_range},
+                        }};
+                        let rpc_provider = {fn_name}_cache().await;
+                        create_hypersync_provider(&hypersync_config, "{network_name}", {chain_id}, {network_max_block_range}, rpc_provider)
+                            .await
+                            .map(|provider| provider as Arc<dyn ChainProvider>)
+                            .expect("Error creating hypersync provider")
+                    }})
+                    .await
+                    .clone()
+            }}
+        "#,
+        provider_name = network_provider_name(network),
+        fn_name = network_provider_fn_name(network),
+        network_name = network.name,
+        chain_id = network.chain_id,
+        url = env_or_literal_expr(&hypersync.url),
+        api_token = env_or_literal_expr(&hypersync.api_token),
+        hypersync_max_block_range = if let Some(max_block_range) = hypersync.max_block_range {
+            format!("Some(U64::from({max_block_range}))")
+        } else {
+            "None".to_string()
+        },
+        network_max_block_range = if let Some(max_block_range) = network.max_block_range {
+            format!("Some(U64::from({max_block_range}))")
+        } else {
+            "None".to_string()
+        },
+    ))
+}
+
 fn generate_provider_cache_for_network_fn(networks: &[Network]) -> Code {
     let mut if_code = Code::blank();
     for network in networks {
-        let network_if = format!(
-            r#"
+        let network_if = if network.hypersync.is_some() {
+            format!(
+                r#"
+            if network == "{network_name}" {{
+                return get_{network_name}_provider_hypersync().await;
+            }}
+        "#,
+                network_name = network.name
+            )
+        } else {
+            format!(
+                r#"
             if network == "{network_name}" {{
                 return get_{network_name}_provider_cache().await;
             }}
         "#,
-            network_name = network.name
-        );
+                network_name = network.name
+            )
+        };
 
         if_code.push_str(&Code::new(network_if));
     }
@@ -193,8 +265,18 @@ pub fn generate_networks_code(networks: &[Network]) -> Code {
         )));
     }
 
+    if networks.iter().any(|network| network.hypersync.is_some()) {
+        output.push_str(&Code::new(
+            r#"
+    use rindexer::{hypersync::create_hypersync_provider, manifest::network::HypersyncConfig};
+        "#
+            .to_string(),
+        ));
+    }
+
     for network in networks {
         output.push_str(&generate_network_provider_code(network));
+        output.push_str(&generate_network_hypersync_provider_code(network));
     }
 
     output.push_str(&generate_provider_cache_for_network_fn(networks));
@@ -219,6 +301,7 @@ mod tests {
             multicall3_address: None,
             reth: None,
             reorg_handling: None,
+            hypersync: None,
         }
     }
 
@@ -253,6 +336,39 @@ mod tests {
         assert!(code.contains(r#"if network == "base""#));
         assert!(code.contains("get_ethereum_provider_cache()"));
         assert!(code.contains("get_base_provider_cache()"));
+    }
+
+    #[test]
+    fn generated_networks_without_hypersync_have_no_hypersync_code() {
+        let networks = vec![test_network("ethereum", 1)];
+        let code = generate_networks_code(&networks).to_string();
+        assert!(!code.contains("hypersync"), "expected no hypersync code, got:\n{code}");
+    }
+
+    #[test]
+    fn generated_hypersync_network_dispatches_to_hypersync_provider() {
+        use crate::manifest::network::HypersyncConfig;
+
+        let mut hypersync_network = test_network("ethereum", 1);
+        hypersync_network.hypersync = Some(HypersyncConfig {
+            url: None,
+            api_token: Some("HYPERSYNC_API_TOKEN".to_string()),
+            max_block_range: None,
+        });
+        let networks = vec![hypersync_network, test_network("base", 8453)];
+        let code = generate_networks_code(&networks).to_string();
+
+        // hypersync network indexes through the wrapped provider, the plain rpc provider
+        // functions remain for direct rpc access from handlers
+        assert!(code.contains("get_ethereum_provider_hypersync()"));
+        assert!(code.contains("pub async fn get_ethereum_provider_cache()"));
+        assert!(code.contains("create_hypersync_provider(&hypersync_config, \"ethereum\", 1,"));
+        assert!(code
+            .contains(r#"Some(public_read_env_value("HYPERSYNC_API_TOKEN").unwrap_or("HYPERSYNC_API_TOKEN".to_string()))"#));
+
+        // non-hypersync networks are unaffected
+        assert!(code.contains("get_base_provider_cache()"));
+        assert!(!code.contains("get_base_provider_hypersync"));
     }
 
     #[test]

--- a/core/src/generator/networks_bindings.rs
+++ b/core/src/generator/networks_bindings.rs
@@ -395,6 +395,64 @@ mod tests {
         assert!(!code.contains("get_base_provider_hypersync"));
     }
 
+    /// Compares code ignoring indentation and blank lines, so the expected block below
+    /// stays readable without mirroring the emitter's exact whitespace.
+    fn normalized(code: &str) -> String {
+        code.lines().map(str::trim).filter(|line| !line.is_empty()).collect::<Vec<_>>().join("\n")
+    }
+
+    /// Human-readable snapshot of the full provider fn the codegen emits for a
+    /// fully-populated `hypersync` config, so reviewers can see the exact output
+    /// without running codegen. Update deliberately when changing the emitter.
+    #[test]
+    fn generated_hypersync_provider_full_output() {
+        use alloy::primitives::U64;
+
+        use crate::manifest::network::HypersyncConfig;
+
+        let mut network = test_network("ethereum", 1);
+        network.max_block_range = Some(U64::from(5000));
+        network.hypersync = Some(HypersyncConfig {
+            url: Some("HYPERSYNC_URL".to_string()),
+            api_token: Some("HYPERSYNC_API_TOKEN".to_string()),
+            max_block_range: Some(U64::from(2000000)),
+            stream_concurrency: Some(20),
+            batch_size: Some(1000),
+            max_batch_size: Some(100000),
+            response_bytes_target: Some(400000),
+        });
+
+        let code = generate_network_hypersync_provider_code(&network).to_string();
+
+        let expected = r#"
+            static ETHEREUM_PROVIDER_HYPERSYNC: OnceCell<Arc<dyn ChainProvider>> = OnceCell::const_new();
+
+            pub async fn get_ethereum_provider_hypersync() -> Arc<dyn ChainProvider> {
+                ETHEREUM_PROVIDER_HYPERSYNC
+                    .get_or_init(|| async {
+                        let hypersync_config = HypersyncConfig {
+                            url: Some(public_read_env_value("HYPERSYNC_URL").unwrap_or("HYPERSYNC_URL".to_string())),
+                            api_token: Some(public_read_env_value("HYPERSYNC_API_TOKEN").unwrap_or("HYPERSYNC_API_TOKEN".to_string())),
+                            max_block_range: Some(U64::from(2000000)),
+                            stream_concurrency: Some(20),
+                            batch_size: Some(1000),
+                            max_batch_size: Some(100000),
+                            response_bytes_target: Some(400000),
+                        };
+                        let rpc_provider = get_ethereum_provider_cache().await;
+                        create_hypersync_provider(&hypersync_config, "ethereum", 1, Some(U64::from(5000)), rpc_provider)
+                            .await
+                            .map(|provider| provider as Arc<dyn ChainProvider>)
+                            .expect("Error creating hypersync provider")
+                    })
+                    .await
+                    .clone()
+            }
+        "#;
+
+        assert_eq!(normalized(&code), normalized(expected));
+    }
+
     #[test]
     fn generated_individual_provider_cache_returns_concrete_type() {
         let networks = vec![test_network("ethereum", 1)];

--- a/core/src/hot_reload/diff.rs
+++ b/core/src/hot_reload/diff.rs
@@ -178,7 +178,8 @@ fn diff_networks(
                     != format!("{:?}", new_net.block_poll_frequency)
                 || old_net.compute_units_per_second != new_net.compute_units_per_second
                 || format!("{:?}", old_net.max_block_range)
-                    != format!("{:?}", new_net.max_block_range);
+                    != format!("{:?}", new_net.max_block_range)
+                || format!("{:?}", old_net.hypersync) != format!("{:?}", new_net.hypersync);
 
             if other_changed {
                 changes.push(ManifestChange::NetworkConfigChanged(name.to_string()));
@@ -442,6 +443,29 @@ storage:
         if let ReloadAction::SelectiveRestart(plan) = &diff.action {
             assert!(plan.networks_to_reconnect.contains(&"ethereum".to_string()));
         }
+    }
+
+    #[test]
+    fn test_network_hypersync_changed() {
+        let old = manifest_from_yaml(BASE_MANIFEST);
+        let new_yaml = BASE_MANIFEST.replace(
+            "rpc: https://eth.rpc.example.com",
+            "rpc: https://eth.rpc.example.com\n    hypersync: true",
+        );
+        let new = manifest_from_yaml(&new_yaml);
+
+        // Enabling hypersync swaps the network's log data source, so it must not be
+        // treated as NoChange while `start --watch` is running.
+        let diff = compute_diff(&old, &new);
+        assert!(diff.changes.iter().any(
+            |c| matches!(c, ManifestChange::NetworkConfigChanged(name) if name == "ethereum")
+        ));
+
+        // And disabling it again must be detected symmetrically.
+        let diff = compute_diff(&new, &old);
+        assert!(diff.changes.iter().any(
+            |c| matches!(c, ManifestChange::NetworkConfigChanged(name) if name == "ethereum")
+        ));
     }
 
     #[test]

--- a/core/src/hypersync.rs
+++ b/core/src/hypersync.rs
@@ -362,7 +362,21 @@ impl ChainProvider for HypersyncProvider {
             start.elapsed().as_secs_f64(),
         );
 
-        result
+        match result {
+            Ok(logs) => Ok(logs),
+            Err(e) => {
+                // A HyperSync failure degrades to RPC rather than failing the fetch.
+                // This also covers a load-balanced instance lagging the height we
+                // checked: the client errors loudly on zero progress instead of
+                // stalling, and the range is served by RPC. If the range is too wide
+                // for the RPC node, its error feeds the fetch loop's usual adaptive
+                // range-halving.
+                warn!(
+                    "HyperSync get_logs failed for blocks [{from_block}..{to_block}], falling back to RPC: {e:#}",
+                );
+                self.rpc.get_logs(event_filter).await
+            }
+        }
     }
 
     // Blocks, receipts and traces could also be served from HyperSync, but faithfully
@@ -422,5 +436,69 @@ impl ChainProvider for HypersyncProvider {
 
     async fn eth_call_latest(&self, to: Address, data: Bytes) -> Result<String, ProviderError> {
         self.rpc.eth_call_latest(to, data).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::transports::mock::Asserter;
+
+    use super::*;
+
+    /// A provider whose HyperSync endpoint refuses connections (nothing listens on the
+    /// target port) and whose RPC side is a mock that serves pushed responses.
+    fn provider_with_unreachable_hypersync() -> (HypersyncProvider, Asserter) {
+        let (rpc, asserter) = JsonRpcCachedProvider::mock_with_asserter(1);
+        let client = Client::builder()
+            .url("http://127.0.0.1:9")
+            .api_token("00000000-0000-0000-0000-000000000000")
+            .max_num_retries(0)
+            .build()
+            .expect("building a client makes no network calls");
+
+        let provider = HypersyncProvider {
+            client,
+            rpc,
+            max_block_range: None,
+            stream_config: StreamConfig::default(),
+            height_cache: Mutex::new(None),
+        };
+
+        (provider, asserter)
+    }
+
+    #[tokio::test]
+    async fn get_logs_falls_back_to_rpc_when_height_check_fails() {
+        let (provider, asserter) = provider_with_unreachable_hypersync();
+        asserter.push_success(&Vec::<Log>::new());
+
+        let logs = provider.get_logs(&RindexerEventFilter::empty_for_test()).await.unwrap();
+
+        assert!(logs.is_empty(), "expected the mocked RPC response, got {logs:?}");
+    }
+
+    #[tokio::test]
+    async fn get_logs_falls_back_to_rpc_when_hypersync_query_errors() {
+        let (provider, asserter) = provider_with_unreachable_hypersync();
+        // Seed the height cache so `covers_block` passes and the HyperSync query path
+        // runs — and errors against the unreachable endpoint — instead of the request
+        // being routed to RPC by the height gate.
+        *provider.height_cache.lock().await = Some((Instant::now(), u64::MAX));
+        asserter.push_success(&Vec::<Log>::new());
+
+        let logs = provider.get_logs(&RindexerEventFilter::empty_for_test()).await.unwrap();
+
+        assert!(logs.is_empty(), "expected the mocked RPC response, got {logs:?}");
+    }
+
+    #[tokio::test]
+    async fn covers_block_trusts_cached_height_at_or_past_target() {
+        let (provider, _asserter) = provider_with_unreachable_hypersync();
+        *provider.height_cache.lock().await = Some((Instant::now(), 100));
+
+        // At or below the cached height: trusted without a network call.
+        assert!(provider.covers_block(100).await);
+        // Past the cached height within the TTL: not covered, no refresh attempted.
+        assert!(!provider.covers_block(101).await);
     }
 }

--- a/core/src/hypersync.rs
+++ b/core/src/hypersync.rs
@@ -54,7 +54,7 @@ pub struct HypersyncProvider {
     /// Fallback provider used for everything HyperSync cannot serve.
     rpc: Arc<JsonRpcCachedProvider>,
     max_block_range: Option<U64>,
-    stream_concurrency: Option<usize>,
+    stream_config: StreamConfig,
     height_cache: Mutex<Option<(Instant, u64)>>,
 }
 
@@ -124,11 +124,25 @@ pub async fn create_hypersync_provider(
         network_name, url, max_block_range
     );
 
+    // Sizing knobs for the client's internal request stream. The concurrency and
+    // response-target defaults matter most on dense ranges; `max_batch_size` matters on
+    // sparse ranges, where unbounded density projection otherwise collapses the stream
+    // to a single serial request covering the whole remaining range.
+    let stream_config = StreamConfig {
+        concurrency: config.stream_concurrency.unwrap_or(DEFAULT_STREAM_CONCURRENCY),
+        batch_size: config.batch_size.unwrap_or(StreamConfig::default_batch_size()),
+        max_batch_size: config.max_batch_size,
+        response_bytes_target: config
+            .response_bytes_target
+            .unwrap_or(StreamConfig::default_response_bytes_target()),
+        ..Default::default()
+    };
+
     Ok(Arc::new(HypersyncProvider {
         client,
         rpc,
         max_block_range,
-        stream_concurrency: config.stream_concurrency,
+        stream_config,
         height_cache: Mutex::new(None),
     }))
 }
@@ -217,16 +231,12 @@ impl HypersyncProvider {
             ])
             .select_block_fields([BlockField::Number, BlockField::Timestamp]);
 
-        let stream_config = StreamConfig {
-            concurrency: self.stream_concurrency.unwrap_or(DEFAULT_STREAM_CONCURRENCY),
-            ..Default::default()
-        };
-
         // `collect_arrow` paginates internally until the full requested range is covered,
         // so a successful return always means complete coverage of [from_block, to_block].
         // The arrow response is materialized straight into alloy types via the arrow row
         // readers, skipping the intermediate simple-types allocation pass.
-        let response = self.client.collect_arrow(query, stream_config).await.map_err(map_err)?;
+        let response =
+            self.client.collect_arrow(query, self.stream_config.clone()).await.map_err(map_err)?;
 
         let map_read =
             |e: ReadError| ProviderError::CustomError(format!("hypersync: arrow read: {e}"));

--- a/core/src/hypersync.rs
+++ b/core/src/hypersync.rs
@@ -1,0 +1,382 @@
+//! Envio HyperSync backed implementation of [`ChainProvider`].
+//!
+//! HyperSync serves log queries orders of magnitude faster than `eth_getLogs`, but it is
+//! not a JSON-RPC node: it cannot serve `eth_call`, receipts or traces, and its archive
+//! height can lag slightly behind the chain head. [`HypersyncProvider`] therefore wraps
+//! the network's [`JsonRpcCachedProvider`] and only routes historical log fetches to
+//! HyperSync — every other request, and any log request past the archive height,
+//! delegates to the RPC provider.
+
+use std::collections::HashMap;
+use std::fmt::{self, Debug};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use alloy::network::{AnyRpcBlock, AnyTransactionReceipt};
+use alloy::primitives::{Address, Bytes, FixedBytes, TxHash, B256, U256, U64};
+use alloy::rpc::types::trace::parity::LocalizedTransactionTrace;
+use alloy::rpc::types::Log;
+use alloy_chains::Chain;
+use async_trait::async_trait;
+use hypersync_client::net_types::block::BlockField;
+use hypersync_client::net_types::log::{LogField, LogFilter};
+use hypersync_client::net_types::Query;
+use hypersync_client::{Client, StreamConfig};
+use tokio::sync::broadcast::Sender;
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+
+use crate::event::RindexerEventFilter;
+use crate::manifest::network::HypersyncConfig;
+use crate::metrics::rpc as rpc_metrics;
+use crate::notifications::ChainStateNotification;
+use crate::provider::{ChainProvider, JsonRpcCachedProvider, ProviderError, RetryClientError};
+
+/// Default maximum block range per HyperSync logs request. HyperSync can serve far larger
+/// ranges than an RPC node, but each `get_logs` call buffers the whole range in memory so
+/// it needs a bound. Overridable via `hypersync.max_block_range` or `max_block_range`.
+const DEFAULT_HYPERSYNC_MAX_BLOCK_RANGE: u64 = 50_000;
+
+/// How long a cached archive height that is *behind* the requested block stays trusted
+/// before we re-query `/height`. Heights only move forward, so a cached height that is
+/// already past the requested block never needs refreshing.
+const HEIGHT_CACHE_TTL: Duration = Duration::from_secs(2);
+
+pub struct HypersyncProvider {
+    client: Client,
+    /// Fallback provider used for everything HyperSync cannot serve.
+    rpc: Arc<JsonRpcCachedProvider>,
+    max_block_range: Option<U64>,
+    height_cache: Mutex<Option<(Instant, u64)>>,
+}
+
+impl Debug for HypersyncProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HypersyncProvider")
+            .field("url", &self.client.url().as_str())
+            .field("chain", &self.rpc.chain)
+            .field("max_block_range", &self.max_block_range)
+            .finish()
+    }
+}
+
+/// Resolve the HyperSync API token from the manifest or well-known environment variables.
+fn resolve_api_token(config: &HypersyncConfig) -> Option<String> {
+    config
+        .api_token
+        .clone()
+        .filter(|token| !token.trim().is_empty())
+        .or_else(|| std::env::var("HYPERSYNC_API_TOKEN").ok())
+        .or_else(|| std::env::var("ENVIO_API_TOKEN").ok())
+        .filter(|token| !token.trim().is_empty())
+}
+
+pub async fn create_hypersync_provider(
+    config: &HypersyncConfig,
+    network_name: &str,
+    chain_id: u64,
+    network_max_block_range: Option<U64>,
+    rpc: Arc<JsonRpcCachedProvider>,
+) -> Result<Arc<HypersyncProvider>, RetryClientError> {
+    let url = config.url.clone().unwrap_or_else(|| format!("https://{chain_id}.hypersync.xyz"));
+
+    let api_token = resolve_api_token(config).ok_or_else(|| {
+        RetryClientError::HypersyncClientCantBeCreated(
+            network_name.to_string(),
+            "no API token found. Set `hypersync.api_token` in the manifest or the \
+             HYPERSYNC_API_TOKEN / ENVIO_API_TOKEN environment variable (create one at \
+             https://envio.dev/app/api-tokens)"
+                .to_string(),
+        )
+    })?;
+
+    let client = Client::builder().url(&url).api_token(api_token).build().map_err(|e| {
+        RetryClientError::HypersyncClientCantBeCreated(network_name.to_string(), format!("{e:#}"))
+    })?;
+
+    // Guards against pointing a network at the wrong HyperSync endpoint.
+    let hypersync_chain_id = client.get_chain_id().await.map_err(|e| {
+        RetryClientError::HypersyncClientCantBeCreated(
+            network_name.to_string(),
+            format!("could not reach {url}: {e:#}"),
+        )
+    })?;
+
+    if hypersync_chain_id != chain_id {
+        return Err(RetryClientError::InvalidClientChainId(url, chain_id, hypersync_chain_id));
+    }
+
+    let max_block_range = config
+        .max_block_range
+        .or(network_max_block_range)
+        .or(Some(U64::from(DEFAULT_HYPERSYNC_MAX_BLOCK_RANGE)));
+
+    debug!(
+        "HyperSync enabled for network {} via {} (max_block_range: {:?})",
+        network_name, url, max_block_range
+    );
+
+    Ok(Arc::new(HypersyncProvider { client, rpc, max_block_range, height_cache: Mutex::new(None) }))
+}
+
+impl HypersyncProvider {
+    /// Whether the HyperSync archive has fully ingested `to_block`.
+    ///
+    /// Uses a cached height: heights only move forward, so a cached height at or past
+    /// `to_block` is always trusted; otherwise it is refreshed at most every
+    /// [`HEIGHT_CACHE_TTL`]. Returns `false` on error so callers fall back to RPC.
+    async fn covers_block(&self, to_block: u64) -> bool {
+        let mut cache = self.height_cache.lock().await;
+
+        if let Some((fetched_at, height)) = *cache {
+            if height >= to_block {
+                return true;
+            }
+            if fetched_at.elapsed() < HEIGHT_CACHE_TTL {
+                return false;
+            }
+        }
+
+        match self.client.get_height().await {
+            Ok(height) => {
+                *cache = Some((Instant::now(), height));
+                height >= to_block
+            }
+            Err(e) => {
+                warn!("HyperSync height check failed, falling back to RPC: {e:#}");
+                false
+            }
+        }
+    }
+
+    async fn get_logs_via_hypersync(
+        &self,
+        event_filter: &RindexerEventFilter,
+        addresses: Option<Vec<Address>>,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<Log>, ProviderError> {
+        let map_err = |e: anyhow::Error| ProviderError::CustomError(format!("hypersync: {e:#}"));
+
+        let mut log_filter =
+            LogFilter::all().and_topic0([event_filter.event_signature().0]).map_err(map_err)?;
+
+        if let Some(addresses) = addresses {
+            log_filter =
+                log_filter.and_address(addresses.into_iter().map(|a| a.0 .0)).map_err(map_err)?;
+        }
+
+        for (idx, topic) in [event_filter.topic1(), event_filter.topic2(), event_filter.topic3()]
+            .into_iter()
+            .enumerate()
+        {
+            let values: Vec<[u8; 32]> = topic.iter().map(|t| t.0).collect();
+            if !values.is_empty() {
+                log_filter = match idx {
+                    0 => log_filter.and_topic1(values),
+                    1 => log_filter.and_topic2(values),
+                    _ => log_filter.and_topic3(values),
+                }
+                .map_err(map_err)?;
+            }
+        }
+
+        // Joined block numbers + timestamps let us stamp `block_timestamp` on each log,
+        // which lets the block clock skip its `eth_getBlockByNumber` batches entirely.
+        let query = Query::new()
+            .from_block(from_block)
+            .to_block_excl(to_block + 1)
+            .where_logs(log_filter)
+            .select_log_fields([
+                LogField::Removed,
+                LogField::LogIndex,
+                LogField::TransactionIndex,
+                LogField::TransactionHash,
+                LogField::BlockHash,
+                LogField::BlockNumber,
+                LogField::Address,
+                LogField::Data,
+                LogField::Topic0,
+                LogField::Topic1,
+                LogField::Topic2,
+                LogField::Topic3,
+            ])
+            .select_block_fields([BlockField::Number, BlockField::Timestamp]);
+
+        // `collect` paginates internally until the full requested range is covered, so a
+        // successful return always means complete coverage of [from_block, to_block].
+        let response =
+            self.client.collect(query, StreamConfig::default()).await.map_err(map_err)?;
+
+        let block_timestamps: HashMap<u64, u64> = response
+            .data
+            .blocks
+            .iter()
+            .flatten()
+            .filter_map(|block| {
+                let number = block.number?;
+                let timestamp = block.timestamp.as_ref()?;
+                Some((number, U256::from_be_slice(timestamp.as_ref()).to::<u64>()))
+            })
+            .collect();
+
+        let mut logs = response
+            .data
+            .logs
+            .into_iter()
+            .flatten()
+            .map(|log| {
+                let address = log
+                    .address
+                    .as_ref()
+                    .map(|a| Address::from(FixedBytes::<20>::from(a)))
+                    .unwrap_or_default();
+                let topics: Vec<B256> = log.topics.iter().flatten().map(B256::from).collect();
+                let data = log
+                    .data
+                    .as_ref()
+                    .map(|d| Bytes::copy_from_slice(d.as_ref()))
+                    .unwrap_or_default();
+                let block_number = log.block_number.map(u64::from);
+
+                Log {
+                    inner: alloy::primitives::Log {
+                        address,
+                        data: alloy::primitives::LogData::new_unchecked(topics, data),
+                    },
+                    block_hash: log.block_hash.as_ref().map(B256::from),
+                    block_number,
+                    block_timestamp: block_number
+                        .and_then(|number| block_timestamps.get(&number).copied()),
+                    transaction_hash: log.transaction_hash.as_ref().map(B256::from),
+                    transaction_index: log.transaction_index.map(u64::from),
+                    log_index: log.log_index.map(u64::from),
+                    removed: log.removed.unwrap_or(false),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // rindexer tracks sync progress off the last log's block number and handlers
+        // assume chain order, so guarantee (block_number, log_index) ordering.
+        logs.sort_by_key(|log| (log.block_number, log.log_index));
+
+        Ok(logs)
+    }
+}
+
+#[async_trait]
+impl ChainProvider for HypersyncProvider {
+    fn chain(&self) -> Chain {
+        self.rpc.chain
+    }
+
+    fn max_block_range(&self) -> Option<U64> {
+        self.max_block_range
+    }
+
+    fn chain_state_notification(&self) -> Option<Sender<ChainStateNotification>> {
+        self.rpc.get_chain_state_notification()
+    }
+
+    async fn get_latest_block(&self) -> Result<Option<Arc<AnyRpcBlock>>, ProviderError> {
+        self.rpc.get_latest_block().await
+    }
+
+    async fn get_block_number(&self) -> Result<U64, ProviderError> {
+        self.rpc.get_block_number().await
+    }
+
+    async fn get_logs(
+        &self,
+        event_filter: &RindexerEventFilter,
+    ) -> Result<Vec<Log>, ProviderError> {
+        let from_block = event_filter.from_block().to::<u64>();
+        let to_block = event_filter.to_block().to::<u64>();
+
+        if from_block > to_block {
+            return Ok(vec![]);
+        }
+
+        let addresses = event_filter.contract_addresses().await;
+
+        // Same semantics as the RPC provider: an explicitly empty address set (e.g. a
+        // factory with no known children yet) means there is nothing to fetch.
+        let addresses = match addresses {
+            Some(addresses) if addresses.is_empty() => return Ok(vec![]),
+            Some(addresses) => Some(addresses.into_iter().collect::<Vec<_>>()),
+            None => None,
+        };
+
+        // The archive lags the chain head by a few blocks, so near-tip requests (live
+        // indexing) go to the RPC node, which is authoritative for the head.
+        if !self.covers_block(to_block).await {
+            return self.rpc.get_logs(event_filter).await;
+        }
+
+        let start = Instant::now();
+        let result =
+            self.get_logs_via_hypersync(event_filter, addresses, from_block, to_block).await;
+
+        rpc_metrics::record_rpc_request(
+            &self.rpc.chain.to_string(),
+            "hypersync_getLogs",
+            result.is_ok(),
+            start.elapsed().as_secs_f64(),
+        );
+
+        result
+    }
+
+    async fn get_block_by_number_batch(
+        &self,
+        block_numbers: &[U64],
+        include_txs: bool,
+    ) -> Result<Vec<AnyRpcBlock>, ProviderError> {
+        self.rpc.get_block_by_number_batch(block_numbers, include_txs).await
+    }
+
+    async fn get_block_by_number_batch_with_size(
+        &self,
+        block_numbers: &[U64],
+        include_txs: bool,
+        rpc_batch_size: Option<usize>,
+    ) -> Result<Vec<AnyRpcBlock>, ProviderError> {
+        self.rpc
+            .get_block_by_number_batch_with_size(block_numbers, include_txs, rpc_batch_size)
+            .await
+    }
+
+    async fn get_tx_receipts_batch(
+        &self,
+        hashes: &[TxHash],
+    ) -> Result<Vec<AnyTransactionReceipt>, ProviderError> {
+        self.rpc.get_tx_receipts_batch(hashes).await
+    }
+
+    async fn trace_block(
+        &self,
+        block_number: U64,
+    ) -> Result<Vec<LocalizedTransactionTrace>, ProviderError> {
+        self.rpc.trace_block(block_number).await
+    }
+
+    async fn debug_trace_block_by_number(
+        &self,
+        block_number: U64,
+    ) -> Result<Vec<LocalizedTransactionTrace>, ProviderError> {
+        self.rpc.debug_trace_block_by_number(block_number).await
+    }
+
+    async fn eth_call(
+        &self,
+        to: Address,
+        data: Bytes,
+        block_number: u64,
+    ) -> Result<String, ProviderError> {
+        self.rpc.eth_call(to, data, block_number).await
+    }
+
+    async fn eth_call_latest(&self, to: Address, data: Bytes) -> Result<String, ProviderError> {
+        self.rpc.eth_call_latest(to, data).await
+    }
+}

--- a/core/src/hypersync.rs
+++ b/core/src/hypersync.rs
@@ -25,7 +25,7 @@ use hypersync_client::net_types::Query;
 use hypersync_client::{Client, StreamConfig};
 use tokio::sync::broadcast::Sender;
 use tokio::sync::Mutex;
-use tracing::{debug, warn};
+use tracing::{info, warn};
 
 use crate::event::RindexerEventFilter;
 use crate::manifest::network::HypersyncConfig;
@@ -33,9 +33,12 @@ use crate::metrics::rpc as rpc_metrics;
 use crate::notifications::ChainStateNotification;
 use crate::provider::{ChainProvider, JsonRpcCachedProvider, ProviderError, RetryClientError};
 
-/// Default maximum block range per HyperSync logs request. HyperSync can serve far larger
-/// ranges than an RPC node, but each `get_logs` call buffers the whole range in memory so
-/// it needs a bound. Overridable via `hypersync.max_block_range` or `max_block_range`.
+/// Default maximum block range per HyperSync logs request. This bounds the *outer*
+/// request rindexer issues, and is intentionally far wider than a single HyperSync
+/// response: within it the client's stream decomposes the range into many
+/// adaptively-sized concurrent requests (see [`StreamConfig`]). A bound is still needed
+/// because each `get_logs` call buffers the whole range's logs in memory. Overridable
+/// via `hypersync.max_block_range` or `max_block_range`.
 const DEFAULT_HYPERSYNC_MAX_BLOCK_RANGE: u64 = 50_000;
 
 /// How long a cached archive height that is *behind* the requested block stays trusted
@@ -119,7 +122,7 @@ pub async fn create_hypersync_provider(
         .or(network_max_block_range)
         .or(Some(U64::from(DEFAULT_HYPERSYNC_MAX_BLOCK_RANGE)));
 
-    debug!(
+    info!(
         "HyperSync enabled for network {} via {} (max_block_range: {:?})",
         network_name, url, max_block_range
     );
@@ -298,6 +301,7 @@ impl HypersyncProvider {
 #[async_trait]
 impl ChainProvider for HypersyncProvider {
     fn chain(&self) -> Chain {
+        // Cached on the wrapped provider at construction — not a network call.
         self.rpc.chain
     }
 
@@ -308,6 +312,9 @@ impl ChainProvider for HypersyncProvider {
     fn chain_state_notification(&self) -> Option<Sender<ChainStateNotification>> {
         self.rpc.get_chain_state_notification()
     }
+
+    // Head tracking stays RPC-authoritative: the HyperSync archive height lags the chain
+    // head by a few blocks, so deriving the tip from it would stall live indexing.
 
     async fn get_latest_block(&self) -> Result<Option<Arc<AnyRpcBlock>>, ProviderError> {
         self.rpc.get_latest_block().await
@@ -357,6 +364,12 @@ impl ChainProvider for HypersyncProvider {
 
         result
     }
+
+    // Blocks, receipts and traces could also be served from HyperSync, but faithfully
+    // reconstructing `AnyRpcBlock`/`AnyTransactionReceipt` across chains is a large
+    // conversion surface, and these paths are mostly cold here: logs already carry
+    // joined timestamps, so the block clock's batch fetches are skipped entirely.
+    // Serving them from HyperSync (e.g. for native transfers) is follow-up work.
 
     async fn get_block_by_number_batch(
         &self,

--- a/core/src/hypersync.rs
+++ b/core/src/hypersync.rs
@@ -43,6 +43,12 @@ const DEFAULT_HYPERSYNC_MAX_BLOCK_RANGE: u64 = 50_000;
 /// already past the requested block never needs refreshing.
 const HEIGHT_CACHE_TTL: Duration = Duration::from_secs(2);
 
+/// Default internal request concurrency per logs request, overridable via
+/// `hypersync.stream_concurrency`. Dense block ranges decompose into hundreds of
+/// adaptively-sized requests, and measured sweeps put 20 ~10-20% faster than the
+/// client default of 10, with diminishing returns beyond.
+const DEFAULT_STREAM_CONCURRENCY: usize = 20;
+
 pub struct HypersyncProvider {
     client: Client,
     /// Fallback provider used for everything HyperSync cannot serve.
@@ -211,10 +217,10 @@ impl HypersyncProvider {
             ])
             .select_block_fields([BlockField::Number, BlockField::Timestamp]);
 
-        let mut stream_config = StreamConfig::default();
-        if let Some(concurrency) = self.stream_concurrency {
-            stream_config.concurrency = concurrency;
-        }
+        let stream_config = StreamConfig {
+            concurrency: self.stream_concurrency.unwrap_or(DEFAULT_STREAM_CONCURRENCY),
+            ..Default::default()
+        };
 
         // `collect_arrow` paginates internally until the full requested range is covered,
         // so a successful return always means complete coverage of [from_block, to_block].

--- a/core/src/hypersync.rs
+++ b/core/src/hypersync.rs
@@ -18,6 +18,7 @@ use alloy::rpc::types::trace::parity::LocalizedTransactionTrace;
 use alloy::rpc::types::Log;
 use alloy_chains::Chain;
 use async_trait::async_trait;
+use hypersync_client::arrow_reader::{BlockReader, LogReader, ReadError};
 use hypersync_client::net_types::block::BlockField;
 use hypersync_client::net_types::log::{LogField, LogFilter};
 use hypersync_client::net_types::Query;
@@ -47,6 +48,7 @@ pub struct HypersyncProvider {
     /// Fallback provider used for everything HyperSync cannot serve.
     rpc: Arc<JsonRpcCachedProvider>,
     max_block_range: Option<U64>,
+    stream_concurrency: Option<usize>,
     height_cache: Mutex<Option<(Instant, u64)>>,
 }
 
@@ -116,7 +118,13 @@ pub async fn create_hypersync_provider(
         network_name, url, max_block_range
     );
 
-    Ok(Arc::new(HypersyncProvider { client, rpc, max_block_range, height_cache: Mutex::new(None) }))
+    Ok(Arc::new(HypersyncProvider {
+        client,
+        rpc,
+        max_block_range,
+        stream_concurrency: config.stream_concurrency,
+        height_cache: Mutex::new(None),
+    }))
 }
 
 impl HypersyncProvider {
@@ -203,58 +211,65 @@ impl HypersyncProvider {
             ])
             .select_block_fields([BlockField::Number, BlockField::Timestamp]);
 
-        // `collect` paginates internally until the full requested range is covered, so a
-        // successful return always means complete coverage of [from_block, to_block].
-        let response =
-            self.client.collect(query, StreamConfig::default()).await.map_err(map_err)?;
+        let mut stream_config = StreamConfig::default();
+        if let Some(concurrency) = self.stream_concurrency {
+            stream_config.concurrency = concurrency;
+        }
 
-        let block_timestamps: HashMap<u64, u64> = response
-            .data
-            .blocks
-            .iter()
-            .flatten()
-            .filter_map(|block| {
-                let number = block.number?;
-                let timestamp = block.timestamp.as_ref()?;
-                Some((number, U256::from_be_slice(timestamp.as_ref()).to::<u64>()))
-            })
-            .collect();
+        // `collect_arrow` paginates internally until the full requested range is covered,
+        // so a successful return always means complete coverage of [from_block, to_block].
+        // The arrow response is materialized straight into alloy types via the arrow row
+        // readers, skipping the intermediate simple-types allocation pass.
+        let response = self.client.collect_arrow(query, stream_config).await.map_err(map_err)?;
 
-        let mut logs = response
-            .data
-            .logs
-            .into_iter()
-            .flatten()
-            .map(|log| {
-                let address = log
-                    .address
-                    .as_ref()
-                    .map(|a| Address::from(FixedBytes::<20>::from(a)))
-                    .unwrap_or_default();
-                let topics: Vec<B256> = log.topics.iter().flatten().map(B256::from).collect();
-                let data = log
-                    .data
-                    .as_ref()
-                    .map(|d| Bytes::copy_from_slice(d.as_ref()))
-                    .unwrap_or_default();
-                let block_number = log.block_number.map(u64::from);
+        let map_read =
+            |e: ReadError| ProviderError::CustomError(format!("hypersync: arrow read: {e}"));
 
-                Log {
-                    inner: alloy::primitives::Log {
-                        address,
-                        data: alloy::primitives::LogData::new_unchecked(topics, data),
-                    },
-                    block_hash: log.block_hash.as_ref().map(B256::from),
-                    block_number,
-                    block_timestamp: block_number
-                        .and_then(|number| block_timestamps.get(&number).copied()),
-                    transaction_hash: log.transaction_hash.as_ref().map(B256::from),
-                    transaction_index: log.transaction_index.map(u64::from),
-                    log_index: log.log_index.map(u64::from),
-                    removed: log.removed.unwrap_or(false),
+        let mut block_timestamps: HashMap<u64, u64> = HashMap::new();
+        for batch in &response.data.blocks {
+            for block in BlockReader::iter(batch) {
+                let number = block.number().map_err(map_read)?;
+                let timestamp = block.timestamp().map_err(map_read)?;
+                block_timestamps
+                    .insert(number, U256::from_be_slice(timestamp.as_ref()).to::<u64>());
+            }
+        }
+
+        let total_logs = response.data.logs.iter().map(|batch| batch.num_rows()).sum();
+        let mut logs: Vec<Log> = Vec::with_capacity(total_logs);
+
+        for batch in &response.data.logs {
+            for log in LogReader::iter(batch) {
+                let address = log.address().map_err(map_read)?;
+                let data = log.data().map_err(map_read)?;
+                let block_number = u64::from(log.block_number().map_err(map_read)?);
+
+                let mut topics: Vec<B256> = Vec::with_capacity(4);
+                for topic in [log.topic0(), log.topic1(), log.topic2(), log.topic3()] {
+                    match topic.map_err(map_read)? {
+                        Some(topic) => topics.push(B256::from(&topic)),
+                        None => break,
+                    }
                 }
-            })
-            .collect::<Vec<_>>();
+
+                logs.push(Log {
+                    inner: alloy::primitives::Log {
+                        address: Address::from(FixedBytes::<20>::from(&address)),
+                        data: alloy::primitives::LogData::new_unchecked(
+                            topics,
+                            Bytes::copy_from_slice(data.as_ref()),
+                        ),
+                    },
+                    block_hash: Some(B256::from(&log.block_hash().map_err(map_read)?)),
+                    block_number: Some(block_number),
+                    block_timestamp: block_timestamps.get(&block_number).copied(),
+                    transaction_hash: Some(B256::from(&log.transaction_hash().map_err(map_read)?)),
+                    transaction_index: Some(u64::from(log.transaction_index().map_err(map_read)?)),
+                    log_index: Some(u64::from(log.log_index().map_err(map_read)?)),
+                    removed: log.removed().map_err(map_read)?.unwrap_or(false),
+                });
+            }
+        }
 
         // rindexer tracks sync progress off the last log's block number and handlers
         // assume chain order, so guarantee (block_number, log_index) ordering.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod notifications;
 pub use indexer::reorg::ReorgEvent;
 pub use notifications::ChainStateNotification;
 pub mod blockclock;
+pub mod hypersync;
 pub mod phantom;
 pub mod provider;
 mod start;

--- a/core/src/manifest/network.rs
+++ b/core/src/manifest/network.rs
@@ -52,8 +52,8 @@ pub struct HypersyncConfig {
     pub max_block_range: Option<U64>,
 
     /// Number of concurrent requests the HyperSync client makes internally while
-    /// serving a single logs request. Defaults to the client default (10).
-    /// Lower this to reduce burst load on the HyperSync endpoint.
+    /// serving a single logs request. Defaults to 20. Lower this to reduce burst
+    /// load on the HyperSync endpoint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_concurrency: Option<usize>,
 }

--- a/core/src/manifest/network.rs
+++ b/core/src/manifest/network.rs
@@ -23,6 +23,76 @@ use crate::reth::node::start_reth_node_with_exex;
 #[cfg(feature = "reth")]
 use reth::cli::Commands;
 
+/// Configuration for using an Envio HyperSync endpoint as the log data source for a network.
+///
+/// When present, historical `eth_getLogs` traffic is served by HyperSync while everything
+/// else (`eth_call`, receipts, traces, latest-block polling and near-tip log fetches)
+/// continues to use the network `rpc` endpoint, which therefore remains required.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HypersyncConfig {
+    /// Custom HyperSync endpoint URL. Defaults to `https://{chain_id}.hypersync.xyz`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// HyperSync API token (see https://envio.dev/app/api-tokens). Supports `${ENV_VAR}`
+    /// substitution. Falls back to the `HYPERSYNC_API_TOKEN` or `ENVIO_API_TOKEN`
+    /// environment variables when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_token: Option<String>,
+
+    /// Maximum block range per HyperSync logs request during historical sync.
+    /// Overrides the network-level `max_block_range` for HyperSync-served requests.
+    /// Defaults to 50,000 blocks when neither is set.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_option_u64_lenient",
+        serialize_with = "serialize_option_u64_as_string"
+    )]
+    pub max_block_range: Option<U64>,
+}
+
+/// Accepts both plain numbers and strings. The `hypersync` field deserializes through a
+/// `serde_yaml::Value`, which is strict about numbers, unlike the raw YAML parser used by
+/// `deserialize_option_u64_from_string`.
+fn deserialize_option_u64_lenient<'de, D>(deserializer: D) -> Result<Option<U64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    use std::str::FromStr;
+
+    let value = Option::<serde_yaml::Value>::deserialize(deserializer)?;
+    match value {
+        None | Some(serde_yaml::Value::Null) => Ok(None),
+        Some(serde_yaml::Value::Number(number)) => number
+            .as_u64()
+            .map(|n| Some(U64::from(n)))
+            .ok_or_else(|| D::Error::custom(format!("invalid u64: {number}"))),
+        Some(serde_yaml::Value::String(string)) => {
+            U64::from_str(&string).map(Some).map_err(D::Error::custom)
+        }
+        Some(other) => Err(D::Error::custom(format!("expected a number, got: {other:?}"))),
+    }
+}
+
+/// Supports `hypersync: true` shorthand alongside the full config map form.
+fn deserialize_option_hypersync<'de, D>(
+    deserializer: D,
+) -> Result<Option<HypersyncConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let value = serde_yaml::Value::deserialize(deserializer)?;
+    match value {
+        serde_yaml::Value::Bool(true) => Ok(Some(HypersyncConfig::default())),
+        serde_yaml::Value::Bool(false) | serde_yaml::Value::Null => Ok(None),
+        other => HypersyncConfig::deserialize(other).map(Some).map_err(D::Error::custom),
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ReorgHandlingConfig {
     #[serde(default = "default_reorg_enabled")]
@@ -69,6 +139,18 @@ pub struct Network {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disable_logs_bloom_checks: Option<bool>,
+
+    /// Use an Envio HyperSync endpoint for historical log fetching on this network.
+    /// The `rpc` endpoint is still required for everything HyperSync cannot serve.
+    ///
+    /// Accepts `hypersync: true` as shorthand for the default endpoint
+    /// (`https://{chain_id}.hypersync.xyz`) or a config map for customisation.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_option_hypersync"
+    )]
+    pub hypersync: Option<HypersyncConfig>,
 
     /// Custom Multicall3 contract address for this network.
     /// If not specified, uses the standard address 0xcA11bde05977b3631167028862bE2a173976CA11.
@@ -319,6 +401,74 @@ mod tests {
         let yaml = serde_yaml::to_string(&network).unwrap();
 
         assert!(!yaml.contains("reth:"));
+    }
+
+    #[test]
+    fn test_network_hypersync_absent_by_default() {
+        let network: Network = serde_yaml::from_str(
+            r#"
+            name: ethereum
+            chain_id: 1
+            rpc: https://mainnet.gateway.tenderly.co
+            "#,
+        )
+        .unwrap();
+
+        assert!(network.hypersync.is_none());
+
+        let yaml = serde_yaml::to_string(&network).unwrap();
+        assert!(!yaml.contains("hypersync"));
+    }
+
+    #[test]
+    fn test_network_hypersync_bool_shorthand() {
+        let network: Network = serde_yaml::from_str(
+            r#"
+            name: ethereum
+            chain_id: 1
+            rpc: https://mainnet.gateway.tenderly.co
+            hypersync: true
+            "#,
+        )
+        .unwrap();
+
+        let hypersync = network.hypersync.expect("hypersync should be enabled");
+        assert!(hypersync.url.is_none());
+        assert!(hypersync.api_token.is_none());
+        assert!(hypersync.max_block_range.is_none());
+
+        let network: Network = serde_yaml::from_str(
+            r#"
+            name: ethereum
+            chain_id: 1
+            rpc: https://mainnet.gateway.tenderly.co
+            hypersync: false
+            "#,
+        )
+        .unwrap();
+
+        assert!(network.hypersync.is_none());
+    }
+
+    #[test]
+    fn test_network_hypersync_full_config() {
+        let network: Network = serde_yaml::from_str(
+            r#"
+            name: ethereum
+            chain_id: 1
+            rpc: https://mainnet.gateway.tenderly.co
+            hypersync:
+                url: https://eth.hypersync.xyz
+                api_token: test-token
+                max_block_range: 100000
+            "#,
+        )
+        .unwrap();
+
+        let hypersync = network.hypersync.expect("hypersync should be enabled");
+        assert_eq!(hypersync.url.as_deref(), Some("https://eth.hypersync.xyz"));
+        assert_eq!(hypersync.api_token.as_deref(), Some("test-token"));
+        assert_eq!(hypersync.max_block_range, Some(U64::from(100000)));
     }
 
     #[test]

--- a/core/src/manifest/network.rs
+++ b/core/src/manifest/network.rs
@@ -56,6 +56,25 @@ pub struct HypersyncConfig {
     /// load on the HyperSync endpoint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_concurrency: Option<usize>,
+
+    /// Initial block span per internal HyperSync request, used before the client
+    /// has measured data density. Defaults to the client default (1,000 blocks).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_size: Option<u64>,
+
+    /// Cap on the block span of a single internal HyperSync request. Unset by
+    /// default. On wide sparse ranges *with data*, a cap (e.g. 100000) keeps
+    /// multiple requests in flight instead of one serialised scan (~25-30%
+    /// faster measured); on ranges dominated by empty blocks it hurts, because
+    /// unbounded requests skip empty space in a single round trip.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_batch_size: Option<u64>,
+
+    /// Response size (bytes) each internal HyperSync request is sized towards.
+    /// Defaults to the client default (400 KB). Lower values produce more,
+    /// smaller, more parallel requests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_bytes_target: Option<u64>,
 }
 
 /// Accepts both plain numbers and strings. The `hypersync` field deserializes through a

--- a/core/src/manifest/network.rs
+++ b/core/src/manifest/network.rs
@@ -50,6 +50,12 @@ pub struct HypersyncConfig {
         serialize_with = "serialize_option_u64_as_string"
     )]
     pub max_block_range: Option<U64>,
+
+    /// Number of concurrent requests the HyperSync client makes internally while
+    /// serving a single logs request. Defaults to the client default (10).
+    /// Lower this to reduce burst load on the HyperSync endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_concurrency: Option<usize>,
 }
 
 /// Accepts both plain numbers and strings. The `hypersync` field deserializes through a

--- a/core/src/manifest/yaml.rs
+++ b/core/src/manifest/yaml.rs
@@ -921,14 +921,29 @@ pub fn read_manifest(file_path: &PathBuf) -> Result<Manifest, ReadManifestError>
             serde_yaml::from_str(&contents_before_transform)?;
 
         for network in &mut manifest_after_transform.networks {
-            network.rpc = manifest_networks_only
-                .networks
-                .iter()
-                .find(|n| n.name == network.name)
-                .map_or_else(
-                    || replace_env_variable_to_raw_name(&network.rpc),
-                    |n| replace_env_variable_to_raw_name(&n.rpc),
-                );
+            let raw_network =
+                manifest_networks_only.networks.iter().find(|n| n.name == network.name);
+
+            network.rpc = raw_network.map_or_else(
+                || replace_env_variable_to_raw_name(&network.rpc),
+                |n| replace_env_variable_to_raw_name(&n.rpc),
+            );
+
+            // the hypersync url and api token follow the same rules as the rpc url so
+            // secrets are never embedded into generated code
+            if let Some(hypersync) = &mut network.hypersync {
+                let raw_hypersync = raw_network.and_then(|n| n.hypersync.as_ref());
+
+                hypersync.url = raw_hypersync
+                    .and_then(|h| h.url.as_ref())
+                    .or(hypersync.url.as_ref())
+                    .map(|url| replace_env_variable_to_raw_name(url));
+
+                hypersync.api_token = raw_hypersync
+                    .and_then(|h| h.api_token.as_ref())
+                    .or(hypersync.api_token.as_ref())
+                    .map(|token| replace_env_variable_to_raw_name(token));
+            }
         }
     }
 

--- a/core/src/provider.rs
+++ b/core/src/provider.rs
@@ -1123,6 +1123,9 @@ pub enum RetryClientError {
 
     #[error("Could not start reth node for network {0}: {1}")]
     RethNodeStartError(String, String),
+
+    #[error("Could not create hypersync client for network {0}: {1}")]
+    HypersyncClientCantBeCreated(String, String),
 }
 
 fn ensure_rpc_url_not_empty(
@@ -1253,7 +1256,7 @@ pub async fn get_chain_id(rpc_url: &str) -> Result<U256, RpcError<TransportError
 pub struct CreateNetworkProvider {
     pub network_name: String,
     pub disable_logs_bloom_checks: bool,
-    pub client: Arc<JsonRpcCachedProvider>,
+    pub client: Arc<dyn ChainProvider>,
 }
 
 impl CreateNetworkProvider {
@@ -1301,10 +1304,26 @@ impl CreateNetworkProvider {
             )
             .await?;
 
+            // When hypersync is configured, historical log fetching is served by
+            // HyperSync with the RPC provider handling everything else.
+            let client: Arc<dyn ChainProvider> = match &network.hypersync {
+                Some(hypersync_config) => {
+                    crate::hypersync::create_hypersync_provider(
+                        hypersync_config,
+                        &network.name,
+                        network.chain_id,
+                        network.max_block_range,
+                        provider,
+                    )
+                    .await?
+                }
+                None => provider,
+            };
+
             Ok::<_, RetryClientError>(CreateNetworkProvider {
                 network_name: network.name.clone(),
                 disable_logs_bloom_checks: network.disable_logs_bloom_checks.unwrap_or_default(),
-                client: provider,
+                client,
             })
         });
 
@@ -1313,7 +1332,7 @@ impl CreateNetworkProvider {
 
     /// Get the chain state notification for this network
     pub fn chain_state_notification(&self) -> Option<Sender<ChainStateNotification>> {
-        self.client.chain_state_notification.clone()
+        self.client.chain_state_notification()
     }
 }
 

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -8,6 +8,7 @@
 
 ### Features
 -------------------------------------------------
+- feat: `networks[].hypersync` — serve historical `get_logs` from [Envio HyperSync](https://docs.envio.dev/docs/HyperSync/overview) instead of RPC. Enable with `hypersync: true` (or a config map with `url`, `api_token`, `max_block_range` and stream tuning options); requires an API token via config or the `HYPERSYNC_API_TOKEN`/`ENVIO_API_TOKEN` env vars. Live indexing, calls, receipts and traces stay on the network RPC, and HyperSync errors degrade to the RPC automatically. Logs come stamped with block timestamps so timestamp indexing skips `eth_getBlockByNumber` batches.
 
 ## Releases
 -------------------------------------------------

--- a/documentation/docs/pages/docs/start-building/yaml-config/networks.mdx
+++ b/documentation/docs/pages/docs/start-building/yaml-config/networks.mdx
@@ -143,6 +143,9 @@ networks:
     api_token: ${HYPERSYNC_API_TOKEN} // [!code focus] # optional, defaults to HYPERSYNC_API_TOKEN / ENVIO_API_TOKEN env vars
     max_block_range: 50000 // [!code focus] # optional, block range per HyperSync request during backfill
     stream_concurrency: 20 // [!code focus] # optional, concurrent internal requests per logs request; lower to reduce burst load
+    batch_size: 1000 // [!code focus] # optional, initial block span per internal request before density is measured
+    max_batch_size: 100000 // [!code focus] # optional, cap per internal request; helps wide sparse ranges with data, hurts empty-heavy scans
+    response_bytes_target: 400000 // [!code focus] # optional, bytes each internal response is sized towards
 ```
 
 Timestamp indexing (`timestamps: true`) gets an extra speed boost with HyperSync enabled: block timestamps are joined into

--- a/documentation/docs/pages/docs/start-building/yaml-config/networks.mdx
+++ b/documentation/docs/pages/docs/start-building/yaml-config/networks.mdx
@@ -142,6 +142,7 @@ networks:
     url: https://eth.hypersync.xyz // [!code focus] # optional, defaults to https://{chain_id}.hypersync.xyz
     api_token: ${HYPERSYNC_API_TOKEN} // [!code focus] # optional, defaults to HYPERSYNC_API_TOKEN / ENVIO_API_TOKEN env vars
     max_block_range: 50000 // [!code focus] # optional, block range per HyperSync request during backfill
+    stream_concurrency: 10 // [!code focus] # optional, concurrent internal requests per logs request; lower to reduce burst load
 ```
 
 Timestamp indexing (`timestamps: true`) gets an extra speed boost with HyperSync enabled: block timestamps are joined into

--- a/documentation/docs/pages/docs/start-building/yaml-config/networks.mdx
+++ b/documentation/docs/pages/docs/start-building/yaml-config/networks.mdx
@@ -100,6 +100,53 @@ networks:
   max_block_range: 10000 // [!code focus]
 ```
 
+### hypersync
+
+Use an [Envio HyperSync](https://docs.envio.dev/docs/HyperSync/overview) endpoint as the data source for historical log fetching,
+which is significantly faster than `eth_getLogs` over RPC for backfills.
+
+The `rpc` field is still required: HyperSync only serves log data, so rindexer continues to use your RPC node for everything
+else — `eth_call`, transaction receipts, traces, latest block polling and live indexing at the chain head. If HyperSync is
+briefly behind the chain head or unavailable, rindexer automatically falls back to the RPC endpoint, so indexing always
+remains correct.
+
+A HyperSync API token is required — you can create one for free at [envio.dev/app/api-tokens](https://envio.dev/app/api-tokens).
+rindexer reads it from `hypersync.api_token` or the `HYPERSYNC_API_TOKEN` / `ENVIO_API_TOKEN` environment variables.
+
+The simplest way to enable it (uses `https://{chain_id}.hypersync.xyz` and the token from your environment):
+
+```yaml [rindexer.yaml]
+name: rETHIndexer
+description: My first rindexer project
+repository: https://github.com/joshstevens19/rindexer
+project_type: no-code
+networks:
+- name: ethereum
+  chain_id: 1
+  rpc: https://mainnet.gateway.tenderly.co
+  hypersync: true // [!code focus]
+```
+
+All the options:
+
+```yaml [rindexer.yaml]
+name: rETHIndexer
+description: My first rindexer project
+repository: https://github.com/joshstevens19/rindexer
+project_type: no-code
+networks:
+- name: ethereum
+  chain_id: 1
+  rpc: https://mainnet.gateway.tenderly.co
+  hypersync: // [!code focus]
+    url: https://eth.hypersync.xyz // [!code focus] # optional, defaults to https://{chain_id}.hypersync.xyz
+    api_token: ${HYPERSYNC_API_TOKEN} // [!code focus] # optional, defaults to HYPERSYNC_API_TOKEN / ENVIO_API_TOKEN env vars
+    max_block_range: 50000 // [!code focus] # optional, block range per HyperSync request during backfill
+```
+
+Timestamp indexing (`timestamps: true`) gets an extra speed boost with HyperSync enabled: block timestamps are joined into
+the log queries directly, so rindexer does not need to fetch blocks over RPC to stamp events.
+
 ### block_poll_frequency
 
 :::info

--- a/documentation/docs/pages/docs/start-building/yaml-config/networks.mdx
+++ b/documentation/docs/pages/docs/start-building/yaml-config/networks.mdx
@@ -142,7 +142,7 @@ networks:
     url: https://eth.hypersync.xyz // [!code focus] # optional, defaults to https://{chain_id}.hypersync.xyz
     api_token: ${HYPERSYNC_API_TOKEN} // [!code focus] # optional, defaults to HYPERSYNC_API_TOKEN / ENVIO_API_TOKEN env vars
     max_block_range: 50000 // [!code focus] # optional, block range per HyperSync request during backfill
-    stream_concurrency: 10 // [!code focus] # optional, concurrent internal requests per logs request; lower to reduce burst load
+    stream_concurrency: 20 // [!code focus] # optional, concurrent internal requests per logs request; lower to reduce burst load
 ```
 
 Timestamp indexing (`timestamps: true`) gets an extra speed boost with HyperSync enabled: block timestamps are joined into


### PR DESCRIPTION
Revives #103 — HyperSync as an alternative log data source — rebuilt against the modern `ChainProvider` trait.

## Why the #103 blocker is gone

#103 was closed because `hypersync-net-types 0.9` required the `capnp` compiler installed on every build machine. Since 0.12 the crate ships pre-generated code and has **no `build.rs`** — verified: a clean `cargo build` needs nothing beyond cargo.

## Design

`HypersyncProvider` implements the existing `ChainProvider` trait and wraps the network's `JsonRpcCachedProvider`:

- **Historical `get_logs` → HyperSync.** Everything else — `eth_call`, receipts, traces, latest-block polling — stays on the `rpc` endpoint, which remains required.
- **Near-tip requests → RPC.** A cached, monotonic archive-height check routes any request past HyperSync's ingested height to the RPC node, so live indexing, bloom checks, and reorg handling are completely unchanged. If HyperSync is down or lagging, everything silently degrades to today's RPC behavior (its errors also flow into the existing retry-with-halving path).
- **Block timestamps are joined** into each HyperSync query and stamped on logs, so with `timestamps: true` the block clock skips its `eth_getBlockByNumber` batching entirely (stage 1 of its waterfall).
- Everything above `get_logs` — factory contracts, parallel backfill, reorg windows, dependency ordering — is untouched.

Rust-project codegen emits a hypersync-wrapped indexing provider too, and `read_manifest` un-substitutes `hypersync.url` / `hypersync.api_token` for rust projects the same way it does for `rpc`, so tokens never land in generated code. The user-facing `get_X_provider()` helpers remain plain RPC.

## Config

```yaml
networks:
- name: ethereum
  chain_id: 1
  rpc: https://mainnet.gateway.tenderly.co
  hypersync: true   # shorthand: https://{chain_id}.hypersync.xyz + token from env
```

Full form: `hypersync: {url, api_token, max_block_range}`. Token falls back to `HYPERSYNC_API_TOKEN` / `ENVIO_API_TOKEN` (free tier at envio.dev/app/api-tokens). `max_block_range` is the window per HyperSync request — default 50,000 keeps dense contracts memory-safe; sparse contracts benefit from much wider windows (the full-history run below used 2M).

## Benchmarks

Same release binary, same manifest per row — only the data source differs. Timings are rindexer's own `Historical indexing completed` measure. Every completed run was verified: identical row counts everywhere, and byte-identical sorted output (MD5) spot-proven on the 8.3M-row run.

**One day of Polymarket pUSD, Polygon, 8,338,067 Transfer events over 43,200 blocks (CSV):**

| Source | Time | vs HyperSync |
|---|---|---|
| HyperSync | **3m 22s** | — |
| dRPC (paid) | 16m 48s | 5.0× |
| Tenderly (free) | 21m 1s | 6.2× |
| Dwellir (paid) | stopped at 10 min / 3.97% — projected ≈ 4.2h | ≈ 75× |

**The rest of the matrix (Ethereum mainnet):**

| Workload | Events | HyperSync | Tenderly (free) | dRPC (paid) |
|---|---|---|---|---|
| USDC, 100k blocks (dense) | 938,890 | **10s** | 3m 49s · 23× | 17m 56s · 107× |
| USDC + `timestamps: true` → Postgres, 10k recent blocks | 925,103 | **17s** | 1m 8s · 4.0× | 11m 49s · 42× |
| rETH, first 2M blocks (sparse, 2M window) | 23,207 | **12s** | 22s · 1.8× | 2m 32s · 12.7× |
| rETH, entire history block 0 → 25.6M | 901,220 | **2m 53s** | stopped at 10 min with 6% of events | — |
| One week of pUSD (HyperSync showcase) | 57,385,711 | **16m 13s** | — | — |

Notes on reading it honestly:

- **Provider variance is the real story.** Tenderly free (the provider the rindexer docs recommend as fastest) is consistently the best RPC because it predicts block ranges; dRPC's paid plan trails it 3–6× due to response/range caps. HyperSync costs the same regardless of provider quirks.
- **The sparse row is the fair caveat**: with a good range-predicting provider, a bounded sparse window closes to 1.8×. The big wins are dense data and whole-chain scans.
- **Timestamps demo**: that window carried logs in 9,994 distinct blocks past the shipped block-clock data — the RPC runs resolved all 9,994 timestamps over the wire, HyperSync resolved zero, and all 925,103 `(tx_hash, log_index, block_timestamp)` rows are identical across all three Postgres databases.
- **Request efficiency** (measured through a counting proxy): backfill averages ~10,300 events per HyperSync request (~370 KB responses).

## Testing

- 734 lib tests pass (new coverage: manifest parsing incl. the `hypersync: true` shorthand, codegen output, secrets un-substitution); clippy and fmt clean.
- Live indexing validated at the chain tip on USDC: block-by-block real time, zero errors, near-tip requests observed falling back to RPC as designed. The provider records `hypersync_getLogs` vs `eth_getLogs` separately in `rindexer_rpc_requests_total`, so the backend split is visible on `/metrics`.

## Follow-ups (not in this PR)

- Density-adaptive HyperSync window sizing (auto-widen on sparse contracts instead of the `max_block_range` knob).
- Use HyperSync's bloom `address_filter` for factory contracts with very large child sets.
- An e2e test behind an env-gated API token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
