### PR TITLE
fix(reorg): support iterated custom table rollbacks

### DIFF
--- a/core/src/database/postgres/client.rs
+++ b/core/src/database/postgres/client.rs
@@ -683,6 +683,30 @@ impl PostgresClient {
         let mut conn = self.pool.get().await?;
         let transaction = conn.transaction().await?;
 
+        let result = Self::reorg_rollback_in_transaction(
+            &transaction,
+            event_table_names,
+            network,
+            fork_point,
+            detection_point,
+            corrected_blocks,
+            checkpoint_tables,
+        )
+        .await?;
+
+        transaction.commit().await?;
+        Ok(result)
+    }
+
+    pub(crate) async fn reorg_rollback_in_transaction(
+        transaction: &PgTransaction<'_>,
+        event_table_names: &[&str],
+        network: &str,
+        fork_point: u64,
+        detection_point: u64,
+        corrected_blocks: &[(u64, &str, &str)],
+        checkpoint_tables: &[&str],
+    ) -> Result<(u64, Vec<String>), PostgresError> {
         let fork_point_i64 = i64::try_from(fork_point)
             .map_err(|_| PostgresError::Custom("fork_point exceeds i64 range".to_string()))?;
         let detection_point_i64 = i64::try_from(detection_point)
@@ -738,8 +762,6 @@ impl PostgresClient {
             );
             transaction.execute(&query, &[&rewind_block, &network]).await?;
         }
-
-        transaction.commit().await?;
 
         Ok((total_deleted, all_affected_tx_hashes))
     }

--- a/core/src/event/filter/ast.rs
+++ b/core/src/event/filter/ast.rs
@@ -214,14 +214,14 @@ impl<'a> Expression<'a> {
         })
     }
 
-    pub(crate) fn to_sql_event_condition<F>(&self, event_column: F) -> Option<String>
+    pub(crate) fn to_sql_event_condition<F>(&self, event_variable: F) -> Option<String>
     where
-        F: Fn(&str) -> String,
+        F: Fn(&ConditionLeft<'_>) -> String,
     {
         if self.has_table_references() {
             return None;
         }
-        Some(self.to_sql_condition_with(&|variable| event_column(variable.base_name())))
+        Some(self.to_sql_condition_with(&event_variable))
     }
 
     fn to_sql_condition_with<F>(&self, variable_to_sql: &F) -> String

--- a/core/src/event/filter/ast.rs
+++ b/core/src/event/filter/ast.rs
@@ -205,10 +205,33 @@ impl<'a> Expression<'a> {
     /// - Event variables ($var) become EXCLUDED.var (the new values being inserted)
     /// - Table variables (@var) become {table_name}.var (current DB values)
     pub fn to_sql_condition(&self, table_name: &str) -> String {
+        self.to_sql_condition_with(&|variable| {
+            let column = variable.base_name();
+            match variable.source() {
+                VariableSource::Event => format!("EXCLUDED.\"{}\"", column),
+                VariableSource::Table => format!("{}.\"{}\"", table_name, column),
+            }
+        })
+    }
+
+    pub(crate) fn to_sql_event_condition<F>(&self, event_column: F) -> Option<String>
+    where
+        F: Fn(&str) -> String,
+    {
+        if self.has_table_references() {
+            return None;
+        }
+        Some(self.to_sql_condition_with(&|variable| event_column(variable.base_name())))
+    }
+
+    fn to_sql_condition_with<F>(&self, variable_to_sql: &F) -> String
+    where
+        F: Fn(&ConditionLeft<'_>) -> String,
+    {
         match self {
             Expression::Condition(cond) => {
-                let left_sql = cond.left.to_sql(table_name);
-                let right_sql = cond.right.to_sql(table_name);
+                let left_sql = cond.left.to_sql_with(variable_to_sql);
+                let right_sql = cond.right.to_sql_with(variable_to_sql);
                 let op_sql = match cond.operator {
                     ComparisonOperator::Eq => "=",
                     ComparisonOperator::Ne => "<>",
@@ -220,8 +243,8 @@ impl<'a> Expression<'a> {
                 format!("{} {} {}", left_sql, op_sql, right_sql)
             }
             Expression::Logical { left, operator, right } => {
-                let left_sql = left.to_sql_condition(table_name);
-                let right_sql = right.to_sql_condition(table_name);
+                let left_sql = left.to_sql_condition_with(variable_to_sql);
+                let right_sql = right.to_sql_condition_with(variable_to_sql);
                 let op_sql = match operator {
                     LogicalOperator::And => "AND",
                     LogicalOperator::Or => "OR",
@@ -229,7 +252,7 @@ impl<'a> Expression<'a> {
                 format!("({} {} {})", left_sql, op_sql, right_sql)
             }
             Expression::Not(inner) => {
-                format!("NOT ({})", inner.to_sql_condition(table_name))
+                format!("NOT ({})", inner.to_sql_condition_with(variable_to_sql))
             }
         }
     }
@@ -250,22 +273,29 @@ impl<'a> ArithmeticExpr<'a> {
     /// Converts this arithmetic expression to SQL.
     /// Column names are double-quoted to handle reserved keywords safely.
     pub fn to_sql(&self, table_name: &str) -> String {
-        match self {
-            ArithmeticExpr::Variable(cond_left) => {
-                let col_name = cond_left.base_name();
-                match cond_left.source() {
-                    VariableSource::Event => format!("EXCLUDED.\"{}\"", col_name),
-                    VariableSource::Table => format!("{}.\"{}\"", table_name, col_name),
-                }
+        self.to_sql_with(&|variable| {
+            let column = variable.base_name();
+            match variable.source() {
+                VariableSource::Event => format!("EXCLUDED.\"{}\"", column),
+                VariableSource::Table => format!("{}.\"{}\"", table_name, column),
             }
+        })
+    }
+
+    fn to_sql_with<F>(&self, variable_to_sql: &F) -> String
+    where
+        F: Fn(&ConditionLeft<'_>) -> String,
+    {
+        match self {
+            ArithmeticExpr::Variable(variable) => variable_to_sql(variable),
             ArithmeticExpr::Literal(lit) => match lit {
                 LiteralValue::Bool(b) => if *b { "TRUE" } else { "FALSE" }.to_string(),
                 LiteralValue::Str(s) => format!("'{}'", s.replace('\'', "''")),
                 LiteralValue::Number(n) => n.to_string(),
             },
             ArithmeticExpr::Binary { left, operator, right } => {
-                let left_sql = left.to_sql(table_name);
-                let right_sql = right.to_sql(table_name);
+                let left_sql = left.to_sql_with(variable_to_sql);
+                let right_sql = right.to_sql_with(variable_to_sql);
                 match operator {
                     ArithmeticOperator::Power => {
                         // Use PostgreSQL POWER() function for exponentiation

--- a/core/src/event/mod.rs
+++ b/core/src/event/mod.rs
@@ -17,7 +17,7 @@ pub use factory_event_filter_sync::{
 mod filter;
 
 pub use filter::ast::VariableSource;
-pub(crate) use filter::ast::{Accessor, ConditionLeft};
+pub(crate) use filter::ast::{Accessor, ArithmeticExpr, ConditionLeft};
 pub use filter::evaluation::{evaluate_arithmetic, evaluate_with_table_data, ComputedValue};
 pub use filter::parsing::{parse as parse_filter_expression, parse_arithmetic_expression};
 pub use filter::{filter_by_expression, filter_event_data_by_conditions};

--- a/core/src/event/mod.rs
+++ b/core/src/event/mod.rs
@@ -17,6 +17,7 @@ pub use factory_event_filter_sync::{
 mod filter;
 
 pub use filter::ast::VariableSource;
+pub(crate) use filter::ast::{Accessor, ConditionLeft};
 pub use filter::evaluation::{evaluate_arithmetic, evaluate_with_table_data, ComputedValue};
 pub use filter::parsing::{parse as parse_filter_expression, parse_arithmetic_expression};
 pub use filter::{filter_by_expression, filter_event_data_by_conditions};

--- a/core/src/indexer/native_transfer.rs
+++ b/core/src/indexer/native_transfer.rs
@@ -15,7 +15,9 @@ use tracing::{debug, error, info, warn};
 use tokio_util::sync::CancellationToken;
 
 use crate::database::clickhouse::client::ClickhouseClient;
-use crate::indexer::reorg::{detect_and_handle_reorg, ReorgContext, ReorgCoordinator};
+use crate::indexer::reorg::{
+    detect_and_handle_reorg, event_writer_barrier, ReorgContext, ReorgCoordinator,
+};
 use crate::is_running;
 use crate::provider::RECOMMENDED_RPC_CHUNK_SIZE;
 use crate::PostgresClient;
@@ -517,6 +519,9 @@ pub async fn native_transfer_block_consumer(
         })
         .collect::<Vec<_>>();
 
+    let writer_barrier = event_writer_barrier(network_name);
+    let _writer_guard = writer_barrier.read().await;
+
     // Important that we call this for every event even if there are no logs.
     // This is because we need to sync the last seen block number still.
     indexing_event_processing();
@@ -622,6 +627,9 @@ pub async fn native_transfer_block_consumer_debug(
     if native_transfers.is_empty() {
         return Ok(());
     }
+
+    let writer_barrier = event_writer_barrier(network_name);
+    let _writer_guard = writer_barrier.read().await;
 
     indexing_event_processing();
     if !native_transfers.is_empty() {

--- a/core/src/indexer/process.rs
+++ b/core/src/indexer/process.rs
@@ -15,7 +15,8 @@ use tracing::{debug, error, info, warn};
 use crate::helpers::is_relevant_block;
 use crate::indexer::heartbeat::{HeartbeatAction, HeartbeatTracker};
 use crate::indexer::reorg::{
-    detect_and_handle_reorg, reorg_safe_distance_for_chain, ReorgContext, ReorgCoordinator,
+    detect_and_handle_reorg, event_writer_barrier, reorg_safe_distance_for_chain, ReorgContext,
+    ReorgCoordinator,
 };
 use crate::metrics::indexing as metrics;
 use crate::provider::ChainProvider;
@@ -492,6 +493,7 @@ async fn live_indexing_for_contract_event_dependencies(
     let generation_cancel = events.first().map(|(config, _)| config.cancel_token().clone());
 
     let reorg_coordinator = reorg_coordinator;
+    let writer_barrier = event_writer_barrier(&network);
 
     let (pg_client, ch_client, event_registry) = events
         .first()
@@ -710,6 +712,7 @@ async fn live_indexing_for_contract_event_dependencies(
 
                 // No event task spawns on this skip path, but the checkpoint write below
                 // must still be tracked so graceful shutdown waits for it.
+                let _writer_guard = writer_barrier.read().await;
                 indexing_event_processing();
                 update_progress_and_last_synced_task(
                     Arc::clone(config),
@@ -901,6 +904,9 @@ async fn handle_logs_result(
                 return Ok(tokio::spawn(async {}));
             }
 
+            let writer_guard =
+                event_writer_barrier(&config.network_contract().network).read_owned().await;
+
             debug!("{} - Processing {} logs", config.info_log_name(), result.logs.len());
 
             let fn_data = result
@@ -918,12 +924,14 @@ async fn handle_logs_result(
 
             if let Ok(permit) = callback_permits.clone().acquire_owned().await {
                 let task = tokio::spawn(async move {
+                    let _writer_guard = writer_guard;
                     trigger_event(config, fn_data, result.to_block).await;
                     drop(permit)
                 });
 
                 Ok(task)
             } else {
+                let _writer_guard = writer_guard;
                 trigger_event(config, fn_data, result.to_block).await;
                 Ok(tokio::spawn(async {}))
             }

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use alloy::primitives::{B256, U64};
 use anyhow::Context;
+use tokio::sync::OwnedRwLockWriteGuard;
 use tracing::{info, warn};
 
 use crate::event::callback_registry::ReorgNotification;
@@ -13,7 +14,7 @@ use crate::streams::StreamsClients;
 use super::persistence::ReorgBlockHashPersistence;
 use super::task::{DerivedTableInfo, DerivedTableRollbackPlan, EventTableInfo, ReorgTask};
 use super::window::{BlockChainWindow, ParentValidation};
-use super::ReorgContext;
+use super::{event_writer_barrier, ReorgContext};
 
 /// Number of blocks between periodic flushes of the in-memory block window to the database.
 /// Balances write frequency against data-loss risk on crash.
@@ -27,6 +28,8 @@ pub struct ReorgCoordinator {
     event_tables: Vec<EventTableInfo>,
     derived_tables: Vec<DerivedTableInfo>,
     rollback_plan: DerivedTableRollbackPlan,
+    /// Retained after a failed rollback so no event writer can race ahead of its retry.
+    rollback_writer_guard: Option<OwnedRwLockWriteGuard<()>>,
     /// All `StreamsClients` configured for this network across every indexing
     /// pipeline (contract events + native transfers). When a reorg is handled
     /// we fan the retraction notification across all of them so consumers
@@ -57,6 +60,7 @@ impl ReorgCoordinator {
             event_tables,
             derived_tables,
             rollback_plan: DerivedTableRollbackPlan::default(),
+            rollback_writer_guard: None,
             streams_clients,
             blocks_since_flush: 0,
         })
@@ -413,7 +417,11 @@ impl ReorgCoordinator {
         reorg_task: ReorgTask,
         ctx: &ReorgContext<'_>,
     ) -> anyhow::Result<()> {
-        let result = reorg_task
+        let writer_guard = match self.rollback_writer_guard.take() {
+            Some(guard) => guard,
+            None => event_writer_barrier(&self.network).write_owned().await,
+        };
+        let result = match reorg_task
             .execute_with_rollback_plan(
                 &mut self.window,
                 ctx.postgres,
@@ -421,7 +429,15 @@ impl ReorgCoordinator {
                 self.provider.as_ref(),
                 &self.rollback_plan,
             )
-            .await?;
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                self.rollback_writer_guard = Some(writer_guard);
+                return Err(error);
+            }
+        };
+        drop(writer_guard);
 
         let affected_tx_hashes: Vec<B256> =
             result.affected_tx_hashes.iter().filter_map(|h| B256::from_str(h).ok()).collect();
@@ -577,6 +593,7 @@ mod tests {
             event_tables: vec![],
             derived_tables: vec![],
             rollback_plan: DerivedTableRollbackPlan::default(),
+            rollback_writer_guard: None,
             streams_clients: vec![],
             blocks_since_flush: 0,
         }
@@ -605,6 +622,37 @@ mod tests {
 
         assert!(result.is_none(), "Expected None for NoPreviousBlock");
         assert!(coordinator.window.get(100).is_some(), "Block should be inserted");
+    }
+
+    #[tokio::test]
+    async fn reorg_drains_writers_and_blocks_them_until_retry_succeeds() {
+        const NETWORK: &str = "writer-barrier-test";
+        let mut coordinator = make_coordinator(BlockChainWindow::try_new(100).unwrap());
+        coordinator.network = NETWORK.to_string();
+        let ctx =
+            ReorgContext { postgres: None, clickhouse: None, registry: None, trace_registry: None };
+        let task = |network: &str| ReorgTask {
+            network: network.to_string(),
+            fork_point: 10,
+            detection_point: 11,
+            event_tables: vec![],
+            derived_tables: vec![],
+            canonical_blocks: vec![],
+        };
+
+        let barrier = event_writer_barrier(NETWORK);
+        let writer = barrier.clone().read_owned().await;
+        let mut rollback = Box::pin(coordinator.handle_reorg(task("invalid network"), &ctx));
+        assert!(futures::poll!(&mut rollback).is_pending(), "rollback must drain active writers");
+        drop(writer);
+        rollback.await.expect_err("invalid network must fail rollback");
+        assert!(barrier.try_read().is_err(), "failed rollback must keep event writers blocked");
+
+        coordinator
+            .handle_reorg(task(NETWORK), &ctx)
+            .await
+            .expect("retry should release the writer barrier");
+        assert!(barrier.try_read().is_ok(), "successful retry must release event writers");
     }
 
     #[tokio::test]
@@ -831,6 +879,7 @@ mod tests {
                 },
             ],
             rollback_plan: DerivedTableRollbackPlan::default(),
+            rollback_writer_guard: None,
             streams_clients: vec![],
             blocks_since_flush: 0,
         };
@@ -861,6 +910,7 @@ mod tests {
                 journal_columns: vec![],
             }],
             rollback_plan: DerivedTableRollbackPlan::default(),
+            rollback_writer_guard: None,
             streams_clients: vec![],
             blocks_since_flush: 0,
         };
@@ -890,6 +940,7 @@ mod tests {
             .unwrap()],
             derived_tables: vec![],
             rollback_plan: DerivedTableRollbackPlan::default(),
+            rollback_writer_guard: None,
             streams_clients: vec![],
             blocks_since_flush: 0,
         };
@@ -923,6 +974,7 @@ mod tests {
             event_tables: vec![],
             derived_tables: vec![],
             rollback_plan: DerivedTableRollbackPlan::default(),
+            rollback_writer_guard: None,
             streams_clients,
             blocks_since_flush: 0,
         }

--- a/core/src/indexer/reorg/coordinator.rs
+++ b/core/src/indexer/reorg/coordinator.rs
@@ -11,7 +11,7 @@ use crate::provider::ChainProvider;
 use crate::streams::StreamsClients;
 
 use super::persistence::ReorgBlockHashPersistence;
-use super::task::{DerivedTableInfo, EventTableInfo, ReorgTask};
+use super::task::{DerivedTableInfo, DerivedTableRollbackPlan, EventTableInfo, ReorgTask};
 use super::window::{BlockChainWindow, ParentValidation};
 use super::ReorgContext;
 
@@ -26,6 +26,7 @@ pub struct ReorgCoordinator {
     provider: Option<Arc<dyn ChainProvider>>,
     event_tables: Vec<EventTableInfo>,
     derived_tables: Vec<DerivedTableInfo>,
+    rollback_plan: DerivedTableRollbackPlan,
     /// All `StreamsClients` configured for this network across every indexing
     /// pipeline (contract events + native transfers). When a reorg is handled
     /// we fan the retraction notification across all of them so consumers
@@ -55,9 +56,15 @@ impl ReorgCoordinator {
             provider: Some(provider),
             event_tables,
             derived_tables,
+            rollback_plan: DerivedTableRollbackPlan::default(),
             streams_clients,
             blocks_since_flush: 0,
         })
+    }
+
+    pub(crate) fn with_rollback_plan(mut self, rollback_plan: DerivedTableRollbackPlan) -> Self {
+        self.rollback_plan = rollback_plan;
+        self
     }
 
     /// Called on each new block during live indexing.
@@ -407,7 +414,13 @@ impl ReorgCoordinator {
         ctx: &ReorgContext<'_>,
     ) -> anyhow::Result<()> {
         let result = reorg_task
-            .execute(&mut self.window, ctx.postgres, ctx.clickhouse, self.provider.as_ref())
+            .execute_with_rollback_plan(
+                &mut self.window,
+                ctx.postgres,
+                ctx.clickhouse,
+                self.provider.as_ref(),
+                &self.rollback_plan,
+            )
             .await?;
 
         let affected_tx_hashes: Vec<B256> =
@@ -563,6 +576,7 @@ mod tests {
             provider: None,
             event_tables: vec![],
             derived_tables: vec![],
+            rollback_plan: DerivedTableRollbackPlan::default(),
             streams_clients: vec![],
             blocks_since_flush: 0,
         }
@@ -816,6 +830,7 @@ mod tests {
                     journal_columns: vec![],
                 },
             ],
+            rollback_plan: DerivedTableRollbackPlan::default(),
             streams_clients: vec![],
             blocks_since_flush: 0,
         };
@@ -845,6 +860,7 @@ mod tests {
                 rollback_ops: vec![],
                 journal_columns: vec![],
             }],
+            rollback_plan: DerivedTableRollbackPlan::default(),
             streams_clients: vec![],
             blocks_since_flush: 0,
         };
@@ -873,6 +889,7 @@ mod tests {
             )
             .unwrap()],
             derived_tables: vec![],
+            rollback_plan: DerivedTableRollbackPlan::default(),
             streams_clients: vec![],
             blocks_since_flush: 0,
         };
@@ -905,6 +922,7 @@ mod tests {
             provider: None,
             event_tables: vec![],
             derived_tables: vec![],
+            rollback_plan: DerivedTableRollbackPlan::default(),
             streams_clients,
             blocks_since_flush: 0,
         }

--- a/core/src/indexer/reorg/mod.rs
+++ b/core/src/indexer/reorg/mod.rs
@@ -20,7 +20,7 @@ pub use coordinator::ReorgCoordinator;
 pub use persistence::ReorgBlockHashPersistence;
 pub use task::{
     AffectedTable, DerivedColumnJournal, DerivedColumnRollback, DerivedTableInfo,
-    DerivedTableRollbackOp, EventTableInfo,
+    DerivedTableRollbackOp, DerivedTableRollbackPlan, EventTableInfo,
 };
 pub use window::BlockChainWindow;
 

--- a/core/src/indexer/reorg/mod.rs
+++ b/core/src/indexer/reorg/mod.rs
@@ -6,7 +6,11 @@ pub mod window;
 use alloy::primitives::{B256, U64};
 use anyhow::Context;
 use serde::Serialize;
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock, Mutex as StdMutex},
+};
+use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
 use crate::database::clickhouse::client::ClickhouseClient;
@@ -23,6 +27,16 @@ pub use task::{
     DerivedTableRollbackOp, DerivedTableRollbackPlan, EventTableInfo,
 };
 pub use window::BlockChainWindow;
+
+static EVENT_WRITER_BARRIERS: LazyLock<StdMutex<HashMap<String, Arc<RwLock<()>>>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+/// One read/write barrier per network: event callbacks hold a read guard while
+/// writing, and reorg recovery holds the write guard from snapshot through rollback.
+pub(crate) fn event_writer_barrier(network: &str) -> Arc<RwLock<()>> {
+    let mut barriers = EVENT_WRITER_BARRIERS.lock().unwrap_or_else(|e| e.into_inner());
+    barriers.entry(network.to_string()).or_default().clone()
+}
 
 /// Validates that a string is safe to use as a SQL identifier (table name, column name, schema).
 /// Rejects anything that doesn't match `[a-zA-Z_][a-zA-Z0-9_]*`.

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use alloy::primitives::{B256, U64};
 use anyhow::Context;
@@ -99,7 +96,7 @@ impl DerivedColumnRollback {
         action: SetAction,
     ) -> anyhow::Result<Self> {
         super::validate_sql_identifier(&derived_column, "derived column")?;
-        validate_event_operand(&event_column, "rollback event column")?;
+        parse_event_operand(&event_column, "rollback event column")?;
         Ok(Self { derived_column, event_column, action })
     }
 }
@@ -133,7 +130,7 @@ impl DerivedTableRollbackOp {
         }
         for (dt_col, ev_col) in &where_columns {
             super::validate_sql_identifier(dt_col, "rollback op WHERE derived column")?;
-            validate_event_operand(ev_col, "rollback op WHERE event column")?;
+            parse_event_operand(ev_col, "rollback op WHERE event column")?;
         }
         if let Some(cond) = &condition {
             validate_sql_condition(cond)?;
@@ -440,10 +437,6 @@ fn parse_event_operand<'a>(operand: &'a str, kind: &str) -> anyhow::Result<Condi
     Ok(variable)
 }
 
-fn validate_event_operand(operand: &str, kind: &str) -> anyhow::Result<()> {
-    parse_event_operand(operand, kind).map(|_| ())
-}
-
 struct ReversalSource<'a> {
     dialect: SqlDialect,
     iterate: &'a [RollbackIterateBinding],
@@ -686,13 +679,13 @@ fn render_reorg_condition(condition: &str, source: &ReversalSource<'_>) -> anyho
             return Ok(condition.to_string());
         }
     };
-    anyhow::ensure!(
-        !expression.has_table_references(),
-        "rollback condition '{condition}' references table state, which cannot be reconstructed from raw events"
-    );
     expression
         .to_sql_event_condition(|variable| source.variable_expression(variable))
-        .ok_or_else(|| anyhow::anyhow!("rollback condition '{condition}' did not produce SQL"))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "rollback condition '{condition}' references table state, which cannot be reconstructed from raw events"
+            )
+        })
 }
 
 impl ReorgTask {
@@ -711,9 +704,6 @@ impl ReorgTask {
         ch: Option<&Arc<ClickhouseClient>>,
         rollback_plan: &DerivedTableRollbackPlan,
     ) -> anyhow::Result<()> {
-        let mut checked_pg = HashSet::new();
-        let mut checked_ch = HashSet::new();
-
         for dt in &self.derived_tables {
             for (op_index, op) in dt.rollback_ops.iter().enumerate() {
                 let Some(metadata) = rollback_plan.operation(&dt.full_table_name, op_index) else {
@@ -741,19 +731,16 @@ impl ReorgTask {
                     );
 
                     let mismatch_count = match (dialect, pg, ch) {
-                        (SqlDialect::Postgres, Some(pg), _) if checked_pg.insert(query.clone()) => {
+                        (SqlDialect::Postgres, Some(pg), _) => {
                             pg.query_one(&query, &[])
                                 .await
                                 .context("failed to validate PostgreSQL rollback iterate lengths")?
                                 .get::<_, i64>(0) as u64
                         }
-                        (SqlDialect::Clickhouse, _, Some(ch))
-                            if checked_ch.insert(query.clone()) =>
-                        {
-                            ch.query_one::<u64>(&query)
-                                .await
-                                .context("failed to validate ClickHouse rollback iterate lengths")?
-                        }
+                        (SqlDialect::Clickhouse, _, Some(ch)) => ch
+                            .query_one::<u64>(&query)
+                            .await
+                            .context("failed to validate ClickHouse rollback iterate lengths")?,
                         _ => continue,
                     };
                     anyhow::ensure!(
@@ -1863,63 +1850,6 @@ mod tests {
         assert_eq!(op.where_columns.len(), 1);
         assert_eq!(op.columns.len(), 1);
         assert!(op.condition.is_none());
-    }
-
-    #[test]
-    fn test_transfer_batch_reversal_source_expands_parallel_arrays() {
-        let op = DerivedTableRollbackOp::try_new(
-            "myschema.transfer_batch".to_string(),
-            vec![("token_id".to_string(), "token_id".to_string())],
-            vec![DerivedColumnRollback::try_new(
-                "balance".to_string(),
-                "amount".to_string(),
-                SetAction::Add,
-            )
-            .unwrap()],
-            Some("$to != 0x0000000000000000000000000000000000000000".to_string()),
-        )
-        .unwrap();
-        let mut plan = DerivedTableRollbackPlan::default();
-        plan.try_add_operation(
-            "myschema.balances".to_string(),
-            0,
-            vec![
-                IterateBinding::parse("$ids as token_id").unwrap(),
-                IterateBinding::parse("$values as amount").unwrap(),
-            ],
-            HashMap::from([
-                ("ids".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
-                ("values".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
-            ]),
-            HashMap::from([
-                ("token_id".to_string(), ColumnType::Uint256),
-                ("balance".to_string(), ColumnType::Uint256),
-            ]),
-        )
-        .unwrap();
-        let metadata = plan.operation("myschema.balances", 0).unwrap();
-        let source = ReversalSource {
-            dialect: SqlDialect::Postgres,
-            iterate: &metadata.iterate,
-            source_column_types: &metadata.source_column_types,
-        };
-
-        assert_eq!(
-            source.from(&op.event_table),
-            "myschema.transfer_batch AS _rindexer_event CROSS JOIN LATERAL ROWS FROM (unnest(_rindexer_event.\"ids\"), unnest(_rindexer_event.\"values\")) AS _rindexer_iter(\"token_id\", \"amount\")"
-        );
-        assert_eq!(source.column("token_id"), "_rindexer_iter.\"token_id\"");
-        assert_eq!(source.column("amount"), "_rindexer_iter.\"amount\"");
-        assert_eq!(
-            source.iterate_length_mismatch().as_deref(),
-            Some(
-                "COALESCE(cardinality(_rindexer_event.\"ids\"), -1) <> COALESCE(cardinality(_rindexer_event.\"values\"), -1)"
-            )
-        );
-        assert_eq!(
-            render_reorg_condition(op.condition.as_deref().unwrap(), &source).unwrap(),
-            "_rindexer_event.\"to\" <> '0x0000000000000000000000000000000000000000'"
-        );
     }
 
     #[test]

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -1,13 +1,13 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use alloy::primitives::{B256, U64};
 use anyhow::Context;
 
 use crate::database::clickhouse::client::ClickhouseClient;
 use crate::database::postgres::client::PostgresClient;
-use crate::event::parse_filter_expression;
+use crate::event::{parse_filter_expression, Accessor, ConditionLeft};
 use crate::helpers::camel_to_snake;
-use crate::manifest::contract::{IterateBinding, SetAction};
+use crate::manifest::contract::{ColumnType, IterateBinding, SetAction};
 use crate::metrics::indexing as metrics;
 use crate::provider::ChainProvider;
 
@@ -110,6 +110,10 @@ pub struct DerivedTableRollbackOp {
     pub condition: Option<String>,
     /// Array bindings expanded by the forward custom-table operation.
     pub iterate: Vec<IterateBinding>,
+    /// Semantic types of source event columns and iterate aliases.
+    pub source_column_types: HashMap<String, ColumnType>,
+    /// Resolved semantic types of derived-table columns.
+    pub derived_column_types: HashMap<String, ColumnType>,
 }
 
 impl DerivedTableRollbackOp {
@@ -133,7 +137,15 @@ impl DerivedTableRollbackOp {
         if let Some(cond) = &condition {
             validate_sql_condition(cond)?;
         }
-        Ok(Self { event_table, where_columns, columns, condition, iterate: Vec::new() })
+        Ok(Self {
+            event_table,
+            where_columns,
+            columns,
+            condition,
+            iterate: Vec::new(),
+            source_column_types: HashMap::new(),
+            derived_column_types: HashMap::new(),
+        })
     }
 
     /// Attach the array bindings used by the forward custom-table operation.
@@ -155,6 +167,25 @@ impl DerivedTableRollbackOp {
         }
         self.iterate = normalized;
         Ok(self)
+    }
+
+    /// Attach the ABI-derived source types and resolved custom-table types used
+    /// to preserve forward-path coercions during rollback SQL rendering.
+    pub fn with_column_types(
+        mut self,
+        mut source_column_types: HashMap<String, ColumnType>,
+        derived_column_types: HashMap<String, ColumnType>,
+    ) -> Self {
+        for binding in &self.iterate {
+            if let Some(ColumnType::Array(inner)) =
+                source_column_types.get(&binding.array_field).cloned()
+            {
+                source_column_types.insert(binding.alias.clone(), *inner);
+            }
+        }
+        self.source_column_types = source_column_types;
+        self.derived_column_types = derived_column_types;
+        self
     }
 }
 
@@ -288,6 +319,27 @@ impl SqlDialect {
             Self::Clickhouse => quote_ch_ident(name),
         }
     }
+
+    fn cast(self, expression: String, column_type: &ColumnType) -> String {
+        match self {
+            // Raw PostgreSQL event tables store 136-256 bit integers as decimal
+            // strings, while custom tables use NUMERIC. Reapply the forward
+            // custom-table coercion before grouping, comparing, or summing.
+            Self::Postgres => {
+                format!("CAST({} AS {})", expression, column_type.to_postgres_type())
+            }
+            // Raw and custom ClickHouse tables share ColumnType's native types.
+            Self::Clickhouse => expression,
+        }
+    }
+
+    fn array_element(self, expression: String, index: usize) -> String {
+        let sql_index = index.saturating_add(1);
+        match self {
+            Self::Postgres => format!("({})[{}]", expression, sql_index),
+            Self::Clickhouse => format!("arrayElement({}, {})", expression, sql_index),
+        }
+    }
 }
 
 fn event_field_to_db_column(field: &str) -> String {
@@ -306,6 +358,7 @@ fn event_field_to_db_column(field: &str) -> String {
 struct ReversalSource<'a> {
     dialect: SqlDialect,
     iterate: &'a [IterateBinding],
+    source_column_types: &'a HashMap<String, ColumnType>,
 }
 
 impl ReversalSource<'_> {
@@ -322,6 +375,69 @@ impl ReversalSource<'_> {
             }
         } else {
             format!("_rindexer_event.{}", self.dialect.quote(&column))
+        }
+    }
+
+    fn condition_variable(&self, variable: &ConditionLeft<'_>) -> String {
+        let mut field_parts = vec![variable.base_name()];
+        let mut accessors = variable.accessors().iter().peekable();
+
+        // Non-array tuple fields are flattened in raw event tables, so
+        // `$data.amount` addresses the `data_amount` column directly.
+        while let Some(Accessor::Key(key)) = accessors.peek() {
+            field_parts.push(key);
+            accessors.next();
+        }
+
+        let field = field_parts.join(".");
+        let db_column = event_field_to_db_column(&field);
+        let mut expression = self.column(&field);
+        let mut column_type = self
+            .source_column_types
+            .get(&db_column)
+            .cloned()
+            .or_else(|| ColumnType::from_tx_metadata_field(variable.base_name()));
+
+        for accessor in accessors {
+            match accessor {
+                Accessor::Index(index) => {
+                    match column_type {
+                        Some(ColumnType::Array(inner)) => {
+                            expression = self.dialect.array_element(expression, *index);
+                            column_type = Some(*inner);
+                        }
+                        _ => {
+                            // Tuple arrays are JSONB in PostgreSQL and use
+                            // zero-based JSON indexing rather than one-based
+                            // native SQL-array indexing.
+                            expression = match self.dialect {
+                                SqlDialect::Postgres => format!("({} -> {})", expression, index),
+                                SqlDialect::Clickhouse => expression,
+                            };
+                            column_type = None;
+                        }
+                    }
+                }
+                Accessor::Key(key) => {
+                    // Tuple arrays are JSONB in PostgreSQL and unsupported in
+                    // ClickHouse raw storage. Preserve their remaining path as
+                    // a JSON lookup when encountered after an array index.
+                    expression = match self.dialect {
+                        SqlDialect::Postgres => {
+                            format!("({} ->> '{}')", expression, key.replace('\'', "''"))
+                        }
+                        SqlDialect::Clickhouse => {
+                            format!("JSONExtractRaw({}, '{}')", expression, key.replace('\'', "''"))
+                        }
+                    };
+                    column_type = None;
+                }
+            }
+        }
+
+        match column_type {
+            Some(column_type) => self.dialect.cast(expression, &column_type),
+            None => expression,
         }
     }
 
@@ -360,7 +476,7 @@ impl ReversalSource<'_> {
 
 fn render_reorg_condition(condition: &str, source: &ReversalSource<'_>) -> Option<String> {
     let expression = parse_filter_expression(condition).ok()?;
-    expression.to_sql_event_condition(|field| source.column(field))
+    expression.to_sql_event_condition(|variable| source.condition_variable(variable))
 }
 
 impl ReorgTask {
@@ -387,10 +503,11 @@ impl ReorgTask {
 
         for dt in &self.derived_tables {
             for op in &dt.rollback_ops {
-                // (is_counter, source event column, agg alias) per reversible
+                // (is_counter, source event column, derived column, agg alias) per reversible
                 // column. The SELECT aggregate is assembled per-backend so each
                 // can quote identifiers with its own convention.
-                let mut agg_specs: Vec<(bool, String, String)> = Vec::new();
+                let mut agg_specs: Vec<(bool, String, String, String)> =
+                    Vec::with_capacity(op.columns.len());
                 let mut set_ops: Vec<ReversalSetOp> = Vec::new();
 
                 for (col_idx, col) in op.columns.iter().enumerate() {
@@ -421,6 +538,7 @@ impl ReorgTask {
                     agg_specs.push((
                         col.action.is_counter_action(),
                         col.event_column.clone(),
+                        col.derived_column.clone(),
                         agg_alias.clone(),
                     ));
                     set_ops.push(ReversalSetOp {
@@ -452,10 +570,21 @@ impl ReorgTask {
                 // reserved words (e.g. `to`, `from`), so each backend quotes them with
                 // its own convention (Postgres double quotes, ClickHouse backticks).
                 let build_select = |dialect: SqlDialect| {
-                    let source = ReversalSource { dialect, iterate: &op.iterate };
-                    let group_expressions = where_ev_cols
+                    let source = ReversalSource {
+                        dialect,
+                        iterate: &op.iterate,
+                        source_column_types: &op.source_column_types,
+                    };
+                    let group_expressions = op
+                        .where_columns
                         .iter()
-                        .map(|column| source.column(column))
+                        .map(|(derived_column, event_column)| {
+                            let expression = source.column(event_column);
+                            match op.derived_column_types.get(derived_column) {
+                                Some(column_type) => dialect.cast(expression, column_type),
+                                None => expression,
+                            }
+                        })
                         .collect::<Vec<_>>();
                     let group = group_expressions.join(", ");
                     let mut group_select = where_ev_cols
@@ -475,11 +604,16 @@ impl ReorgTask {
                     let group_select = group_select.join(", ");
                     let aggs = agg_specs
                         .iter()
-                        .map(|(is_counter, ev, alias)| {
+                        .map(|(is_counter, event_column, derived_column, alias)| {
                             if *is_counter {
                                 format!("COUNT(*) AS {}", alias)
                             } else {
-                                format!("SUM({}) AS {}", source.column(ev), alias)
+                                let expression = source.column(event_column);
+                                let expression = match op.derived_column_types.get(derived_column) {
+                                    Some(column_type) => dialect.cast(expression, column_type),
+                                    None => expression,
+                                };
+                                format!("SUM({}) AS {}", expression, alias)
                             }
                         })
                         .collect::<Vec<_>>()
@@ -1358,8 +1492,22 @@ mod tests {
             IterateBinding::parse("$ids as token_id").unwrap(),
             IterateBinding::parse("$values as amount").unwrap(),
         ])
-        .unwrap();
-        let source = ReversalSource { dialect: SqlDialect::Postgres, iterate: &op.iterate };
+        .unwrap()
+        .with_column_types(
+            HashMap::from([
+                ("ids".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+                ("values".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+            ]),
+            HashMap::from([
+                ("token_id".to_string(), ColumnType::Uint256),
+                ("balance".to_string(), ColumnType::Uint256),
+            ]),
+        );
+        let source = ReversalSource {
+            dialect: SqlDialect::Postgres,
+            iterate: &op.iterate,
+            source_column_types: &op.source_column_types,
+        };
 
         assert_eq!(
             source.from(&op.event_table),
@@ -1370,6 +1518,41 @@ mod tests {
         assert_eq!(
             render_reorg_condition(op.condition.as_deref().unwrap(), &source).unwrap(),
             "_rindexer_event.\"to\" <> '0x0000000000000000000000000000000000000000'"
+        );
+    }
+
+    #[test]
+    fn test_reorg_condition_preserves_nested_and_index_accessors() {
+        let source_column_types = HashMap::from([
+            ("data_amount".to_string(), ColumnType::Uint256),
+            ("ids".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+        ]);
+        let pg_source = ReversalSource {
+            dialect: SqlDialect::Postgres,
+            iterate: &[],
+            source_column_types: &source_column_types,
+        };
+        assert_eq!(
+            render_reorg_condition("$data.amount > 0", &pg_source).unwrap(),
+            "CAST(_rindexer_event.\"data_amount\" AS NUMERIC) > 0"
+        );
+        assert_eq!(
+            render_reorg_condition("$ids[0] > 0", &pg_source).unwrap(),
+            "CAST((_rindexer_event.\"ids\")[1] AS NUMERIC) > 0"
+        );
+
+        let ch_source = ReversalSource {
+            dialect: SqlDialect::Clickhouse,
+            iterate: &[],
+            source_column_types: &source_column_types,
+        };
+        assert_eq!(
+            render_reorg_condition("$data.amount > 0", &ch_source).unwrap(),
+            "_rindexer_event.`data_amount` > 0"
+        );
+        assert_eq!(
+            render_reorg_condition("$ids[0] > 0", &ch_source).unwrap(),
+            "arrayElement(_rindexer_event.`ids`, 1) > 0"
         );
     }
 

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -351,6 +351,11 @@ struct ReversalSnapshot {
     set_ops: Vec<ReversalSetOp>,
 }
 
+struct ReversalSnapshots {
+    entries: Vec<ReversalSnapshot>,
+    clickhouse_marker: Option<String>,
+}
+
 /// A single reversal SET assignment, kept structured (rather than as a
 /// pre-rendered SQL string) so each backend can quote the derived column with
 /// its own convention. `derived_column` is reversed by `op_symbol` against the
@@ -765,18 +770,92 @@ impl ReorgTask {
         pg: Option<&PgTransaction<'_>>,
         ch: Option<&Arc<ClickhouseClient>>,
         rollback_plan: &DerivedTableRollbackPlan,
-        attempt_id: &str,
-    ) -> anyhow::Result<Vec<ReversalSnapshot>> {
+    ) -> anyhow::Result<ReversalSnapshots> {
         self.validate_iterate_lengths(pg, ch, rollback_plan).await?;
 
+        let (attempt_id, clickhouse_marker, resumed) = match ch {
+            Some(ch) => {
+                let (attempt_id, marker, resumed) = self.clickhouse_reversal_attempt(ch).await?;
+                (attempt_id, Some(marker), resumed)
+            }
+            None => (
+                format!("_rindexer_reorg_snap_{}", generate_random_id(24).to_ascii_lowercase()),
+                None,
+                false,
+            ),
+        };
         let mut snapshots = Vec::new();
-        let create_result =
-            self.create_reversal_snapshots(pg, ch, rollback_plan, attempt_id, &mut snapshots).await;
+        let create_result = self
+            .create_reversal_snapshots(pg, ch, rollback_plan, &attempt_id, &mut snapshots)
+            .await;
         if let Err(error) = create_result {
-            Self::cleanup_reversal_snapshots(&snapshots, pg, ch).await;
+            if !resumed {
+                Self::cleanup_reversal_snapshots(&snapshots, None, pg, ch).await;
+            }
             return Err(error);
         }
-        Ok(snapshots)
+
+        let has_clickhouse_snapshots =
+            snapshots.iter().any(|snap| snap.backend == SnapshotBackend::Clickhouse);
+        if has_clickhouse_snapshots && !resumed {
+            if let (Some(ch), Some(marker)) = (ch, clickhouse_marker.as_deref()) {
+                if let Err(error) = ch
+                    .execute(&format!("CREATE TABLE {} (ready UInt8) ENGINE = Memory", marker))
+                    .await
+                {
+                    Self::cleanup_reversal_snapshots(&snapshots, None, pg, Some(ch)).await;
+                    return Err(error)
+                        .context("Failed to mark ClickHouse reversal snapshots ready");
+                }
+            }
+        }
+
+        Ok(ReversalSnapshots {
+            entries: snapshots,
+            clickhouse_marker: clickhouse_marker.filter(|_| has_clickhouse_snapshots),
+        })
+    }
+
+    async fn clickhouse_reversal_attempt(
+        &self,
+        ch: &Arc<ClickhouseClient>,
+    ) -> anyhow::Result<(String, String, bool)> {
+        let safe_network = self.network.replace('-', "_");
+        let prefix = format!(
+            "_rindexer_reorg_snap_{}_{}_{}_",
+            safe_network, self.fork_point, self.detection_point
+        );
+        let markers = ch
+            .query_all::<String>(&format!(
+                "SELECT name FROM system.tables \
+                 WHERE database = 'rindexer_internal' \
+                   AND startsWith(name, '{}') AND endsWith(name, '_ready') \
+                 ORDER BY name LIMIT 2",
+                prefix
+            ))
+            .await
+            .context("Failed to find pending ClickHouse reversal snapshots")?;
+        anyhow::ensure!(
+            markers.len() <= 1,
+            "multiple pending ClickHouse reversal attempts found for {} blocks {}-{}",
+            self.network,
+            self.fork_point,
+            self.detection_point
+        );
+
+        if let Some(marker) = markers.into_iter().next() {
+            let attempt_id = marker
+                .strip_suffix("_ready")
+                .filter(|name| name.starts_with(&prefix))
+                .ok_or_else(|| anyhow::anyhow!("invalid ClickHouse reversal marker '{}'", marker))?
+                .to_string();
+            super::validate_sql_identifier(&attempt_id, "ClickHouse reversal attempt")?;
+            return Ok((attempt_id, format!("rindexer_internal.{}", marker), true));
+        }
+
+        let attempt_id = format!("{}{}", prefix, generate_random_id(24).to_ascii_lowercase());
+        let marker = format!("rindexer_internal.{}_ready", attempt_id);
+        Ok((attempt_id, marker, false))
     }
 
     async fn create_reversal_snapshots(
@@ -859,7 +938,7 @@ impl ReorgTask {
                     })
                     .collect::<Vec<_>>();
 
-                let temp_base = format!("_rindexer_reorg_snap_{}_{}", attempt_id, snap_idx);
+                let temp_base = format!("{}_{}", attempt_id, snap_idx);
                 snap_idx += 1;
 
                 // Build the SELECT per-backend. Group/where and aggregate-source
@@ -986,7 +1065,7 @@ impl ReorgTask {
                     // support correlated subqueries the way Postgres does, so
                     // we cannot use `(SELECT ... WHERE snap.k = dt.k LIMIT 1)`.
                     let ch_create = format!(
-                        "CREATE TABLE {} ENGINE = Join(ANY, LEFT, _rindexer_key) AS {}",
+                        "CREATE TABLE IF NOT EXISTS {} ENGINE = Join(ANY, LEFT, _rindexer_key) AS {}",
                         ch_temp,
                         build_select(SqlDialect::Clickhouse)?,
                     );
@@ -1131,6 +1210,15 @@ impl ReorgTask {
                         table = %snap.derived_table,
                         "ClickHouse: reversed accumulative ops"
                     );
+                    if let Err(error) =
+                        ch.execute(&format!("DROP TABLE IF EXISTS {}", snap.temp_table)).await
+                    {
+                        tracing::warn!(
+                            temp_table = %snap.temp_table,
+                            %error,
+                            "Failed to checkpoint completed ClickHouse reversal snapshot"
+                        );
+                    }
                 }
             }
         }
@@ -1139,6 +1227,7 @@ impl ReorgTask {
 
     async fn cleanup_reversal_snapshots(
         snapshots: &[ReversalSnapshot],
+        clickhouse_marker: Option<&str>,
         pg: Option<&PgTransaction<'_>>,
         ch: Option<&Arc<ClickhouseClient>>,
     ) {
@@ -1164,6 +1253,15 @@ impl ReorgTask {
                     temp_table = %snap.temp_table,
                     %error,
                     "Failed to clean up reorg reversal snapshot"
+                );
+            }
+        }
+        if let (Some(marker), Some(ch)) = (clickhouse_marker, ch) {
+            if let Err(error) = ch.execute(&format!("DROP TABLE IF EXISTS {}", marker)).await {
+                tracing::warn!(
+                    temp_table = %marker,
+                    %error,
+                    "Failed to clean up ClickHouse reversal marker"
                 );
             }
         }
@@ -1462,12 +1560,7 @@ impl ReorgTask {
         };
         let pg = pg_transaction.as_ref();
 
-        // One nonce scopes every snapshot created by this execution. PostgreSQL
-        // still relies on its session-local temp namespace; ClickHouse needs the
-        // nonce because its snapshot tables are database-global.
-        let attempt_id = generate_random_id(24).to_ascii_lowercase();
-        let reversal_snapshots =
-            self.snapshot_for_reversal(pg, clickhouse, rollback_plan, &attempt_id).await?;
+        let reversal_snapshots = self.snapshot_for_reversal(pg, clickhouse, rollback_plan).await?;
 
         let rollback_result: anyhow::Result<(u64, Vec<String>)> = async {
             let mut affected_tx_hashes = Vec::new();
@@ -1532,7 +1625,7 @@ impl ReorgTask {
                 }
             }
 
-            Self::apply_reversal_from_snapshots(&reversal_snapshots, pg, clickhouse)
+            Self::apply_reversal_from_snapshots(&reversal_snapshots.entries, pg, clickhouse)
                 .await
                 .context("Accumulative reversal from snapshots failed")?;
             self.recalculate_from_journal(pg, clickhouse)
@@ -1585,7 +1678,15 @@ impl ReorgTask {
         }
         .await;
 
-        Self::cleanup_reversal_snapshots(&reversal_snapshots, pg, clickhouse).await;
+        if rollback_result.is_ok() {
+            Self::cleanup_reversal_snapshots(
+                &reversal_snapshots.entries,
+                reversal_snapshots.clickhouse_marker.as_deref(),
+                pg,
+                clickhouse,
+            )
+            .await;
+        }
         let (total_deleted, affected_tx_hashes) = rollback_result?;
         if let Some(transaction) = pg_transaction {
             transaction.commit().await.context("PostgreSQL reorg commit failed")?;

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -5,7 +5,9 @@ use anyhow::Context;
 
 use crate::database::clickhouse::client::ClickhouseClient;
 use crate::database::postgres::client::PostgresClient;
-use crate::manifest::contract::SetAction;
+use crate::event::parse_filter_expression;
+use crate::helpers::camel_to_snake;
+use crate::manifest::contract::{IterateBinding, SetAction};
 use crate::metrics::indexing as metrics;
 use crate::provider::ChainProvider;
 
@@ -106,6 +108,8 @@ pub struct DerivedTableRollbackOp {
     pub columns: Vec<DerivedColumnRollback>,
     /// Optional SQL condition re-evaluated against event data.
     pub condition: Option<String>,
+    /// Array bindings expanded by the forward custom-table operation.
+    pub iterate: Vec<IterateBinding>,
 }
 
 impl DerivedTableRollbackOp {
@@ -129,7 +133,28 @@ impl DerivedTableRollbackOp {
         if let Some(cond) = &condition {
             validate_sql_condition(cond)?;
         }
-        Ok(Self { event_table, where_columns, columns, condition })
+        Ok(Self { event_table, where_columns, columns, condition, iterate: Vec::new() })
+    }
+
+    /// Attach the array bindings used by the forward custom-table operation.
+    pub fn with_iterate(mut self, bindings: Vec<IterateBinding>) -> anyhow::Result<Self> {
+        let mut normalized = Vec::with_capacity(bindings.len());
+        for binding in bindings {
+            let binding = IterateBinding {
+                array_field: event_field_to_db_column(&binding.array_field),
+                alias: event_field_to_db_column(&binding.alias),
+            };
+            super::validate_sql_identifier(&binding.array_field, "rollback iterate array column")?;
+            super::validate_sql_identifier(&binding.alias, "rollback iterate alias")?;
+            anyhow::ensure!(
+                !normalized.iter().any(|existing: &IterateBinding| existing.alias == binding.alias),
+                "duplicate rollback iterate alias '{}'",
+                binding.alias
+            );
+            normalized.push(binding);
+        }
+        self.iterate = normalized;
+        Ok(self)
     }
 }
 
@@ -250,6 +275,94 @@ fn quote_ch_ident(name: &str) -> String {
     format!("`{}`", name.replace('`', "\\`"))
 }
 
+#[derive(Clone, Copy)]
+enum SqlDialect {
+    Postgres,
+    Clickhouse,
+}
+
+impl SqlDialect {
+    fn quote(self, name: &str) -> String {
+        match self {
+            Self::Postgres => quote_pg_ident(name),
+            Self::Clickhouse => quote_ch_ident(name),
+        }
+    }
+}
+
+fn event_field_to_db_column(field: &str) -> String {
+    match field {
+        "rindexer_block_number" => "block_number".to_string(),
+        "rindexer_block_timestamp" => "block_timestamp".to_string(),
+        "rindexer_tx_hash" => "tx_hash".to_string(),
+        "rindexer_block_hash" => "block_hash".to_string(),
+        "rindexer_contract_address" => "contract_address".to_string(),
+        "rindexer_log_index" => "log_index".to_string(),
+        "rindexer_tx_index" => "tx_index".to_string(),
+        _ => field.split('.').map(camel_to_snake).collect::<Vec<_>>().join("_"),
+    }
+}
+
+struct ReversalSource<'a> {
+    dialect: SqlDialect,
+    iterate: &'a [IterateBinding],
+}
+
+impl ReversalSource<'_> {
+    fn column(&self, field: &str) -> String {
+        let column = event_field_to_db_column(field);
+        if let Some(index) = self.iterate.iter().position(|binding| binding.alias == column) {
+            match self.dialect {
+                SqlDialect::Postgres => {
+                    format!("_rindexer_iter.{}", self.dialect.quote(&column))
+                }
+                SqlDialect::Clickhouse => {
+                    format!("tupleElement(_rindexer_iter, {})", index + 1)
+                }
+            }
+        } else {
+            format!("_rindexer_event.{}", self.dialect.quote(&column))
+        }
+    }
+
+    fn from(&self, event_table: &str) -> String {
+        if self.iterate.is_empty() {
+            return format!("{} AS _rindexer_event", event_table);
+        }
+
+        let arrays = self
+            .iterate
+            .iter()
+            .map(|binding| format!("_rindexer_event.{}", self.dialect.quote(&binding.array_field)))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        match self.dialect {
+            SqlDialect::Postgres => {
+                let aliases = self
+                    .iterate
+                    .iter()
+                    .map(|binding| self.dialect.quote(&binding.alias))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "{} AS _rindexer_event CROSS JOIN LATERAL unnest({}) AS _rindexer_iter({})",
+                    event_table, arrays, aliases
+                )
+            }
+            SqlDialect::Clickhouse => format!(
+                "{} AS _rindexer_event ARRAY JOIN arrayZip({}) AS _rindexer_iter",
+                event_table, arrays
+            ),
+        }
+    }
+}
+
+fn render_reorg_condition(condition: &str, source: &ReversalSource<'_>) -> Option<String> {
+    let expression = parse_filter_expression(condition).ok()?;
+    expression.to_sql_event_condition(|field| source.column(field))
+}
+
 impl ReorgTask {
     /// Returns ` AND network = '<network>'` when not cross-chain, empty string otherwise.
     fn network_filter(&self, cross_chain: bool) -> String {
@@ -324,13 +437,6 @@ impl ReorgTask {
                 let where_ev_cols: Vec<&str> =
                     op.where_columns.iter().map(|(_, ev_col)| ev_col.as_str()).collect();
 
-                let network_filter = self.network_filter(dt.cross_chain);
-
-                let condition_filter = match &op.condition {
-                    Some(cond) => format!(" AND ({})", cond),
-                    None => String::new(),
-                };
-
                 // Include network + fork_point in temp table name to avoid collisions
                 // across concurrent reorg tasks on different networks.
                 // Replace hyphens with underscores so the name is a valid SQL identifier.
@@ -345,26 +451,64 @@ impl ReorgTask {
                 // columns are user-controlled identifiers that may collide with SQL
                 // reserved words (e.g. `to`, `from`), so each backend quotes them with
                 // its own convention (Postgres double quotes, ClickHouse backticks).
-                let build_select = |quote: &dyn Fn(&str) -> String| {
-                    let group =
-                        where_ev_cols.iter().map(|c| quote(c)).collect::<Vec<_>>().join(", ");
+                let build_select = |dialect: SqlDialect| {
+                    let source = ReversalSource { dialect, iterate: &op.iterate };
+                    let group_expressions = where_ev_cols
+                        .iter()
+                        .map(|column| source.column(column))
+                        .collect::<Vec<_>>();
+                    let group = group_expressions.join(", ");
+                    let mut group_select = where_ev_cols
+                        .iter()
+                        .zip(&group_expressions)
+                        .map(|(column, expression)| {
+                            format!("{} AS {}", expression, dialect.quote(column))
+                        })
+                        .collect::<Vec<_>>();
+                    if matches!(dialect, SqlDialect::Clickhouse) {
+                        // Older ClickHouse StorageJoin implementations reject
+                        // composite and UInt256 keys. A single serialized tuple
+                        // supports the full range of custom-table key types.
+                        group_select
+                            .push(format!("toJSONString(tuple({})) AS _rindexer_key", group));
+                    }
+                    let group_select = group_select.join(", ");
                     let aggs = agg_specs
                         .iter()
                         .map(|(is_counter, ev, alias)| {
                             if *is_counter {
                                 format!("COUNT(*) AS {}", alias)
                             } else {
-                                format!("SUM({}) AS {}", quote(ev), alias)
+                                format!("SUM({}) AS {}", source.column(ev), alias)
                             }
                         })
                         .collect::<Vec<_>>()
                         .join(", ");
+                    let network_filter = if dt.cross_chain {
+                        String::new()
+                    } else {
+                        format!(
+                            " AND _rindexer_event.{} = '{}'",
+                            dialect.quote("network"),
+                            self.network
+                        )
+                    };
+                    let condition_filter = match &op.condition {
+                        Some(condition) => {
+                            let condition = render_reorg_condition(condition, &source)
+                                .unwrap_or_else(|| condition.clone());
+                            format!(" AND ({})", condition)
+                        }
+                        None => String::new(),
+                    };
                     format!(
-                        "SELECT {}, {} FROM {} WHERE block_number >= {} AND block_number <= {}{}{} GROUP BY {}",
-                        group,
+                        "SELECT {}, {} FROM {} WHERE _rindexer_event.{} >= {} AND _rindexer_event.{} <= {}{}{} GROUP BY {}",
+                        group_select,
                         aggs,
-                        op.event_table,
+                        source.from(&op.event_table),
+                        dialect.quote("block_number"),
                         self.fork_point,
+                        dialect.quote("block_number"),
                         self.detection_point,
                         network_filter,
                         condition_filter,
@@ -377,7 +521,7 @@ impl ReorgTask {
                     let pg_create = format!(
                         "CREATE TEMP TABLE {} AS {}",
                         pg_temp,
-                        build_select(&quote_pg_ident)
+                        build_select(SqlDialect::Postgres)
                     );
                     pg.batch_execute(&pg_create).await.with_context(|| {
                         format!(
@@ -404,13 +548,10 @@ impl ReorgTask {
                     // aggregates via joinGet(). ClickHouse mutations don't
                     // support correlated subqueries the way Postgres does, so
                     // we cannot use `(SELECT ... WHERE snap.k = dt.k LIMIT 1)`.
-                    let ch_snap_keys: Vec<String> =
-                        where_ev_cols.iter().map(|ev_col| quote_ch_ident(ev_col)).collect();
                     let ch_create = format!(
-                        "CREATE TABLE IF NOT EXISTS {} ENGINE = Join(ANY, LEFT, {}) AS {}",
+                        "CREATE TABLE IF NOT EXISTS {} ENGINE = Join(ANY, LEFT, _rindexer_key) AS {}",
                         ch_temp,
-                        ch_snap_keys.join(", "),
-                        build_select(&quote_ch_ident),
+                        build_select(SqlDialect::Clickhouse),
                     );
                     ch.execute(&ch_create).await.with_context(|| {
                         format!(
@@ -495,12 +636,13 @@ impl ReorgTask {
                     // ClickHouse ALTER TABLE ... UPDATE with per-row aggregate lookups
                     // against a Join-engine snapshot table. joinGet() is the mutation-
                     // safe equivalent of PG's correlated subquery.
-                    let dt_keys: Vec<String> = snap
+                    let dt_keys = snap
                         .where_columns
                         .iter()
                         .map(|(dt_col, _)| quote_ch_ident(dt_col))
-                        .collect();
-                    let join_get_keys = dt_keys.join(", ");
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let join_get_key = format!("toJSONString(tuple({}))", dt_keys);
 
                     // Build CH set clauses directly from the structured ops: the
                     // per-row aggregate is looked up via joinGet() against the
@@ -512,7 +654,7 @@ impl ReorgTask {
                             let col = quote_ch_ident(&s.derived_column);
                             format!(
                                 "{} = {} {} joinGet('{}', '{}', {})",
-                                col, col, s.op_symbol, snap.temp_table, s.agg_alias, join_get_keys
+                                col, col, s.op_symbol, snap.temp_table, s.agg_alias, join_get_key
                             )
                         })
                         .collect();
@@ -524,22 +666,13 @@ impl ReorgTask {
                     };
 
                     // Only update rows that have a matching entry in the snapshot
-                    let ch_exists_filter: Vec<String> = snap
-                        .where_columns
-                        .iter()
-                        .map(|(dt_col, ev_col)| {
-                            format!(
-                                "{} IN (SELECT {} FROM {})",
-                                quote_ch_ident(dt_col),
-                                quote_ch_ident(ev_col),
-                                snap.temp_table
-                            )
-                        })
-                        .collect();
-                    let ch_scope = if ch_exists_filter.is_empty() {
+                    let ch_scope = if snap.where_columns.is_empty() {
                         ch_network.clone()
                     } else {
-                        format!("{} AND {}", ch_network, ch_exists_filter.join(" AND "))
+                        format!(
+                            "{} AND {} IN (SELECT _rindexer_key FROM {})",
+                            ch_network, join_get_key, snap.temp_table
+                        )
                     };
 
                     let ch_update = format!(
@@ -1204,6 +1337,40 @@ mod tests {
         assert_eq!(op.where_columns.len(), 1);
         assert_eq!(op.columns.len(), 1);
         assert!(op.condition.is_none());
+        assert!(op.iterate.is_empty());
+    }
+
+    #[test]
+    fn test_transfer_batch_reversal_source_expands_parallel_arrays() {
+        let op = DerivedTableRollbackOp::try_new(
+            "myschema.transfer_batch".to_string(),
+            vec![("token_id".to_string(), "token_id".to_string())],
+            vec![DerivedColumnRollback::try_new(
+                "balance".to_string(),
+                "amount".to_string(),
+                SetAction::Add,
+            )
+            .unwrap()],
+            Some("$to != 0x0000000000000000000000000000000000000000".to_string()),
+        )
+        .unwrap()
+        .with_iterate(vec![
+            IterateBinding::parse("$ids as token_id").unwrap(),
+            IterateBinding::parse("$values as amount").unwrap(),
+        ])
+        .unwrap();
+        let source = ReversalSource { dialect: SqlDialect::Postgres, iterate: &op.iterate };
+
+        assert_eq!(
+            source.from(&op.event_table),
+            "myschema.transfer_batch AS _rindexer_event CROSS JOIN LATERAL unnest(_rindexer_event.\"ids\", _rindexer_event.\"values\") AS _rindexer_iter(\"token_id\", \"amount\")"
+        );
+        assert_eq!(source.column("token_id"), "_rindexer_iter.\"token_id\"");
+        assert_eq!(source.column("amount"), "_rindexer_iter.\"amount\"");
+        assert_eq!(
+            render_reorg_condition(op.condition.as_deref().unwrap(), &source).unwrap(),
+            "_rindexer_event.\"to\" <> '0x0000000000000000000000000000000000000000'"
+        );
     }
 
     // ======================================================================

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -5,6 +5,7 @@ use std::{
 
 use alloy::primitives::{B256, U64};
 use anyhow::Context;
+use tokio_postgres::Transaction as PgTransaction;
 
 use crate::database::clickhouse::client::ClickhouseClient;
 use crate::database::postgres::client::PostgresClient;
@@ -12,7 +13,7 @@ use crate::event::{
     parse_arithmetic_expression, parse_filter_expression, Accessor, ArithmeticExpr, ConditionLeft,
     VariableSource,
 };
-use crate::helpers::camel_to_snake;
+use crate::helpers::{camel_to_snake, generate_random_id};
 use crate::manifest::contract::{ColumnType, IterateBinding, SetAction};
 use crate::metrics::indexing as metrics;
 use crate::provider::ChainProvider;
@@ -153,13 +154,28 @@ pub struct DerivedTableRollbackPlan {
 
 #[derive(Clone, Debug)]
 pub(crate) struct DerivedTableRollbackMetadata {
-    pub(crate) iterate: Vec<IterateBinding>,
+    pub(crate) iterate: Vec<RollbackIterateBinding>,
     pub(crate) source_column_types: HashMap<String, ColumnType>,
     pub(crate) derived_column_types: HashMap<String, ColumnType>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IterateStorage {
+    NativeArray,
+    PostgresJsonb,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RollbackIterateBinding {
+    pub(crate) array_field: String,
+    pub(crate) alias: String,
+    storage: IterateStorage,
+}
+
 impl DerivedTableRollbackPlan {
     /// Add metadata for one rollback operation.
+    /// Tuple-array element types use dotted keys such as `accounts.owner`;
+    /// their raw PostgreSQL column is represented as JSONB.
     ///
     /// # Errors
     ///
@@ -180,7 +196,7 @@ impl DerivedTableRollbackPlan {
             super::validate_sql_identifier(&derived_table, "rollback plan derived table name")?;
         }
 
-        let mut iterate = Vec::with_capacity(bindings.len());
+        let mut iterate: Vec<RollbackIterateBinding> = Vec::with_capacity(bindings.len());
         for binding in bindings {
             let binding = IterateBinding {
                 array_field: event_field_to_db_column(&binding.array_field),
@@ -189,16 +205,37 @@ impl DerivedTableRollbackPlan {
             super::validate_sql_identifier(&binding.array_field, "rollback iterate array column")?;
             super::validate_sql_identifier(&binding.alias, "rollback iterate alias")?;
             anyhow::ensure!(
-                !iterate.iter().any(|existing: &IterateBinding| existing.alias == binding.alias),
+                !iterate.iter().any(|existing| existing.alias == binding.alias),
                 "duplicate rollback iterate alias '{}'",
                 binding.alias
             );
-            if let Some(ColumnType::Array(inner)) =
-                source_column_types.get(&binding.array_field).cloned()
-            {
-                source_column_types.insert(binding.alias.clone(), *inner);
-            }
-            iterate.push(binding);
+            let jsonb_prefix = format!("{}.", binding.array_field);
+            let jsonb_element_types = source_column_types
+                .iter()
+                .filter_map(|(field, column_type)| {
+                    field
+                        .strip_prefix(&jsonb_prefix)
+                        .map(|path| (path.to_string(), column_type.clone()))
+                })
+                .collect::<Vec<_>>();
+            let storage = if jsonb_element_types.is_empty() {
+                if let Some(ColumnType::Array(inner)) =
+                    source_column_types.get(&binding.array_field).cloned()
+                {
+                    source_column_types.insert(binding.alias.clone(), *inner);
+                }
+                IterateStorage::NativeArray
+            } else {
+                for (path, column_type) in jsonb_element_types {
+                    source_column_types.insert(format!("{}.{}", binding.alias, path), column_type);
+                }
+                IterateStorage::PostgresJsonb
+            };
+            iterate.push(RollbackIterateBinding {
+                array_field: binding.array_field,
+                alias: binding.alias,
+                storage,
+            });
         }
 
         let table_operations = self.operations.entry(derived_table.clone()).or_default();
@@ -409,7 +446,7 @@ fn validate_event_operand(operand: &str, kind: &str) -> anyhow::Result<()> {
 
 struct ReversalSource<'a> {
     dialect: SqlDialect,
-    iterate: &'a [IterateBinding],
+    iterate: &'a [RollbackIterateBinding],
     source_column_types: &'a HashMap<String, ColumnType>,
 }
 
@@ -431,6 +468,11 @@ impl ReversalSource<'_> {
     }
 
     fn variable_expression(&self, variable: &ConditionLeft<'_>) -> String {
+        let base = event_field_to_db_column(variable.base_name());
+        if let Some(binding) = self.iterate.iter().find(|binding| binding.alias == base) {
+            return self.iterate_variable_expression(variable, binding);
+        }
+
         let mut field_parts = vec![variable.base_name()];
         let mut accessors = variable.accessors().iter().peekable();
 
@@ -493,6 +535,64 @@ impl ReversalSource<'_> {
         }
     }
 
+    fn iterate_variable_expression(
+        &self,
+        variable: &ConditionLeft<'_>,
+        binding: &RollbackIterateBinding,
+    ) -> String {
+        let mut expression = self.column(&binding.alias);
+        let mut column_type = self.source_column_types.get(&binding.alias).cloned();
+
+        if binding.storage == IterateStorage::PostgresJsonb {
+            let mut field = binding.alias.clone();
+            let path = variable
+                .accessors()
+                .iter()
+                .map(|accessor| match accessor {
+                    Accessor::Key(key) => {
+                        field.push('.');
+                        field.push_str(key);
+                        column_type = self.source_column_types.get(&field).cloned();
+                        key.to_string()
+                    }
+                    Accessor::Index(index) => {
+                        if let Some(ColumnType::Array(inner)) = column_type.take() {
+                            column_type = Some(*inner);
+                        }
+                        index.to_string()
+                    }
+                })
+                .collect::<Vec<_>>();
+            if !path.is_empty() {
+                let path = path
+                    .iter()
+                    .map(|part| format!("'{}'", part.replace('\'', "''")))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                expression = match self.dialect {
+                    SqlDialect::Postgres => {
+                        format!("jsonb_extract_path_text({}, {})", expression, path)
+                    }
+                    SqlDialect::Clickhouse => expression,
+                };
+            }
+        } else {
+            for accessor in variable.accessors() {
+                if let Accessor::Index(index) = accessor {
+                    if let Some(ColumnType::Array(inner)) = column_type.take() {
+                        expression = self.dialect.array_element(expression, *index);
+                        column_type = Some(*inner);
+                    }
+                }
+            }
+        }
+
+        match column_type {
+            Some(column_type) => self.dialect.cast(expression, &column_type),
+            None => expression,
+        }
+    }
+
     fn operand(&self, operand: &str) -> anyhow::Result<String> {
         let variable = parse_event_operand(operand, "rollback operand")?;
         Ok(self.variable_expression(&variable))
@@ -504,10 +604,17 @@ impl ReversalSource<'_> {
             return None;
         }
 
-        let length = |binding: &IterateBinding| {
+        let length = |binding: &RollbackIterateBinding| {
             let column = format!("_rindexer_event.{}", self.dialect.quote(&binding.array_field));
             match self.dialect {
-                SqlDialect::Postgres => format!("COALESCE(cardinality({}), -1)", column),
+                SqlDialect::Postgres => match binding.storage {
+                    IterateStorage::NativeArray => {
+                        format!("COALESCE(cardinality({}), -1)", column)
+                    }
+                    IterateStorage::PostgresJsonb => {
+                        format!("COALESCE(jsonb_array_length({}), -1)", column)
+                    }
+                },
                 SqlDialect::Clickhouse => format!("length({})", column),
             }
         };
@@ -525,15 +632,23 @@ impl ReversalSource<'_> {
             return format!("{} AS _rindexer_event", event_table);
         }
 
-        let arrays = self
-            .iterate
-            .iter()
-            .map(|binding| format!("_rindexer_event.{}", self.dialect.quote(&binding.array_field)))
-            .collect::<Vec<_>>()
-            .join(", ");
-
         match self.dialect {
             SqlDialect::Postgres => {
+                let iterators = self
+                    .iterate
+                    .iter()
+                    .map(|binding| {
+                        let column =
+                            format!("_rindexer_event.{}", self.dialect.quote(&binding.array_field));
+                        match binding.storage {
+                            IterateStorage::NativeArray => format!("unnest({})", column),
+                            IterateStorage::PostgresJsonb => {
+                                format!("jsonb_array_elements({})", column)
+                            }
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 let aliases = self
                     .iterate
                     .iter()
@@ -541,14 +656,24 @@ impl ReversalSource<'_> {
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!(
-                    "{} AS _rindexer_event CROSS JOIN LATERAL unnest({}) AS _rindexer_iter({})",
-                    event_table, arrays, aliases
+                    "{} AS _rindexer_event CROSS JOIN LATERAL ROWS FROM ({}) AS _rindexer_iter({})",
+                    event_table, iterators, aliases
                 )
             }
-            SqlDialect::Clickhouse => format!(
-                "{} AS _rindexer_event ARRAY JOIN arrayZip({}) AS _rindexer_iter",
-                event_table, arrays
-            ),
+            SqlDialect::Clickhouse => {
+                let arrays = self
+                    .iterate
+                    .iter()
+                    .map(|binding| {
+                        format!("_rindexer_event.{}", self.dialect.quote(&binding.array_field))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "{} AS _rindexer_event ARRAY JOIN arrayZip({}) AS _rindexer_iter",
+                    event_table, arrays
+                )
+            }
         }
     }
 }
@@ -582,7 +707,7 @@ impl ReorgTask {
 
     async fn validate_iterate_lengths(
         &self,
-        pg: Option<&PostgresClient>,
+        pg: Option<&PgTransaction<'_>>,
         ch: Option<&Arc<ClickhouseClient>>,
         rollback_plan: &DerivedTableRollbackPlan,
     ) -> anyhow::Result<()> {
@@ -650,13 +775,31 @@ impl ReorgTask {
     /// event deletion from proceeding without proper reversal data.
     async fn snapshot_for_reversal(
         &self,
-        pg: Option<&PostgresClient>,
+        pg: Option<&PgTransaction<'_>>,
         ch: Option<&Arc<ClickhouseClient>>,
         rollback_plan: &DerivedTableRollbackPlan,
+        attempt_id: &str,
     ) -> anyhow::Result<Vec<ReversalSnapshot>> {
         self.validate_iterate_lengths(pg, ch, rollback_plan).await?;
 
         let mut snapshots = Vec::new();
+        let create_result =
+            self.create_reversal_snapshots(pg, ch, rollback_plan, attempt_id, &mut snapshots).await;
+        if let Err(error) = create_result {
+            Self::cleanup_reversal_snapshots(&snapshots, pg, ch).await;
+            return Err(error);
+        }
+        Ok(snapshots)
+    }
+
+    async fn create_reversal_snapshots(
+        &self,
+        pg: Option<&PgTransaction<'_>>,
+        ch: Option<&Arc<ClickhouseClient>>,
+        rollback_plan: &DerivedTableRollbackPlan,
+        attempt_id: &str,
+        snapshots: &mut Vec<ReversalSnapshot>,
+    ) -> anyhow::Result<()> {
         let mut snap_idx = 0usize;
         let empty_column_types = HashMap::new();
 
@@ -729,14 +872,7 @@ impl ReorgTask {
                     })
                     .collect::<Vec<_>>();
 
-                // Include network + fork_point in temp table name to avoid collisions
-                // across concurrent reorg tasks on different networks.
-                // Replace hyphens with underscores so the name is a valid SQL identifier.
-                let safe_network = self.network.replace('-', "_");
-                let temp_base = format!(
-                    "_rindexer_reorg_snap_{}_{}_{}",
-                    safe_network, self.fork_point, snap_idx
-                );
+                let temp_base = format!("_rindexer_reorg_snap_{}_{}", attempt_id, snap_idx);
                 snap_idx += 1;
 
                 // Build the SELECT per-backend. Group/where and aggregate-source
@@ -833,10 +969,19 @@ impl ReorgTask {
                 if let Some(pg) = pg {
                     let pg_temp = format!("{}_pg", temp_base);
                     let pg_create = format!(
-                        "CREATE TEMP TABLE {} AS {}",
+                        "CREATE TEMP TABLE {} ON COMMIT DROP AS {}",
                         pg_temp,
                         build_select(SqlDialect::Postgres)?
                     );
+                    snapshots.push(ReversalSnapshot {
+                        backend: SnapshotBackend::Postgres,
+                        temp_table: pg_temp.clone(),
+                        derived_table: dt.full_table_name.clone(),
+                        cross_chain: dt.cross_chain,
+                        network: self.network.clone(),
+                        where_columns: snapshot_where_columns.clone(),
+                        set_ops: set_ops.clone(),
+                    });
                     pg.batch_execute(&pg_create).await.with_context(|| {
                         format!(
                             "Failed to create PG reorg reversal snapshot for {}",
@@ -844,15 +989,6 @@ impl ReorgTask {
                         )
                     })?;
                     tracing::debug!(temp_table = %pg_temp, "Created PG reorg reversal snapshot");
-                    snapshots.push(ReversalSnapshot {
-                        backend: SnapshotBackend::Postgres,
-                        temp_table: pg_temp,
-                        derived_table: dt.full_table_name.clone(),
-                        cross_chain: dt.cross_chain,
-                        network: self.network.clone(),
-                        where_columns: snapshot_where_columns.clone(),
-                        set_ops: set_ops.clone(),
-                    });
                 }
 
                 if let Some(ch) = ch {
@@ -863,10 +999,19 @@ impl ReorgTask {
                     // support correlated subqueries the way Postgres does, so
                     // we cannot use `(SELECT ... WHERE snap.k = dt.k LIMIT 1)`.
                     let ch_create = format!(
-                        "CREATE TABLE IF NOT EXISTS {} ENGINE = Join(ANY, LEFT, _rindexer_key) AS {}",
+                        "CREATE TABLE {} ENGINE = Join(ANY, LEFT, _rindexer_key) AS {}",
                         ch_temp,
                         build_select(SqlDialect::Clickhouse)?,
                     );
+                    snapshots.push(ReversalSnapshot {
+                        backend: SnapshotBackend::Clickhouse,
+                        temp_table: ch_temp.clone(),
+                        derived_table: dt.full_table_name.clone(),
+                        cross_chain: dt.cross_chain,
+                        network: self.network.clone(),
+                        where_columns: snapshot_where_columns.clone(),
+                        set_ops: set_ops.clone(),
+                    });
                     ch.execute(&ch_create).await.with_context(|| {
                         format!(
                             "Failed to create CH reorg reversal snapshot for {}",
@@ -874,26 +1019,16 @@ impl ReorgTask {
                         )
                     })?;
                     tracing::debug!(temp_table = %ch_temp, "Created CH reorg reversal snapshot");
-                    snapshots.push(ReversalSnapshot {
-                        backend: SnapshotBackend::Clickhouse,
-                        temp_table: ch_temp,
-                        derived_table: dt.full_table_name.clone(),
-                        cross_chain: dt.cross_chain,
-                        network: self.network.clone(),
-                        where_columns: snapshot_where_columns,
-                        set_ops,
-                    });
                 }
             }
         }
-
-        Ok(snapshots)
+        Ok(())
     }
 
-    /// Phase 2: After event deletion, apply reverse UPDATEs from snapshots and drop temp tables.
+    /// Phase 2: After event deletion, apply reverse UPDATEs from snapshots.
     async fn apply_reversal_from_snapshots(
         snapshots: &[ReversalSnapshot],
-        pg: Option<&PostgresClient>,
+        pg: Option<&PgTransaction<'_>>,
         ch: Option<&Arc<ClickhouseClient>>,
     ) -> anyhow::Result<()> {
         for snap in snapshots {
@@ -942,9 +1077,6 @@ impl ReorgTask {
                         table = %snap.derived_table,
                         "PostgreSQL: reversed accumulative ops"
                     );
-                    let _ = pg
-                        .batch_execute(&format!("DROP TABLE IF EXISTS {}", snap.temp_table))
-                        .await;
                 }
                 SnapshotBackend::Clickhouse => {
                     let Some(ch) = ch else { continue };
@@ -1012,19 +1144,49 @@ impl ReorgTask {
                         table = %snap.derived_table,
                         "ClickHouse: reversed accumulative ops"
                     );
-
-                    let _ = ch.execute(&format!("DROP TABLE IF EXISTS {}", snap.temp_table)).await;
                 }
             }
         }
         Ok(())
     }
 
+    async fn cleanup_reversal_snapshots(
+        snapshots: &[ReversalSnapshot],
+        pg: Option<&PgTransaction<'_>>,
+        ch: Option<&Arc<ClickhouseClient>>,
+    ) {
+        for snap in snapshots.iter().rev() {
+            let result = match snap.backend {
+                SnapshotBackend::Postgres => match pg {
+                    Some(pg) => pg
+                        .batch_execute(&format!("DROP TABLE IF EXISTS {}", snap.temp_table))
+                        .await
+                        .map_err(anyhow::Error::from),
+                    None => continue,
+                },
+                SnapshotBackend::Clickhouse => match ch {
+                    Some(ch) => ch
+                        .execute(&format!("DROP TABLE IF EXISTS {}", snap.temp_table))
+                        .await
+                        .map_err(anyhow::Error::from),
+                    None => continue,
+                },
+            };
+            if let Err(error) = result {
+                tracing::warn!(
+                    temp_table = %snap.temp_table,
+                    %error,
+                    "Failed to clean up reorg reversal snapshot"
+                );
+            }
+        }
+    }
+
     /// Recalculate non-reversible columns (Set/Max/Min) from the operation journal.
     /// Deletes journal entries in the reorg range, then recalculates from remaining entries.
     async fn recalculate_from_journal(
         &self,
-        pg: Option<&PostgresClient>,
+        pg: Option<&PgTransaction<'_>>,
         ch: Option<&Arc<ClickhouseClient>>,
     ) -> anyhow::Result<()> {
         for dt in &self.derived_tables {
@@ -1301,21 +1463,39 @@ impl ReorgTask {
         let corrected_blocks: Vec<(u64, &str, &str)> =
             corrected_blocks_owned.iter().map(|(n, h, p)| (*n, h.as_str(), p.as_str())).collect();
 
-        // Phase 1: snapshot event data for accumulative reversal (before deletion)
+        let mut pg_connection = match postgres {
+            Some(pg) => Some(pg.raw_connection().await.context("PostgreSQL connection failed")?),
+            None => None,
+        };
+        let pg_transaction = match pg_connection.as_mut() {
+            Some(connection) => {
+                Some(connection.transaction().await.context("PostgreSQL transaction failed")?)
+            }
+            None => None,
+        };
+        let pg = pg_transaction.as_ref();
+
+        // One nonce scopes every snapshot created by this execution. PostgreSQL
+        // still relies on its session-local temp namespace; ClickHouse needs the
+        // nonce because its snapshot tables are database-global.
+        let attempt_id = generate_random_id(24).to_ascii_lowercase();
         let reversal_snapshots =
-            self.snapshot_for_reversal(postgres, clickhouse, rollback_plan).await?;
+            self.snapshot_for_reversal(pg, clickhouse, rollback_plan, &attempt_id).await?;
 
-        let mut affected_tx_hashes: Vec<String> = Vec::new();
-        let mut total_deleted = 0u64;
+        let rollback_result: anyhow::Result<(u64, Vec<String>)> = async {
+            let mut affected_tx_hashes = Vec::new();
+            let mut total_deleted = 0u64;
 
-        if let Some(pg) = postgres {
-            let table_names: Vec<&str> =
-                self.event_tables.iter().map(|t| t.full_name.as_str()).collect();
-            let checkpoint_tables: Vec<&str> =
-                self.event_tables.iter().map(|t| t.checkpoint_table.as_str()).collect();
-
-            let (deleted, tx_hashes) = pg
-                .reorg_rollback_transaction(
+            if let Some(pg) = pg {
+                let table_names =
+                    self.event_tables.iter().map(|t| t.full_name.as_str()).collect::<Vec<_>>();
+                let checkpoint_tables = self
+                    .event_tables
+                    .iter()
+                    .map(|t| t.checkpoint_table.as_str())
+                    .collect::<Vec<_>>();
+                let (deleted, tx_hashes) = PostgresClient::reorg_rollback_in_transaction(
+                    pg,
                     &table_names,
                     &self.network,
                     self.fork_point,
@@ -1325,96 +1505,103 @@ impl ReorgTask {
                 )
                 .await
                 .context("PostgreSQL reorg rollback transaction failed")?;
-            total_deleted = deleted;
-            affected_tx_hashes = tx_hashes;
-        }
-
-        if let Some(ch) = clickhouse {
-            let tables: Vec<(String, String)> = self
-                .event_tables
-                .iter()
-                .map(|t| (t.schema.clone(), t.table_name.clone()))
-                .collect();
-            let checkpoint_tables: Vec<String> =
-                self.event_tables.iter().map(|t| t.checkpoint_table.clone()).collect();
-
-            let (ch_deleted, ch_tx_hashes) = ch
-                .reorg_rollback(
-                    &tables,
-                    &self.network,
-                    self.fork_point,
-                    self.detection_point,
-                    &checkpoint_tables,
-                    &corrected_blocks,
-                )
-                .await
-                .context("ClickHouse reorg rollback failed")?;
-
-            if postgres.is_none() {
-                total_deleted = ch_deleted;
-                affected_tx_hashes = ch_tx_hashes;
-            } else if ch_deleted != total_deleted {
-                tracing::warn!(
-                    network = %self.network,
-                    postgres_deleted = total_deleted,
-                    clickhouse_deleted = ch_deleted,
-                    "Reorg rollback: postgres and clickhouse deleted counts differ"
-                );
-            }
-        }
-
-        // Phase 2: apply accumulative reversals from snapshots (after event deletion)
-        Self::apply_reversal_from_snapshots(&reversal_snapshots, postgres, clickhouse)
-            .await
-            .context("Accumulative reversal from snapshots failed")?;
-
-        // Phase 3: recalculate non-reversible columns (Set/Max/Min) from operation journal
-        self.recalculate_from_journal(postgres, clickhouse)
-            .await
-            .context("Journal recalculation failed")?;
-
-        // Phase 4: DELETE insert-only derived tables (no rollback_ops and no journal_columns)
-        for dt in &self.derived_tables {
-            if !dt.rollback_ops.is_empty() || !dt.journal_columns.is_empty() {
-                continue; // handled by reversal and/or journal recalculation
-            }
-            let network_filter = self.network_filter(dt.cross_chain);
-
-            if let Some(pg) = postgres {
-                let query = format!(
-                    "DELETE FROM {} WHERE rindexer_block_number >= {}{}",
-                    dt.full_table_name, self.fork_point, network_filter
-                );
-                pg.batch_execute(&query).await.with_context(|| {
-                    format!(
-                        "PostgreSQL: failed to delete derived table rows in {}",
-                        dt.full_table_name
-                    )
-                })?;
-                tracing::info!(
-                    "PostgreSQL: deleted derived table rows from block >= {} in {}",
-                    self.fork_point,
-                    dt.full_table_name
-                );
+                total_deleted = deleted;
+                affected_tx_hashes = tx_hashes;
             }
 
             if let Some(ch) = clickhouse {
-                let query = format!(
-                    "ALTER TABLE {} DELETE WHERE rindexer_block_number >= {}{} SETTINGS mutations_sync = 1",
-                    dt.full_table_name, self.fork_point, network_filter
-                );
-                ch.execute(&query).await.with_context(|| {
-                    format!(
-                        "ClickHouse: failed to delete derived table rows in {}",
-                        dt.full_table_name
+                let tables = self
+                    .event_tables
+                    .iter()
+                    .map(|t| (t.schema.clone(), t.table_name.clone()))
+                    .collect::<Vec<_>>();
+                let checkpoint_tables = self
+                    .event_tables
+                    .iter()
+                    .map(|t| t.checkpoint_table.clone())
+                    .collect::<Vec<_>>();
+                let (ch_deleted, ch_tx_hashes) = ch
+                    .reorg_rollback(
+                        &tables,
+                        &self.network,
+                        self.fork_point,
+                        self.detection_point,
+                        &checkpoint_tables,
+                        &corrected_blocks,
                     )
-                })?;
-                tracing::info!(
-                    "ClickHouse: deleted derived table rows from block >= {} in {}",
-                    self.fork_point,
-                    dt.full_table_name
-                );
+                    .await
+                    .context("ClickHouse reorg rollback failed")?;
+
+                if pg.is_none() {
+                    total_deleted = ch_deleted;
+                    affected_tx_hashes = ch_tx_hashes;
+                } else if ch_deleted != total_deleted {
+                    tracing::warn!(
+                        network = %self.network,
+                        postgres_deleted = total_deleted,
+                        clickhouse_deleted = ch_deleted,
+                        "Reorg rollback: postgres and clickhouse deleted counts differ"
+                    );
+                }
             }
+
+            Self::apply_reversal_from_snapshots(&reversal_snapshots, pg, clickhouse)
+                .await
+                .context("Accumulative reversal from snapshots failed")?;
+            self.recalculate_from_journal(pg, clickhouse)
+                .await
+                .context("Journal recalculation failed")?;
+
+            for dt in &self.derived_tables {
+                if !dt.rollback_ops.is_empty() || !dt.journal_columns.is_empty() {
+                    continue;
+                }
+                let network_filter = self.network_filter(dt.cross_chain);
+
+                if let Some(pg) = pg {
+                    let query = format!(
+                        "DELETE FROM {} WHERE rindexer_block_number >= {}{}",
+                        dt.full_table_name, self.fork_point, network_filter
+                    );
+                    pg.batch_execute(&query).await.with_context(|| {
+                        format!(
+                            "PostgreSQL: failed to delete derived table rows in {}",
+                            dt.full_table_name
+                        )
+                    })?;
+                    tracing::info!(
+                        "PostgreSQL: deleted derived table rows from block >= {} in {}",
+                        self.fork_point,
+                        dt.full_table_name
+                    );
+                }
+                if let Some(ch) = clickhouse {
+                    let query = format!(
+                        "ALTER TABLE {} DELETE WHERE rindexer_block_number >= {}{} SETTINGS mutations_sync = 1",
+                        dt.full_table_name, self.fork_point, network_filter
+                    );
+                    ch.execute(&query).await.with_context(|| {
+                        format!(
+                            "ClickHouse: failed to delete derived table rows in {}",
+                            dt.full_table_name
+                        )
+                    })?;
+                    tracing::info!(
+                        "ClickHouse: deleted derived table rows from block >= {} in {}",
+                        self.fork_point,
+                        dt.full_table_name
+                    );
+                }
+            }
+
+            Ok((total_deleted, affected_tx_hashes))
+        }
+        .await;
+
+        Self::cleanup_reversal_snapshots(&reversal_snapshots, pg, clickhouse).await;
+        let (total_deleted, affected_tx_hashes) = rollback_result?;
+        if let Some(transaction) = pg_transaction {
+            transaction.commit().await.context("PostgreSQL reorg commit failed")?;
         }
 
         // Update the in-memory window after all DB changes succeed.
@@ -1719,7 +1906,7 @@ mod tests {
 
         assert_eq!(
             source.from(&op.event_table),
-            "myschema.transfer_batch AS _rindexer_event CROSS JOIN LATERAL unnest(_rindexer_event.\"ids\", _rindexer_event.\"values\") AS _rindexer_iter(\"token_id\", \"amount\")"
+            "myschema.transfer_batch AS _rindexer_event CROSS JOIN LATERAL ROWS FROM (unnest(_rindexer_event.\"ids\"), unnest(_rindexer_event.\"values\")) AS _rindexer_iter(\"token_id\", \"amount\")"
         );
         assert_eq!(source.column("token_id"), "_rindexer_iter.\"token_id\"");
         assert_eq!(source.column("amount"), "_rindexer_iter.\"amount\"");

--- a/core/src/indexer/reorg/task.rs
+++ b/core/src/indexer/reorg/task.rs
@@ -1,11 +1,17 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use alloy::primitives::{B256, U64};
 use anyhow::Context;
 
 use crate::database::clickhouse::client::ClickhouseClient;
 use crate::database::postgres::client::PostgresClient;
-use crate::event::{parse_filter_expression, Accessor, ConditionLeft};
+use crate::event::{
+    parse_arithmetic_expression, parse_filter_expression, Accessor, ArithmeticExpr, ConditionLeft,
+    VariableSource,
+};
 use crate::helpers::camel_to_snake;
 use crate::manifest::contract::{ColumnType, IterateBinding, SetAction};
 use crate::metrics::indexing as metrics;
@@ -92,7 +98,7 @@ impl DerivedColumnRollback {
         action: SetAction,
     ) -> anyhow::Result<Self> {
         super::validate_sql_identifier(&derived_column, "derived column")?;
-        super::validate_sql_identifier(&event_column, "event column")?;
+        validate_event_operand(&event_column, "rollback event column")?;
         Ok(Self { derived_column, event_column, action })
     }
 }
@@ -108,12 +114,6 @@ pub struct DerivedTableRollbackOp {
     pub columns: Vec<DerivedColumnRollback>,
     /// Optional SQL condition re-evaluated against event data.
     pub condition: Option<String>,
-    /// Array bindings expanded by the forward custom-table operation.
-    pub iterate: Vec<IterateBinding>,
-    /// Semantic types of source event columns and iterate aliases.
-    pub source_column_types: HashMap<String, ColumnType>,
-    /// Resolved semantic types of derived-table columns.
-    pub derived_column_types: HashMap<String, ColumnType>,
 }
 
 impl DerivedTableRollbackOp {
@@ -132,25 +132,55 @@ impl DerivedTableRollbackOp {
         }
         for (dt_col, ev_col) in &where_columns {
             super::validate_sql_identifier(dt_col, "rollback op WHERE derived column")?;
-            super::validate_sql_identifier(ev_col, "rollback op WHERE event column")?;
+            validate_event_operand(ev_col, "rollback op WHERE event column")?;
         }
         if let Some(cond) = &condition {
             validate_sql_condition(cond)?;
         }
-        Ok(Self {
-            event_table,
-            where_columns,
-            columns,
-            condition,
-            iterate: Vec::new(),
-            source_column_types: HashMap::new(),
-            derived_column_types: HashMap::new(),
-        })
+        Ok(Self { event_table, where_columns, columns, condition })
     }
+}
 
-    /// Attach the array bindings used by the forward custom-table operation.
-    pub fn with_iterate(mut self, bindings: Vec<IterateBinding>) -> anyhow::Result<Self> {
-        let mut normalized = Vec::with_capacity(bindings.len());
+/// Optional execution metadata for custom-table rollback operations.
+///
+/// This sidecar keeps [`DerivedTableRollbackOp`] source-compatible for callers
+/// that construct it with struct literals. Operation indexes correspond to the
+/// order of `DerivedTableInfo::rollback_ops` for the named table.
+#[derive(Clone, Debug, Default)]
+pub struct DerivedTableRollbackPlan {
+    operations: HashMap<String, HashMap<usize, DerivedTableRollbackMetadata>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DerivedTableRollbackMetadata {
+    pub(crate) iterate: Vec<IterateBinding>,
+    pub(crate) source_column_types: HashMap<String, ColumnType>,
+    pub(crate) derived_column_types: HashMap<String, ColumnType>,
+}
+
+impl DerivedTableRollbackPlan {
+    /// Add metadata for one rollback operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the table name or iterate bindings are invalid,
+    /// or when metadata was already registered for the same operation index.
+    pub fn try_add_operation(
+        &mut self,
+        derived_table: String,
+        operation_index: usize,
+        bindings: Vec<IterateBinding>,
+        mut source_column_types: HashMap<String, ColumnType>,
+        derived_column_types: HashMap<String, ColumnType>,
+    ) -> anyhow::Result<()> {
+        if let Some((schema, table)) = derived_table.split_once('.') {
+            super::validate_sql_identifier(schema, "rollback plan derived table schema")?;
+            super::validate_sql_identifier(table, "rollback plan derived table name")?;
+        } else {
+            super::validate_sql_identifier(&derived_table, "rollback plan derived table name")?;
+        }
+
+        let mut iterate = Vec::with_capacity(bindings.len());
         for binding in bindings {
             let binding = IterateBinding {
                 array_field: event_field_to_db_column(&binding.array_field),
@@ -159,33 +189,38 @@ impl DerivedTableRollbackOp {
             super::validate_sql_identifier(&binding.array_field, "rollback iterate array column")?;
             super::validate_sql_identifier(&binding.alias, "rollback iterate alias")?;
             anyhow::ensure!(
-                !normalized.iter().any(|existing: &IterateBinding| existing.alias == binding.alias),
+                !iterate.iter().any(|existing: &IterateBinding| existing.alias == binding.alias),
                 "duplicate rollback iterate alias '{}'",
                 binding.alias
             );
-            normalized.push(binding);
-        }
-        self.iterate = normalized;
-        Ok(self)
-    }
-
-    /// Attach the ABI-derived source types and resolved custom-table types used
-    /// to preserve forward-path coercions during rollback SQL rendering.
-    pub fn with_column_types(
-        mut self,
-        mut source_column_types: HashMap<String, ColumnType>,
-        derived_column_types: HashMap<String, ColumnType>,
-    ) -> Self {
-        for binding in &self.iterate {
             if let Some(ColumnType::Array(inner)) =
                 source_column_types.get(&binding.array_field).cloned()
             {
                 source_column_types.insert(binding.alias.clone(), *inner);
             }
+            iterate.push(binding);
         }
-        self.source_column_types = source_column_types;
-        self.derived_column_types = derived_column_types;
-        self
+
+        let table_operations = self.operations.entry(derived_table.clone()).or_default();
+        anyhow::ensure!(
+            !table_operations.contains_key(&operation_index),
+            "duplicate rollback metadata for table '{}' operation {}",
+            derived_table,
+            operation_index
+        );
+        table_operations.insert(
+            operation_index,
+            DerivedTableRollbackMetadata { iterate, source_column_types, derived_column_types },
+        );
+        Ok(())
+    }
+
+    pub(crate) fn operation(
+        &self,
+        derived_table: &str,
+        operation_index: usize,
+    ) -> Option<&DerivedTableRollbackMetadata> {
+        self.operations.get(derived_table)?.get(&operation_index)
     }
 }
 
@@ -355,6 +390,23 @@ fn event_field_to_db_column(field: &str) -> String {
     }
 }
 
+fn parse_event_operand<'a>(operand: &'a str, kind: &str) -> anyhow::Result<ConditionLeft<'a>> {
+    let expression = parse_arithmetic_expression(operand)
+        .map_err(|error| anyhow::anyhow!("invalid {kind} '{operand}': {error}"))?;
+    let ArithmeticExpr::Variable(variable) = expression else {
+        anyhow::bail!("{kind} '{operand}' must be a single event-field reference");
+    };
+    anyhow::ensure!(
+        variable.source() == VariableSource::Event,
+        "{kind} '{operand}' must reference event data, not table state"
+    );
+    Ok(variable)
+}
+
+fn validate_event_operand(operand: &str, kind: &str) -> anyhow::Result<()> {
+    parse_event_operand(operand, kind).map(|_| ())
+}
+
 struct ReversalSource<'a> {
     dialect: SqlDialect,
     iterate: &'a [IterateBinding],
@@ -378,7 +430,7 @@ impl ReversalSource<'_> {
         }
     }
 
-    fn condition_variable(&self, variable: &ConditionLeft<'_>) -> String {
+    fn variable_expression(&self, variable: &ConditionLeft<'_>) -> String {
         let mut field_parts = vec![variable.base_name()];
         let mut accessors = variable.accessors().iter().peekable();
 
@@ -441,6 +493,33 @@ impl ReversalSource<'_> {
         }
     }
 
+    fn operand(&self, operand: &str) -> anyhow::Result<String> {
+        let variable = parse_event_operand(operand, "rollback operand")?;
+        Ok(self.variable_expression(&variable))
+    }
+
+    fn iterate_length_mismatch(&self) -> Option<String> {
+        let (first, rest) = self.iterate.split_first()?;
+        if rest.is_empty() {
+            return None;
+        }
+
+        let length = |binding: &IterateBinding| {
+            let column = format!("_rindexer_event.{}", self.dialect.quote(&binding.array_field));
+            match self.dialect {
+                SqlDialect::Postgres => format!("COALESCE(cardinality({}), -1)", column),
+                SqlDialect::Clickhouse => format!("length({})", column),
+            }
+        };
+        let first_length = length(first);
+        Some(
+            rest.iter()
+                .map(|binding| format!("{} <> {}", first_length, length(binding)))
+                .collect::<Vec<_>>()
+                .join(" OR "),
+        )
+    }
+
     fn from(&self, event_table: &str) -> String {
         if self.iterate.is_empty() {
             return format!("{} AS _rindexer_event", event_table);
@@ -474,9 +553,21 @@ impl ReversalSource<'_> {
     }
 }
 
-fn render_reorg_condition(condition: &str, source: &ReversalSource<'_>) -> Option<String> {
-    let expression = parse_filter_expression(condition).ok()?;
-    expression.to_sql_event_condition(|variable| source.condition_variable(variable))
+fn render_reorg_condition(condition: &str, source: &ReversalSource<'_>) -> anyhow::Result<String> {
+    let expression = match parse_filter_expression(condition) {
+        Ok(expression) => expression,
+        Err(_) => {
+            validate_sql_condition(condition)?;
+            return Ok(condition.to_string());
+        }
+    };
+    anyhow::ensure!(
+        !expression.has_table_references(),
+        "rollback condition '{condition}' references table state, which cannot be reconstructed from raw events"
+    );
+    expression
+        .to_sql_event_condition(|variable| source.variable_expression(variable))
+        .ok_or_else(|| anyhow::anyhow!("rollback condition '{condition}' did not produce SQL"))
 }
 
 impl ReorgTask {
@@ -489,6 +580,70 @@ impl ReorgTask {
         }
     }
 
+    async fn validate_iterate_lengths(
+        &self,
+        pg: Option<&PostgresClient>,
+        ch: Option<&Arc<ClickhouseClient>>,
+        rollback_plan: &DerivedTableRollbackPlan,
+    ) -> anyhow::Result<()> {
+        let mut checked_pg = HashSet::new();
+        let mut checked_ch = HashSet::new();
+
+        for dt in &self.derived_tables {
+            for (op_index, op) in dt.rollback_ops.iter().enumerate() {
+                let Some(metadata) = rollback_plan.operation(&dt.full_table_name, op_index) else {
+                    continue;
+                };
+                for dialect in [SqlDialect::Postgres, SqlDialect::Clickhouse] {
+                    let source = ReversalSource {
+                        dialect,
+                        iterate: &metadata.iterate,
+                        source_column_types: &metadata.source_column_types,
+                    };
+                    let Some(mismatch) = source.iterate_length_mismatch() else {
+                        continue;
+                    };
+                    let query = format!(
+                        "SELECT count(*) FROM {} AS _rindexer_event WHERE _rindexer_event.{} >= {} AND _rindexer_event.{} <= {} AND _rindexer_event.{} = '{}' AND ({})",
+                        op.event_table,
+                        dialect.quote("block_number"),
+                        self.fork_point,
+                        dialect.quote("block_number"),
+                        self.detection_point,
+                        dialect.quote("network"),
+                        self.network,
+                        mismatch,
+                    );
+
+                    let mismatch_count = match (dialect, pg, ch) {
+                        (SqlDialect::Postgres, Some(pg), _) if checked_pg.insert(query.clone()) => {
+                            pg.query_one(&query, &[])
+                                .await
+                                .context("failed to validate PostgreSQL rollback iterate lengths")?
+                                .get::<_, i64>(0) as u64
+                        }
+                        (SqlDialect::Clickhouse, _, Some(ch))
+                            if checked_ch.insert(query.clone()) =>
+                        {
+                            ch.query_one::<u64>(&query)
+                                .await
+                                .context("failed to validate ClickHouse rollback iterate lengths")?
+                        }
+                        _ => continue,
+                    };
+                    anyhow::ensure!(
+                        mismatch_count == 0,
+                        "rollback iterate arrays have unequal lengths in {} between blocks {} and {}; aborting before event deletion",
+                        op.event_table,
+                        self.fork_point,
+                        self.detection_point,
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Phase 1: Before event deletion, snapshot aggregated event data into temp tables.
     /// Returns the snapshots needed for phase 2.
     /// Fails the entire reorg task if any snapshot cannot be created — this prevents
@@ -497,12 +652,25 @@ impl ReorgTask {
         &self,
         pg: Option<&PostgresClient>,
         ch: Option<&Arc<ClickhouseClient>>,
+        rollback_plan: &DerivedTableRollbackPlan,
     ) -> anyhow::Result<Vec<ReversalSnapshot>> {
+        self.validate_iterate_lengths(pg, ch, rollback_plan).await?;
+
         let mut snapshots = Vec::new();
         let mut snap_idx = 0usize;
+        let empty_column_types = HashMap::new();
 
         for dt in &self.derived_tables {
-            for op in &dt.rollback_ops {
+            for (op_index, op) in dt.rollback_ops.iter().enumerate() {
+                let metadata = rollback_plan.operation(&dt.full_table_name, op_index);
+                let iterate = metadata.map_or(&[][..], |metadata| metadata.iterate.as_slice());
+                let source_column_types = metadata
+                    .map(|metadata| &metadata.source_column_types)
+                    .unwrap_or(&empty_column_types);
+                let derived_column_types = metadata
+                    .map(|metadata| &metadata.derived_column_types)
+                    .unwrap_or(&empty_column_types);
+
                 // (is_counter, source event column, derived column, agg alias) per reversible
                 // column. The SELECT aggregate is assembled per-backend so each
                 // can quote identifiers with its own convention.
@@ -552,8 +720,14 @@ impl ReorgTask {
                     continue;
                 }
 
-                let where_ev_cols: Vec<&str> =
-                    op.where_columns.iter().map(|(_, ev_col)| ev_col.as_str()).collect();
+                let snapshot_where_columns = op
+                    .where_columns
+                    .iter()
+                    .enumerate()
+                    .map(|(index, (derived_column, _))| {
+                        (derived_column.clone(), format!("_rindexer_where_{}", index))
+                    })
+                    .collect::<Vec<_>>();
 
                 // Include network + fork_point in temp table name to avoid collisions
                 // across concurrent reorg tasks on different networks.
@@ -569,76 +743,82 @@ impl ReorgTask {
                 // columns are user-controlled identifiers that may collide with SQL
                 // reserved words (e.g. `to`, `from`), so each backend quotes them with
                 // its own convention (Postgres double quotes, ClickHouse backticks).
-                let build_select = |dialect: SqlDialect| {
-                    let source = ReversalSource {
-                        dialect,
-                        iterate: &op.iterate,
-                        source_column_types: &op.source_column_types,
-                    };
+                let build_select = |dialect: SqlDialect| -> anyhow::Result<String> {
+                    let source = ReversalSource { dialect, iterate, source_column_types };
                     let group_expressions = op
                         .where_columns
                         .iter()
                         .map(|(derived_column, event_column)| {
-                            let expression = source.column(event_column);
-                            match op.derived_column_types.get(derived_column) {
+                            let expression = source.operand(event_column)?;
+                            Ok(match derived_column_types.get(derived_column) {
                                 Some(column_type) => dialect.cast(expression, column_type),
                                 None => expression,
-                            }
+                            })
                         })
-                        .collect::<Vec<_>>();
+                        .collect::<anyhow::Result<Vec<_>>>()?;
                     let group = group_expressions.join(", ");
-                    let mut group_select = where_ev_cols
+                    let mut group_select = snapshot_where_columns
                         .iter()
                         .zip(&group_expressions)
-                        .map(|(column, expression)| {
-                            format!("{} AS {}", expression, dialect.quote(column))
+                        .map(|((_, snapshot_column), expression)| {
+                            format!("{} AS {}", expression, dialect.quote(snapshot_column))
                         })
                         .collect::<Vec<_>>();
                     if matches!(dialect, SqlDialect::Clickhouse) {
                         // Older ClickHouse StorageJoin implementations reject
                         // composite and UInt256 keys. A single serialized tuple
                         // supports the full range of custom-table key types.
-                        group_select
-                            .push(format!("toJSONString(tuple({})) AS _rindexer_key", group));
+                        let key = if group.is_empty() {
+                            "''".to_string()
+                        } else {
+                            format!("toJSONString(tuple({}))", group)
+                        };
+                        group_select.push(format!("{} AS _rindexer_key", key));
                     }
                     let group_select = group_select.join(", ");
                     let aggs = agg_specs
                         .iter()
                         .map(|(is_counter, event_column, derived_column, alias)| {
                             if *is_counter {
-                                format!("COUNT(*) AS {}", alias)
+                                Ok(format!("COUNT(*) AS {}", alias))
                             } else {
-                                let expression = source.column(event_column);
-                                let expression = match op.derived_column_types.get(derived_column) {
+                                let expression = source.operand(event_column)?;
+                                let expression = match derived_column_types.get(derived_column) {
                                     Some(column_type) => dialect.cast(expression, column_type),
                                     None => expression,
                                 };
-                                format!("SUM({}) AS {}", expression, alias)
+                                Ok(format!("SUM({}) AS {}", expression, alias))
                             }
                         })
-                        .collect::<Vec<_>>()
+                        .collect::<anyhow::Result<Vec<_>>>()?
                         .join(", ");
-                    let network_filter = if dt.cross_chain {
-                        String::new()
-                    } else {
-                        format!(
-                            " AND _rindexer_event.{} = '{}'",
-                            dialect.quote("network"),
-                            self.network
-                        )
-                    };
+                    // The source event table is always network-scoped, even when
+                    // the derived table combines contributions across networks.
+                    let network_filter = format!(
+                        " AND _rindexer_event.{} = '{}'",
+                        dialect.quote("network"),
+                        self.network
+                    );
                     let condition_filter = match &op.condition {
                         Some(condition) => {
-                            let condition = render_reorg_condition(condition, &source)
-                                .unwrap_or_else(|| condition.clone());
+                            let condition = render_reorg_condition(condition, &source)?;
                             format!(" AND ({})", condition)
                         }
                         None => String::new(),
                     };
-                    format!(
-                        "SELECT {}, {} FROM {} WHERE _rindexer_event.{} >= {} AND _rindexer_event.{} <= {}{}{} GROUP BY {}",
-                        group_select,
-                        aggs,
+                    let select = if group_select.is_empty() {
+                        aggs
+                    } else {
+                        format!("{}, {}", group_select, aggs)
+                    };
+                    let group_by = if group.is_empty() {
+                        " HAVING COUNT(*) > 0".to_string()
+                    } else {
+                        format!(" GROUP BY {}", group)
+                    };
+                    Ok(format!(
+                        "SELECT {} FROM {} WHERE _rindexer_event.{} >= {} AND _rindexer_event.{} <= {}{}{}{}",
+                        select,
                         source.from(&op.event_table),
                         dialect.quote("block_number"),
                         self.fork_point,
@@ -646,8 +826,8 @@ impl ReorgTask {
                         self.detection_point,
                         network_filter,
                         condition_filter,
-                        group,
-                    )
+                        group_by,
+                    ))
                 };
 
                 if let Some(pg) = pg {
@@ -655,7 +835,7 @@ impl ReorgTask {
                     let pg_create = format!(
                         "CREATE TEMP TABLE {} AS {}",
                         pg_temp,
-                        build_select(SqlDialect::Postgres)
+                        build_select(SqlDialect::Postgres)?
                     );
                     pg.batch_execute(&pg_create).await.with_context(|| {
                         format!(
@@ -670,7 +850,7 @@ impl ReorgTask {
                         derived_table: dt.full_table_name.clone(),
                         cross_chain: dt.cross_chain,
                         network: self.network.clone(),
-                        where_columns: op.where_columns.clone(),
+                        where_columns: snapshot_where_columns.clone(),
                         set_ops: set_ops.clone(),
                     });
                 }
@@ -685,7 +865,7 @@ impl ReorgTask {
                     let ch_create = format!(
                         "CREATE TABLE IF NOT EXISTS {} ENGINE = Join(ANY, LEFT, _rindexer_key) AS {}",
                         ch_temp,
-                        build_select(SqlDialect::Clickhouse),
+                        build_select(SqlDialect::Clickhouse)?,
                     );
                     ch.execute(&ch_create).await.with_context(|| {
                         format!(
@@ -700,7 +880,7 @@ impl ReorgTask {
                         derived_table: dt.full_table_name.clone(),
                         cross_chain: dt.cross_chain,
                         network: self.network.clone(),
-                        where_columns: op.where_columns.clone(),
+                        where_columns: snapshot_where_columns,
                         set_ops,
                     });
                 }
@@ -725,12 +905,6 @@ impl ReorgTask {
                 })
                 .collect();
 
-            let network_join = if snap.cross_chain {
-                String::new()
-            } else {
-                format!(" AND dt.network = '{}'", snap.network)
-            };
-
             match snap.backend {
                 SnapshotBackend::Postgres => {
                     let Some(pg) = pg else { continue };
@@ -742,13 +916,21 @@ impl ReorgTask {
                             format!("{} = dt.{} {} snap.{}", col, col, s.op_symbol, s.agg_alias)
                         })
                         .collect();
+                    let mut pg_scope = where_join.clone();
+                    if !snap.cross_chain {
+                        pg_scope.push(format!("dt.network = '{}'", snap.network));
+                    }
+                    let pg_scope = if pg_scope.is_empty() {
+                        "TRUE".to_string()
+                    } else {
+                        pg_scope.join(" AND ")
+                    };
                     let update_sql = format!(
-                        "UPDATE {} AS dt SET {} FROM {} AS snap WHERE {}{}",
+                        "UPDATE {} AS dt SET {} FROM {} AS snap WHERE {}",
                         snap.derived_table,
                         pg_set_clauses.join(", "),
                         snap.temp_table,
-                        where_join.join(" AND "),
-                        network_join,
+                        pg_scope,
                     );
                     pg.batch_execute(&update_sql).await.with_context(|| {
                         format!(
@@ -776,7 +958,11 @@ impl ReorgTask {
                         .map(|(dt_col, _)| quote_ch_ident(dt_col))
                         .collect::<Vec<_>>()
                         .join(", ");
-                    let join_get_key = format!("toJSONString(tuple({}))", dt_keys);
+                    let join_get_key = if dt_keys.is_empty() {
+                        "''".to_string()
+                    } else {
+                        format!("toJSONString(tuple({}))", dt_keys)
+                    };
 
                     // Build CH set clauses directly from the structured ops: the
                     // per-row aggregate is looked up via joinGet() against the
@@ -1052,6 +1238,24 @@ impl ReorgTask {
         clickhouse: Option<&Arc<ClickhouseClient>>,
         provider: Option<&Arc<dyn ChainProvider>>,
     ) -> anyhow::Result<ReorgTaskResult> {
+        let rollback_plan = DerivedTableRollbackPlan::default();
+        self.execute_with_rollback_plan(window, postgres, clickhouse, provider, &rollback_plan)
+            .await
+    }
+
+    /// Execute a reorg with optional iterate and type metadata for derived-table rollback.
+    ///
+    /// Existing callers can continue using [`Self::execute`]. This additive entry point
+    /// is used by the runtime-generated coordinator plan and by integrations that need
+    /// custom-table iterate rollback without changing `ReorgTask` struct literals.
+    pub async fn execute_with_rollback_plan(
+        &self,
+        window: &mut BlockChainWindow,
+        postgres: Option<&PostgresClient>,
+        clickhouse: Option<&Arc<ClickhouseClient>>,
+        provider: Option<&Arc<dyn ChainProvider>>,
+        rollback_plan: &DerivedTableRollbackPlan,
+    ) -> anyhow::Result<ReorgTaskResult> {
         // Validate network before any SQL interpolation
         super::validate_sql_value(&self.network, "reorg task network")?;
 
@@ -1098,7 +1302,8 @@ impl ReorgTask {
             corrected_blocks_owned.iter().map(|(n, h, p)| (*n, h.as_str(), p.as_str())).collect();
 
         // Phase 1: snapshot event data for accumulative reversal (before deletion)
-        let reversal_snapshots = self.snapshot_for_reversal(postgres, clickhouse).await?;
+        let reversal_snapshots =
+            self.snapshot_for_reversal(postgres, clickhouse, rollback_plan).await?;
 
         let mut affected_tx_hashes: Vec<String> = Vec::new();
         let mut total_deleted = 0u64;
@@ -1471,7 +1676,6 @@ mod tests {
         assert_eq!(op.where_columns.len(), 1);
         assert_eq!(op.columns.len(), 1);
         assert!(op.condition.is_none());
-        assert!(op.iterate.is_empty());
     }
 
     #[test]
@@ -1487,13 +1691,15 @@ mod tests {
             .unwrap()],
             Some("$to != 0x0000000000000000000000000000000000000000".to_string()),
         )
-        .unwrap()
-        .with_iterate(vec![
-            IterateBinding::parse("$ids as token_id").unwrap(),
-            IterateBinding::parse("$values as amount").unwrap(),
-        ])
-        .unwrap()
-        .with_column_types(
+        .unwrap();
+        let mut plan = DerivedTableRollbackPlan::default();
+        plan.try_add_operation(
+            "myschema.balances".to_string(),
+            0,
+            vec![
+                IterateBinding::parse("$ids as token_id").unwrap(),
+                IterateBinding::parse("$values as amount").unwrap(),
+            ],
             HashMap::from([
                 ("ids".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
                 ("values".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
@@ -1502,11 +1708,13 @@ mod tests {
                 ("token_id".to_string(), ColumnType::Uint256),
                 ("balance".to_string(), ColumnType::Uint256),
             ]),
-        );
+        )
+        .unwrap();
+        let metadata = plan.operation("myschema.balances", 0).unwrap();
         let source = ReversalSource {
             dialect: SqlDialect::Postgres,
-            iterate: &op.iterate,
-            source_column_types: &op.source_column_types,
+            iterate: &metadata.iterate,
+            source_column_types: &metadata.source_column_types,
         };
 
         assert_eq!(
@@ -1515,6 +1723,12 @@ mod tests {
         );
         assert_eq!(source.column("token_id"), "_rindexer_iter.\"token_id\"");
         assert_eq!(source.column("amount"), "_rindexer_iter.\"amount\"");
+        assert_eq!(
+            source.iterate_length_mismatch().as_deref(),
+            Some(
+                "COALESCE(cardinality(_rindexer_event.\"ids\"), -1) <> COALESCE(cardinality(_rindexer_event.\"values\"), -1)"
+            )
+        );
         assert_eq!(
             render_reorg_condition(op.condition.as_deref().unwrap(), &source).unwrap(),
             "_rindexer_event.\"to\" <> '0x0000000000000000000000000000000000000000'"
@@ -1553,6 +1767,23 @@ mod tests {
         assert_eq!(
             render_reorg_condition("$ids[0] > 0", &ch_source).unwrap(),
             "arrayElement(_rindexer_event.`ids`, 1) > 0"
+        );
+        assert_eq!(
+            pg_source.operand("data.amount").unwrap(),
+            "CAST(_rindexer_event.\"data_amount\" AS NUMERIC)"
+        );
+        assert_eq!(
+            pg_source.operand("ids[0]").unwrap(),
+            "CAST((_rindexer_event.\"ids\")[1] AS NUMERIC)"
+        );
+        assert!(
+            render_reorg_condition("$ids[0] > @balance", &pg_source).is_err(),
+            "table-state conditions must fail before raw events are deleted"
+        );
+        assert_eq!(
+            render_reorg_condition("id::NUMERIC > 7", &pg_source).unwrap(),
+            "id::NUMERIC > 7",
+            "validated legacy SQL conditions remain compatible"
         );
     }
 

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -21,8 +21,8 @@ use crate::helpers::{camel_to_snake, format_duration};
 use crate::indexer::native_transfer::native_transfer_block_processor;
 use crate::indexer::reorg::{
     reorg_safe_distance_for_chain, BlockChainWindow, DerivedColumnJournal, DerivedColumnRollback,
-    DerivedTableInfo, DerivedTableRollbackOp, EventTableInfo, ReorgBlockHashPersistence,
-    ReorgContext, ReorgCoordinator,
+    DerivedTableInfo, DerivedTableRollbackOp, DerivedTableRollbackPlan, EventTableInfo,
+    ReorgBlockHashPersistence, ReorgContext, ReorgCoordinator,
 };
 use crate::indexer::Indexer;
 use crate::manifest::network::ReorgHandlingConfig;
@@ -507,6 +507,11 @@ fn event_source_column_types(
 /// Build derived-table rollback + journal entries for an event's tables and merge
 /// them into `accumulator` keyed by `network`. Shared between contract events and
 /// native-transfer trace events so both sources contribute to reorg rollback.
+struct DerivedTableRollbackAccumulators<'a> {
+    tables: &'a mut HashMap<String, Vec<DerivedTableInfo>>,
+    plans: &'a mut HashMap<String, DerivedTableRollbackPlan>,
+}
+
 fn build_derived_tables_for_event(
     event_name: &str,
     indexer_name: &str,
@@ -514,13 +519,13 @@ fn build_derived_tables_for_event(
     network: &str,
     source_column_types: &HashMap<String, ColumnType>,
     tables: &[crate::indexer::tables::TableRuntime],
-    accumulator: &mut HashMap<String, Vec<DerivedTableInfo>>,
+    accumulator: &mut DerivedTableRollbackAccumulators<'_>,
 ) -> anyhow::Result<()> {
     let schema = generate_indexer_contract_schema_name(indexer_name, contract_name);
     let event_table_full = format!("{}.{}", schema, camel_to_snake(event_name));
 
     for tr in tables.iter() {
-        let derived = accumulator.entry(network.to_string()).or_default();
+        let derived = accumulator.tables.entry(network.to_string()).or_default();
         let derived_column_types = tr
             .table
             .columns
@@ -532,6 +537,7 @@ fn build_derived_tables_for_event(
 
         let event_table_name = event_table_full.clone();
         let mut rollback_ops: Vec<DerivedTableRollbackOp> = Vec::new();
+        let mut rollback_metadata = Vec::new();
         let mut journal_columns: Vec<DerivedColumnJournal> = Vec::new();
 
         for table_event in &tr.table.events {
@@ -551,24 +557,31 @@ fn build_derived_tables_for_event(
                     .where_clause
                     .iter()
                     .filter_map(|(col, val)| {
-                        val.strip_prefix('$').map(|field| (col.clone(), camel_to_snake(field)))
+                        val.strip_prefix('$').map(|field| (col.clone(), field.to_string()))
                     })
                     .collect();
                 where_columns.sort_by(|a, b| a.0.cmp(&b.0));
 
-                let where_col_names: Vec<String> =
-                    where_columns.iter().map(|(col, _)| col.clone()).collect();
+                let mut where_col_names =
+                    operation.where_clause.keys().cloned().collect::<Vec<_>>();
+                where_col_names.sort();
 
                 let columns: Vec<DerivedColumnRollback> = operation
                     .set
                     .iter()
                     .filter(|set_col| {
-                        set_col.action.reverse().is_some() && set_col.event_field_name().is_some()
+                        set_col.action.reverse().is_some()
+                            && (set_col.action.is_counter_action()
+                                || set_col.event_field_name().is_some())
                     })
                     .map(|set_col| {
+                        let event_field = set_col
+                            .event_field_name()
+                            .unwrap_or("rindexer_block_number")
+                            .to_string();
                         DerivedColumnRollback::try_new(
                             set_col.column.clone(),
-                            camel_to_snake(set_col.event_field_name().unwrap()),
+                            event_field,
                             set_col.action.clone(),
                         )
                     })
@@ -589,32 +602,38 @@ fn build_derived_tables_for_event(
                 }
 
                 if !columns.is_empty() {
-                    rollback_ops.push(
-                        DerivedTableRollbackOp::try_new(
-                            event_table_name.clone(),
-                            where_columns,
-                            columns,
-                            operation.condition().map(String::from),
-                        )?
-                        .with_iterate(table_event.iterate.clone())?
-                        .with_column_types(
-                            source_column_types.clone(),
-                            derived_column_types.clone(),
-                        ),
+                    anyhow::ensure!(
+                        where_columns.len() == operation.where_clause.len(),
+                        "reorg rollback for {} requires every WHERE value to be a single event-field reference",
+                        tr.full_table_name,
                     );
+                    rollback_ops.push(DerivedTableRollbackOp::try_new(
+                        event_table_name.clone(),
+                        where_columns,
+                        columns,
+                        operation.condition().map(String::from),
+                    )?);
+                    rollback_metadata.push((
+                        table_event.iterate.clone(),
+                        source_column_types.clone(),
+                        derived_column_types.clone(),
+                    ));
                 }
             }
         }
 
         // Merge into existing entry or create a new one
-        if let Some(existing) = derived.iter_mut().find(|d| d.full_table_name == tr.full_table_name)
+        let operation_offset = if let Some(existing) =
+            derived.iter_mut().find(|d| d.full_table_name == tr.full_table_name)
         {
+            let operation_offset = existing.rollback_ops.len();
             existing.rollback_ops.extend(rollback_ops);
             for jc in journal_columns {
                 if !existing.journal_columns.iter().any(|e| e.derived_column == jc.derived_column) {
                     existing.journal_columns.push(jc);
                 }
             }
+            operation_offset
         } else {
             derived.push(DerivedTableInfo::try_new(
                 tr.full_table_name.clone(),
@@ -622,6 +641,20 @@ fn build_derived_tables_for_event(
                 rollback_ops,
                 journal_columns,
             )?);
+            0
+        };
+
+        let rollback_plan = accumulator.plans.entry(network.to_string()).or_default();
+        for (operation_index, (iterate, source_types, derived_types)) in
+            rollback_metadata.into_iter().enumerate()
+        {
+            rollback_plan.try_add_operation(
+                tr.full_table_name.clone(),
+                operation_offset + operation_index,
+                iterate,
+                source_types,
+                derived_types,
+            )?;
         }
     }
 
@@ -743,6 +776,7 @@ async fn start_indexing_contract_events(
     // Build per-network event tables and derived tables for reorg rollback.
     let mut network_event_tables: HashMap<String, Vec<EventTableInfo>> = HashMap::new();
     let mut network_derived_tables: HashMap<String, Vec<DerivedTableInfo>> = HashMap::new();
+    let mut network_rollback_plans: HashMap<String, DerivedTableRollbackPlan> = HashMap::new();
     for event in registry.events.iter() {
         let source_column_types = if event.tables.is_empty() {
             HashMap::new()
@@ -777,7 +811,10 @@ async fn start_indexing_contract_events(
                 &network_contract.network,
                 &source_column_types,
                 &event.tables,
-                &mut network_derived_tables,
+                &mut DerivedTableRollbackAccumulators {
+                    tables: &mut network_derived_tables,
+                    plans: &mut network_rollback_plans,
+                },
             )?;
         }
     }
@@ -828,7 +865,10 @@ async fn start_indexing_contract_events(
                     &network_detail.network,
                     &source_column_types,
                     &trace_event.tables,
-                    &mut network_derived_tables,
+                    &mut DerivedTableRollbackAccumulators {
+                        tables: &mut network_derived_tables,
+                        plans: &mut network_rollback_plans,
+                    },
                 )?;
             }
         }
@@ -884,6 +924,8 @@ async fn start_indexing_contract_events(
         if let Some(provider) = provider {
             let derived_tables =
                 network_derived_tables.get(network_name).cloned().unwrap_or_default();
+            let rollback_plan =
+                network_rollback_plans.get(network_name).cloned().unwrap_or_default();
             let streams_clients =
                 collect_streams_clients_for_network(&registry, &trace_registry, network_name);
             register_network_reorg_distance_on_streams(
@@ -901,7 +943,8 @@ async fn start_indexing_contract_events(
                 event_tables,
                 derived_tables,
                 streams_clients,
-            )?;
+            )?
+            .with_rollback_plan(rollback_plan);
 
             // Run startup validation
             match coordinator.validate_on_startup().await {
@@ -1190,6 +1233,8 @@ async fn start_indexing_contract_events(
                 if let Some(provider) = provider {
                     let derived_tables =
                         network_derived_tables.get(network_name).cloned().unwrap_or_default();
+                    let rollback_plan =
+                        network_rollback_plans.get(network_name).cloned().unwrap_or_default();
                     let streams_clients = collect_streams_clients_for_network(
                         &registry,
                         &trace_registry,
@@ -1210,7 +1255,8 @@ async fn start_indexing_contract_events(
                         event_tables,
                         derived_tables,
                         streams_clients,
-                    )?;
+                    )?
+                    .with_rollback_plan(rollback_plan);
 
                     match coordinator.validate_on_startup().await {
                         Ok(Some(startup_task)) => {
@@ -2045,6 +2091,7 @@ mod tests {
         ]);
 
         let mut accumulator: HashMap<String, Vec<DerivedTableInfo>> = HashMap::new();
+        let mut rollback_plans = HashMap::new();
         build_derived_tables_for_event(
             "NativeTransfer",
             "test_indexer",
@@ -2052,7 +2099,10 @@ mod tests {
             "anvil",
             &source_column_types,
             &tables,
-            &mut accumulator,
+            &mut DerivedTableRollbackAccumulators {
+                tables: &mut accumulator,
+                plans: &mut rollback_plans,
+            },
         )
         .expect("build_derived_tables_for_event should succeed");
 
@@ -2116,6 +2166,7 @@ events:
 
         let runtime = TableRuntime::new(table, "test_indexer", "ConditionalTokens");
         let mut accumulator = HashMap::new();
+        let mut rollback_plans = HashMap::new();
         let source_column_types = HashMap::from([
             ("to".to_string(), ColumnType::Address),
             ("ids".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
@@ -2128,21 +2179,137 @@ events:
             "polygon",
             &source_column_types,
             &[runtime],
-            &mut accumulator,
+            &mut DerivedTableRollbackAccumulators {
+                tables: &mut accumulator,
+                plans: &mut rollback_plans,
+            },
         )
         .expect("TransferBatch rollback metadata should compile");
 
         let rollback = &accumulator["polygon"][0].rollback_ops[0];
         assert_eq!(rollback.where_columns[0].1, "token_id");
         assert_eq!(rollback.columns[0].event_column, "amount");
-        assert_eq!(rollback.iterate.len(), 2);
-        assert_eq!(rollback.iterate[0].array_field, "ids");
-        assert_eq!(rollback.iterate[0].alias, "token_id");
-        assert_eq!(rollback.iterate[1].array_field, "values");
-        assert_eq!(rollback.iterate[1].alias, "amount");
-        assert_eq!(rollback.source_column_types["token_id"], ColumnType::Uint256);
-        assert_eq!(rollback.source_column_types["amount"], ColumnType::Uint256);
-        assert_eq!(rollback.derived_column_types["token_id"], ColumnType::Uint256);
-        assert_eq!(rollback.derived_column_types["balance"], ColumnType::Uint256);
+        let rollback_metadata = rollback_plans["polygon"]
+            .operation(&accumulator["polygon"][0].full_table_name, 0)
+            .expect("iterate rollback metadata should be registered");
+        assert_eq!(rollback_metadata.iterate.len(), 2);
+        assert_eq!(rollback_metadata.iterate[0].array_field, "ids");
+        assert_eq!(rollback_metadata.iterate[0].alias, "token_id");
+        assert_eq!(rollback_metadata.iterate[1].array_field, "values");
+        assert_eq!(rollback_metadata.iterate[1].alias, "amount");
+        assert_eq!(rollback_metadata.source_column_types["token_id"], ColumnType::Uint256);
+        assert_eq!(rollback_metadata.source_column_types["amount"], ColumnType::Uint256);
+        assert_eq!(rollback_metadata.derived_column_types["token_id"], ColumnType::Uint256);
+        assert_eq!(rollback_metadata.derived_column_types["balance"], ColumnType::Uint256);
+    }
+
+    #[test]
+    fn build_derived_tables_preserves_operand_accessors() {
+        use crate::indexer::tables::TableRuntime;
+        use crate::manifest::contract::Table;
+
+        let table: Table = serde_yaml::from_str(
+            r#"
+name: indexed_balances
+columns:
+  - name: account
+    type: address
+  - name: token_id
+    type: uint256
+  - name: balance
+    type: uint256
+events:
+  - event: ComplexTransfer
+    operations:
+      - type: upsert
+        where:
+          account: $data.owner
+          token_id: $ids[0]
+        set:
+          - column: balance
+            action: add
+            value: $values[0]
+"#,
+        )
+        .expect("accessor table YAML should parse");
+
+        let runtime = TableRuntime::new(table, "test_indexer", "ComplexTokens");
+        let source_column_types = HashMap::from([
+            ("data_owner".to_string(), ColumnType::Address),
+            ("ids".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+            ("values".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+        ]);
+        let mut accumulator = HashMap::new();
+        let mut rollback_plans = HashMap::new();
+
+        build_derived_tables_for_event(
+            "ComplexTransfer",
+            "test_indexer",
+            "ComplexTokens",
+            "polygon",
+            &source_column_types,
+            &[runtime],
+            &mut DerivedTableRollbackAccumulators {
+                tables: &mut accumulator,
+                plans: &mut rollback_plans,
+            },
+        )
+        .expect("accessor rollback metadata should compile");
+
+        let rollback = &accumulator["polygon"][0].rollback_ops[0];
+        assert_eq!(
+            rollback.where_columns,
+            vec![
+                ("account".to_string(), "data.owner".to_string()),
+                ("token_id".to_string(), "ids[0]".to_string()),
+            ]
+        );
+        assert_eq!(rollback.columns[0].event_column, "values[0]");
+    }
+
+    #[test]
+    fn build_derived_tables_includes_global_counter_operations() {
+        use crate::indexer::tables::TableRuntime;
+        use crate::manifest::contract::Table;
+
+        let table: Table = serde_yaml::from_str(
+            r#"
+name: transfer_count
+global: true
+columns:
+  - name: count
+    type: uint256
+events:
+  - event: Transfer
+    operations:
+      - type: upsert
+        set:
+          - column: count
+            action: increment
+"#,
+        )
+        .expect("global counter table YAML should parse");
+
+        let runtime = TableRuntime::new(table, "test_indexer", "Token");
+        let mut accumulator = HashMap::new();
+        let mut rollback_plans = HashMap::new();
+        build_derived_tables_for_event(
+            "Transfer",
+            "test_indexer",
+            "Token",
+            "polygon",
+            &HashMap::new(),
+            &[runtime],
+            &mut DerivedTableRollbackAccumulators {
+                tables: &mut accumulator,
+                plans: &mut rollback_plans,
+            },
+        )
+        .expect("global counter rollback metadata should compile");
+
+        let rollback = &accumulator["polygon"][0].rollback_ops[0];
+        assert!(rollback.where_columns.is_empty());
+        assert_eq!(rollback.columns.len(), 1);
+        assert_eq!(rollback.columns[0].action, crate::manifest::contract::SetAction::Increment);
     }
 }

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -523,13 +523,10 @@ fn event_source_column_types(
 }
 
 /// Build derived-table rollback + journal entries for an event's tables and merge
-/// them into `accumulator` keyed by `network`. Shared between contract events and
-/// native-transfer trace events so both sources contribute to reorg rollback.
-struct DerivedTableRollbackAccumulators<'a> {
-    tables: &'a mut HashMap<String, Vec<DerivedTableInfo>>,
-    plans: &'a mut HashMap<String, DerivedTableRollbackPlan>,
-}
-
+/// them into the per-network maps. Shared between contract events and native-transfer
+/// trace events so both sources contribute to reorg rollback.
+// Keep the two output maps explicit instead of wrapping them in a behaviorless type.
+#[allow(clippy::too_many_arguments)]
 fn build_derived_tables_for_event(
     event_name: &str,
     indexer_name: &str,
@@ -537,13 +534,14 @@ fn build_derived_tables_for_event(
     network: &str,
     source_column_types: &HashMap<String, ColumnType>,
     tables: &[crate::indexer::tables::TableRuntime],
-    accumulator: &mut DerivedTableRollbackAccumulators<'_>,
+    derived_tables: &mut HashMap<String, Vec<DerivedTableInfo>>,
+    rollback_plans: &mut HashMap<String, DerivedTableRollbackPlan>,
 ) -> anyhow::Result<()> {
     let schema = generate_indexer_contract_schema_name(indexer_name, contract_name);
     let event_table_full = format!("{}.{}", schema, camel_to_snake(event_name));
 
     for tr in tables.iter() {
-        let derived = accumulator.tables.entry(network.to_string()).or_default();
+        let derived = derived_tables.entry(network.to_string()).or_default();
         let derived_column_types = tr
             .table
             .columns
@@ -662,7 +660,7 @@ fn build_derived_tables_for_event(
             0
         };
 
-        let rollback_plan = accumulator.plans.entry(network.to_string()).or_default();
+        let rollback_plan = rollback_plans.entry(network.to_string()).or_default();
         for (operation_index, (iterate, source_types, derived_types)) in
             rollback_metadata.into_iter().enumerate()
         {
@@ -829,10 +827,8 @@ async fn start_indexing_contract_events(
                 &network_contract.network,
                 &source_column_types,
                 &event.tables,
-                &mut DerivedTableRollbackAccumulators {
-                    tables: &mut network_derived_tables,
-                    plans: &mut network_rollback_plans,
-                },
+                &mut network_derived_tables,
+                &mut network_rollback_plans,
             )?;
         }
     }
@@ -883,10 +879,8 @@ async fn start_indexing_contract_events(
                     &network_detail.network,
                     &source_column_types,
                     &trace_event.tables,
-                    &mut DerivedTableRollbackAccumulators {
-                        tables: &mut network_derived_tables,
-                        plans: &mut network_rollback_plans,
-                    },
+                    &mut network_derived_tables,
+                    &mut network_rollback_plans,
                 )?;
             }
         }
@@ -2131,10 +2125,8 @@ mod tests {
             "anvil",
             &source_column_types,
             &tables,
-            &mut DerivedTableRollbackAccumulators {
-                tables: &mut accumulator,
-                plans: &mut rollback_plans,
-            },
+            &mut accumulator,
+            &mut rollback_plans,
         )
         .expect("build_derived_tables_for_event should succeed");
 
@@ -2211,10 +2203,8 @@ events:
             "polygon",
             &source_column_types,
             &[runtime],
-            &mut DerivedTableRollbackAccumulators {
-                tables: &mut accumulator,
-                plans: &mut rollback_plans,
-            },
+            &mut accumulator,
+            &mut rollback_plans,
         )
         .expect("TransferBatch rollback metadata should compile");
 
@@ -2281,10 +2271,8 @@ events:
             "polygon",
             &source_column_types,
             &[runtime],
-            &mut DerivedTableRollbackAccumulators {
-                tables: &mut accumulator,
-                plans: &mut rollback_plans,
-            },
+            &mut accumulator,
+            &mut rollback_plans,
         )
         .expect("accessor rollback metadata should compile");
 
@@ -2332,10 +2320,8 @@ events:
             "polygon",
             &HashMap::new(),
             &[runtime],
-            &mut DerivedTableRollbackAccumulators {
-                tables: &mut accumulator,
-                plans: &mut rollback_plans,
-            },
+            &mut accumulator,
+            &mut rollback_plans,
         )
         .expect("global counter rollback metadata should compile");
 

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -452,15 +452,33 @@ fn collect_source_column_types(
             None => name,
         };
 
-        if !input.type_.starts_with("tuple[") {
-            if let Some(components) = &input.components {
+        if let Some(components) = &input.components {
+            if input.type_.starts_with("tuple[") {
+                collect_jsonb_tuple_element_types(components, &column, source_column_types);
+            } else {
                 collect_source_column_types(components, Some(&column), source_column_types);
-                continue;
             }
+            continue;
         }
 
         if let Some(column_type) = ColumnType::from_solidity_type(&input.type_) {
             source_column_types.insert(column, column_type);
+        }
+    }
+}
+
+fn collect_jsonb_tuple_element_types(
+    components: &[ABIInput],
+    prefix: &str,
+    source_column_types: &mut HashMap<String, ColumnType>,
+) {
+    for component in components {
+        // JSONB tuple objects retain ABI component names verbatim.
+        let field = format!("{}.{}", prefix, component.name);
+        if let Some(nested) = &component.components {
+            collect_jsonb_tuple_element_types(nested, &field, source_column_types);
+        } else if let Some(column_type) = ColumnType::from_solidity_type(&component.type_) {
+            source_column_types.insert(field, column_type);
         }
     }
 }
@@ -2021,6 +2039,16 @@ mod tests {
                 "name": "data",
                 "type": "tuple",
                 "components": [{"name": "amount", "type": "uint256"}]
+            },
+            {
+                "name": "accounts",
+                "type": "tuple[]",
+                "components": [{"name": "owner", "type": "address"}]
+            },
+            {
+                "name": "fixedAccounts",
+                "type": "tuple[2]",
+                "components": [{"name": "tokenAmount", "type": "uint256"}]
             }
         ]))
         .expect("valid ABI inputs");
@@ -2029,6 +2057,10 @@ mod tests {
 
         assert_eq!(source_column_types["ids"], ColumnType::Array(Box::new(ColumnType::Uint256)));
         assert_eq!(source_column_types["data_amount"], ColumnType::Uint256);
+        assert_eq!(source_column_types["accounts.owner"], ColumnType::Address);
+        assert_eq!(source_column_types["fixed_accounts.tokenAmount"], ColumnType::Uint256);
+        assert!(!source_column_types.contains_key("accounts"));
+        assert!(!source_column_types.contains_key("fixed_accounts"));
     }
 
     #[test]

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -12,6 +12,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
+use crate::abi::{ABIInput, ABIItem};
 use crate::database::clickhouse::client::{ClickhouseClient, ClickhouseConnectionError};
 use crate::database::generate::generate_indexer_contract_schema_name;
 use crate::database::postgres::generate::generate_internal_event_table_name;
@@ -34,7 +35,9 @@ use crate::{
     indexer::{
         dependency::ContractEventsDependenciesConfig,
         last_synced::{get_last_synced_block_number, SyncConfig},
-        native_transfer::{native_transfer_block_fetch, NATIVE_TRANSFER_CONTRACT_NAME},
+        native_transfer::{
+            native_transfer_block_fetch, NATIVE_TRANSFER_ABI, NATIVE_TRANSFER_CONTRACT_NAME,
+        },
         process::{
             process_contracts_events_with_dependencies, process_non_blocking_event,
             ProcessContractsEventsWithDependenciesError, ProcessEventError,
@@ -42,7 +45,10 @@ use crate::{
         progress::IndexingEventsProgressState,
         ContractEventDependencies,
     },
-    manifest::{contract::ReorgSafeDistance, core::Manifest},
+    manifest::{
+        contract::{ColumnType, ReorgSafeDistance},
+        core::Manifest,
+    },
     provider::{ChainProvider, ProviderError},
     PostgresClient,
 };
@@ -434,6 +440,70 @@ fn collect_streams_clients_for_network(
     out
 }
 
+fn collect_source_column_types(
+    inputs: &[ABIInput],
+    prefix: Option<&str>,
+    source_column_types: &mut HashMap<String, ColumnType>,
+) {
+    for input in inputs {
+        let name = camel_to_snake(&input.name);
+        let column = match prefix {
+            Some(prefix) => format!("{}_{}", prefix, name),
+            None => name,
+        };
+
+        if !input.type_.starts_with("tuple[") {
+            if let Some(components) = &input.components {
+                collect_source_column_types(components, Some(&column), source_column_types);
+                continue;
+            }
+        }
+
+        if let Some(column_type) = ColumnType::from_solidity_type(&input.type_) {
+            source_column_types.insert(column, column_type);
+        }
+    }
+}
+
+fn event_source_column_types(
+    manifest: &Manifest,
+    project_path: &Path,
+    contract_name: &str,
+    event_name: &str,
+) -> anyhow::Result<HashMap<String, ColumnType>> {
+    let abi_items: Vec<ABIItem> = if contract_name == NATIVE_TRANSFER_CONTRACT_NAME {
+        serde_json::from_str(NATIVE_TRANSFER_ABI)?
+    } else {
+        let contract = manifest
+            .all_contracts()
+            .into_iter()
+            .find(|contract| contract.name == contract_name)
+            .ok_or_else(|| anyhow::anyhow!("contract '{}' not found in manifest", contract_name))?;
+        ABIItem::read_abi_items(project_path, &contract)?
+    };
+    let event =
+        abi_items.iter().find(|item| item.type_ == "event" && item.name == event_name).ok_or_else(
+            || anyhow::anyhow!("event '{}::{}' not found in ABI", contract_name, event_name),
+        )?;
+
+    let mut source_column_types = HashMap::new();
+    collect_source_column_types(&event.inputs, None, &mut source_column_types);
+    for (field, column) in [
+        ("rindexer_block_number", "block_number"),
+        ("rindexer_block_timestamp", "block_timestamp"),
+        ("rindexer_tx_hash", "tx_hash"),
+        ("rindexer_block_hash", "block_hash"),
+        ("rindexer_contract_address", "contract_address"),
+        ("rindexer_log_index", "log_index"),
+        ("rindexer_tx_index", "tx_index"),
+    ] {
+        if let Some(column_type) = ColumnType::from_tx_metadata_field(field) {
+            source_column_types.insert(column.to_string(), column_type);
+        }
+    }
+    Ok(source_column_types)
+}
+
 /// Build derived-table rollback + journal entries for an event's tables and merge
 /// them into `accumulator` keyed by `network`. Shared between contract events and
 /// native-transfer trace events so both sources contribute to reorg rollback.
@@ -442,6 +512,7 @@ fn build_derived_tables_for_event(
     indexer_name: &str,
     contract_name: &str,
     network: &str,
+    source_column_types: &HashMap<String, ColumnType>,
     tables: &[crate::indexer::tables::TableRuntime],
     accumulator: &mut HashMap<String, Vec<DerivedTableInfo>>,
 ) -> anyhow::Result<()> {
@@ -450,6 +521,14 @@ fn build_derived_tables_for_event(
 
     for tr in tables.iter() {
         let derived = accumulator.entry(network.to_string()).or_default();
+        let derived_column_types = tr
+            .table
+            .columns
+            .iter()
+            .filter_map(|column| {
+                column.column_type.clone().map(|column_type| (column.name.clone(), column_type))
+            })
+            .collect::<HashMap<_, _>>();
 
         let event_table_name = event_table_full.clone();
         let mut rollback_ops: Vec<DerivedTableRollbackOp> = Vec::new();
@@ -517,7 +596,11 @@ fn build_derived_tables_for_event(
                             columns,
                             operation.condition().map(String::from),
                         )?
-                        .with_iterate(table_event.iterate.clone())?,
+                        .with_iterate(table_event.iterate.clone())?
+                        .with_column_types(
+                            source_column_types.clone(),
+                            derived_column_types.clone(),
+                        ),
                     );
                 }
             }
@@ -661,6 +744,16 @@ async fn start_indexing_contract_events(
     let mut network_event_tables: HashMap<String, Vec<EventTableInfo>> = HashMap::new();
     let mut network_derived_tables: HashMap<String, Vec<DerivedTableInfo>> = HashMap::new();
     for event in registry.events.iter() {
+        let source_column_types = if event.tables.is_empty() {
+            HashMap::new()
+        } else {
+            event_source_column_types(
+                manifest,
+                project_path,
+                &event.contract.name,
+                &event.event_name,
+            )?
+        };
         for network_contract in event.contract.details.iter() {
             let schema =
                 generate_indexer_contract_schema_name(&event.indexer_name, &event.contract.name);
@@ -682,6 +775,7 @@ async fn start_indexing_contract_events(
                 &event.indexer_name,
                 &event.contract.name,
                 &network_contract.network,
+                &source_column_types,
                 &event.tables,
                 &mut network_derived_tables,
             )?;
@@ -716,12 +810,23 @@ async fn start_indexing_contract_events(
         // Mirror the contract-events pass for native-transfer derived tables: every
         // trace event contributes rollback ops for each configured network.
         for trace_event in trace_registry.events.iter() {
+            let source_column_types = if trace_event.tables.is_empty() {
+                HashMap::new()
+            } else {
+                event_source_column_types(
+                    manifest,
+                    project_path,
+                    &trace_event.contract_name,
+                    &trace_event.event_name,
+                )?
+            };
             for network_detail in trace_event.trace_information.details.iter() {
                 build_derived_tables_for_event(
                     &trace_event.event_name,
                     &trace_event.indexer_name,
                     &trace_event.contract_name,
                     &network_detail.network,
+                    &source_column_types,
                     &trace_event.tables,
                     &mut network_derived_tables,
                 )?;
@@ -1863,6 +1968,24 @@ mod tests {
     // source table.
 
     #[test]
+    fn collect_source_column_types_flattens_tuples_and_preserves_arrays() {
+        let inputs: Vec<ABIInput> = serde_json::from_value(serde_json::json!([
+            {"name": "ids", "type": "uint256[]"},
+            {
+                "name": "data",
+                "type": "tuple",
+                "components": [{"name": "amount", "type": "uint256"}]
+            }
+        ]))
+        .expect("valid ABI inputs");
+        let mut source_column_types = HashMap::new();
+        collect_source_column_types(&inputs, None, &mut source_column_types);
+
+        assert_eq!(source_column_types["ids"], ColumnType::Array(Box::new(ColumnType::Uint256)));
+        assert_eq!(source_column_types["data_amount"], ColumnType::Uint256);
+    }
+
+    #[test]
     fn build_derived_tables_for_native_transfer_populates_accumulator() {
         use crate::indexer::tables::TableRuntime;
         use crate::manifest::contract::{
@@ -1879,13 +2002,13 @@ mod tests {
             columns: vec![
                 TableColumn {
                     name: "account".to_string(),
-                    column_type: None,
+                    column_type: Some(ColumnType::Address),
                     nullable: false,
                     default: None,
                 },
                 TableColumn {
                     name: "total_sent".to_string(),
-                    column_type: None,
+                    column_type: Some(ColumnType::Uint256),
                     nullable: false,
                     default: None,
                 },
@@ -1916,6 +2039,10 @@ mod tests {
 
         let runtime = TableRuntime::new(table, "test_indexer", NATIVE_TRANSFER_CONTRACT_NAME);
         let tables = vec![runtime];
+        let source_column_types = HashMap::from([
+            ("from".to_string(), ColumnType::Address),
+            ("value".to_string(), ColumnType::Uint256),
+        ]);
 
         let mut accumulator: HashMap<String, Vec<DerivedTableInfo>> = HashMap::new();
         build_derived_tables_for_event(
@@ -1923,6 +2050,7 @@ mod tests {
             "test_indexer",
             NATIVE_TRANSFER_CONTRACT_NAME,
             "anvil",
+            &source_column_types,
             &tables,
             &mut accumulator,
         )
@@ -1962,8 +2090,11 @@ mod tests {
 name: custody_balances
 columns:
   - name: user
+    type: address
   - name: token_id
+    type: uint256
   - name: balance
+    type: uint256
 events:
   - event: TransferBatch
     iterate:
@@ -1985,11 +2116,17 @@ events:
 
         let runtime = TableRuntime::new(table, "test_indexer", "ConditionalTokens");
         let mut accumulator = HashMap::new();
+        let source_column_types = HashMap::from([
+            ("to".to_string(), ColumnType::Address),
+            ("ids".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+            ("values".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+        ]);
         build_derived_tables_for_event(
             "TransferBatch",
             "test_indexer",
             "ConditionalTokens",
             "polygon",
+            &source_column_types,
             &[runtime],
             &mut accumulator,
         )
@@ -2003,5 +2140,9 @@ events:
         assert_eq!(rollback.iterate[0].alias, "token_id");
         assert_eq!(rollback.iterate[1].array_field, "values");
         assert_eq!(rollback.iterate[1].alias, "amount");
+        assert_eq!(rollback.source_column_types["token_id"], ColumnType::Uint256);
+        assert_eq!(rollback.source_column_types["amount"], ColumnType::Uint256);
+        assert_eq!(rollback.derived_column_types["token_id"], ColumnType::Uint256);
+        assert_eq!(rollback.derived_column_types["balance"], ColumnType::Uint256);
     }
 }

--- a/core/src/indexer/start.rs
+++ b/core/src/indexer/start.rs
@@ -510,12 +510,15 @@ fn build_derived_tables_for_event(
                 }
 
                 if !columns.is_empty() {
-                    rollback_ops.push(DerivedTableRollbackOp::try_new(
-                        event_table_name.clone(),
-                        where_columns,
-                        columns,
-                        operation.condition().map(String::from),
-                    )?);
+                    rollback_ops.push(
+                        DerivedTableRollbackOp::try_new(
+                            event_table_name.clone(),
+                            where_columns,
+                            columns,
+                            operation.condition().map(String::from),
+                        )?
+                        .with_iterate(table_event.iterate.clone())?,
+                    );
                 }
             }
         }
@@ -1947,5 +1950,58 @@ mod tests {
             op.event_table,
         );
         assert!(entry.journal_columns.is_empty(), "no non-reversible columns in this fixture");
+    }
+
+    #[test]
+    fn build_derived_tables_preserves_transfer_batch_iteration() {
+        use crate::indexer::tables::TableRuntime;
+        use crate::manifest::contract::Table;
+
+        let table: Table = serde_yaml::from_str(
+            r#"
+name: custody_balances
+columns:
+  - name: user
+  - name: token_id
+  - name: balance
+events:
+  - event: TransferBatch
+    iterate:
+      - "$ids as token_id"
+      - "$values as amount"
+    operations:
+      - type: upsert
+        where:
+          user: $to
+          token_id: $token_id
+        if: "$to != 0x0000000000000000000000000000000000000000"
+        set:
+          - column: balance
+            action: add
+            value: $amount
+"#,
+        )
+        .expect("TransferBatch table YAML should parse");
+
+        let runtime = TableRuntime::new(table, "test_indexer", "ConditionalTokens");
+        let mut accumulator = HashMap::new();
+        build_derived_tables_for_event(
+            "TransferBatch",
+            "test_indexer",
+            "ConditionalTokens",
+            "polygon",
+            &[runtime],
+            &mut accumulator,
+        )
+        .expect("TransferBatch rollback metadata should compile");
+
+        let rollback = &accumulator["polygon"][0].rollback_ops[0];
+        assert_eq!(rollback.where_columns[0].1, "token_id");
+        assert_eq!(rollback.columns[0].event_column, "amount");
+        assert_eq!(rollback.iterate.len(), 2);
+        assert_eq!(rollback.iterate[0].array_field, "ids");
+        assert_eq!(rollback.iterate[0].alias, "token_id");
+        assert_eq!(rollback.iterate[1].array_field, "values");
+        assert_eq!(rollback.iterate[1].alias, "amount");
     }
 }

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -2639,17 +2639,12 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
     .await
     .unwrap();
 
-    let (contract, _) = deploy_ping_pong(&env.http, &env.rpc_url, env.deployer).await;
-    let block1 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 1).await;
-    let block2 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 2).await;
-
+    let block2 = 2;
     let network = "dev";
-    let accounts = get_accounts(&env.http, &env.rpc_url).await;
-    let sender = format!("{:#x}", accounts[0]);
-    let recipient = format!("{:#x}", accounts[1]);
+    let sender = "0x1111111111111111111111111111111111111111";
+    let recipient = "0x2222222222222222222222222222222222222222";
     let zero_tx = "0x0000000000000000000000000000000000000000000000000000000000000000";
-    let (block_hash, _) = get_block_by_number(&env.http, &env.rpc_url, block2).await;
-    let block_hash = format!("{:#x}", block_hash);
+    let block_hash = zero_tx;
     pg.execute(
         "INSERT INTO test_schema.erc1155_transfer_batch
          (operator, \"from\", \"to\", ids, values, tx_hash, block_number,
@@ -2657,15 +2652,7 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
          VALUES ($1, $2, $3, ARRAY['101', '202']::VARCHAR(78)[],
                  ARRAY['7', '11']::VARCHAR(78)[],
                  $4, $5, $6, $7, 0, '0')",
-        &[
-            &sender.as_str(),
-            &sender.as_str(),
-            &recipient.as_str(),
-            &zero_tx,
-            &Decimal::from(block2),
-            &block_hash.as_str(),
-            &network,
-        ],
+        &[&sender, &sender, &recipient, &zero_tx, &Decimal::from(block2), &block_hash, &network],
     )
     .await
     .unwrap();
@@ -2679,8 +2666,6 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
     .await
     .unwrap();
 
-    env.insert_block_hashes(&pg, network, block1, block2).await;
-    env.insert_ch_block_hashes(&ch, network, block1, block2).await;
     pg.execute(
         "INSERT INTO rindexer_internal.test_schema_transfer_batch
          (network, last_synced_block) VALUES ($1, $2)",
@@ -2695,12 +2680,9 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
     .await
     .unwrap();
 
-    for (user, token_id, balance) in [
-        (sender.as_str(), 101u64, 13u64),
-        (sender.as_str(), 202, 19),
-        (recipient.as_str(), 101, 8),
-        (recipient.as_str(), 202, 13),
-    ] {
+    for (user, token_id, balance) in
+        [(sender, 101u64, 13u64), (sender, 202, 19), (recipient, 101, 8), (recipient, 202, 13)]
+    {
         pg.execute(
             "INSERT INTO test_schema.custody_balances
              (network, user_address, token_id, balance, rindexer_block_number)
@@ -2717,8 +2699,6 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
         .await
         .unwrap();
     }
-
-    trigger_reorg(&env.http, &env.rpc_url, 1).await;
 
     let iterate = vec![
         IterateBinding::parse("$ids as token_id").unwrap(),
@@ -2863,12 +2843,9 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
         .into_iter()
         .map(|row| (row.get::<_, String>(0), row.get::<_, Decimal>(1), row.get::<_, Decimal>(2)))
         .collect::<Vec<_>>();
-    for (user, token_id, expected) in [
-        (sender.as_str(), 101u64, 20u64),
-        (sender.as_str(), 202, 30),
-        (recipient.as_str(), 101, 1),
-        (recipient.as_str(), 202, 2),
-    ] {
+    for (user, token_id, expected) in
+        [(sender, 101u64, 20u64), (sender, 202, 30), (recipient, 101, 1), (recipient, 202, 2)]
+    {
         assert!(balances.contains(&(
             user.to_string(),
             Decimal::from(token_id),

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -3831,7 +3831,7 @@ async fn test_reorg_clickhouse_add_reversal() {
 
     trigger_reorg(&env.http, &env.rpc_url, 2).await; // invalidates block2, block3
 
-    let task = ReorgTask {
+    let mut task = ReorgTask {
         network: network.to_string(),
         fork_point: block2,
         detection_point: block3,
@@ -3865,9 +3865,60 @@ async fn test_reorg_clickhouse_add_reversal() {
     let rindexer_pg = env.rindexer_pg().await;
     let mut task_window = BlockChainWindow::try_new(256).unwrap();
 
+    task.derived_tables[0].rollback_ops[0].columns[0].derived_column =
+        "missing_balance".to_string();
+    let error = match task.execute(&mut task_window, None, Some(&ch), None).await {
+        Ok(_) => panic!("invalid ClickHouse reversal must fail after raw deletion"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("Accumulative reversal"));
+    let retained_snapshots: u64 = ch
+        .query_one(
+            "SELECT count() FROM system.tables
+             WHERE database = 'rindexer_internal'
+               AND name LIKE '_rindexer_reorg_snap_%'",
+        )
+        .await
+        .unwrap();
+    assert_eq!(retained_snapshots, 2, "failed reversal must retain its snapshot and marker");
+
+    task.derived_tables[0].rollback_ops[0].columns[0].derived_column = "balance".to_string();
+    task.derived_tables.push(DerivedTableInfo {
+        full_table_name: "test_schema.missing_cleanup".to_string(),
+        cross_chain: false,
+        rollback_ops: vec![],
+        journal_columns: vec![],
+    });
+    let error = match task.execute(&mut task_window, None, Some(&ch), None).await {
+        Ok(_) => panic!("invalid later ClickHouse phase must fail"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("failed to delete derived table rows"));
+    let ch_balance_after_late_failure: u64 = ch
+        .query_one(&format!(
+            "SELECT toUInt64(balance) FROM test_schema.user_balances FINAL
+             WHERE network = '{network}' AND user_address = '{user}'"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        ch_balance_after_late_failure, 100,
+        "successful reversal must be checkpointed before a later phase fails"
+    );
+    let retained_marker: u64 = ch
+        .query_one(
+            "SELECT count() FROM system.tables
+             WHERE database = 'rindexer_internal'
+               AND name LIKE '_rindexer_reorg_snap_%'",
+        )
+        .await
+        .unwrap();
+    assert_eq!(retained_marker, 1, "only the pending-attempt marker should remain");
+
+    task.derived_tables.pop();
     task.execute(&mut task_window, Some(&rindexer_pg), Some(&ch), None)
         .await
-        .expect("clickhouse add reversal reorg task failed");
+        .expect("ClickHouse reversal retry must reuse the retained snapshot");
 
     // PG: balance was 180, events at block2 (id=50) + block3 (id=30) = 80 subtracted -> 100
     let balance: rust_decimal::Decimal = pg
@@ -3882,6 +3933,26 @@ async fn test_reorg_clickhouse_add_reversal() {
 
     // PG: only the block1 event should remain
     assert_eq!(env.event_count(&pg).await, 1, "PG: only Ping(100) at block1 should remain");
+    let ch_balance: u64 = ch
+        .query_one(&format!(
+            "SELECT toUInt64(balance) FROM test_schema.user_balances FINAL
+             WHERE network = '{network}' AND user_address = '{user}'"
+        ))
+        .await
+        .expect("CH balance row should still exist after retry");
+    assert_eq!(ch_balance, 100, "CH retry must reverse the retained 80-point delta once");
+    let remaining_ch_events: u64 =
+        ch.query_one("SELECT count() FROM test_schema.ping_pong_ping FINAL").await.unwrap();
+    assert_eq!(remaining_ch_events, 1, "CH: only Ping(100) at block1 should remain");
+    let leaked_snapshots: u64 = ch
+        .query_one(
+            "SELECT count() FROM system.tables
+             WHERE database = 'rindexer_internal'
+               AND name LIKE '_rindexer_reorg_snap_%'",
+        )
+        .await
+        .unwrap();
+    assert_eq!(leaked_snapshots, 0, "successful retry must clean up snapshot state");
 }
 
 // ---------------------------------------------------------------------------

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -17,7 +17,7 @@ use rindexer::indexer::reorg::{
     persistence::ReorgBlockHashPersistence,
     task::{
         DerivedColumnJournal, DerivedColumnRollback, DerivedTableInfo, DerivedTableRollbackOp,
-        EventTableInfo, ReorgTask,
+        DerivedTableRollbackPlan, EventTableInfo, ReorgTask,
     },
     window::{BlockChainWindow, ParentValidation},
 };
@@ -2132,9 +2132,6 @@ async fn test_reorg_reversal_add() {
                     action: SetAction::Add,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2247,9 +2244,6 @@ async fn test_reorg_reversal_reserved_word_column() {
                     action: SetAction::Add,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2344,9 +2338,6 @@ async fn test_reorg_reversal_subtract() {
                     action: SetAction::Subtract,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2442,9 +2433,6 @@ async fn test_reorg_reversal_increment() {
                     action: SetAction::Increment,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2539,9 +2527,6 @@ async fn test_reorg_reversal_with_condition() {
                 }],
                 // Only events where id > 7 were accumulated
                 condition: Some("id::NUMERIC > 7".to_string()),
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2766,10 +2751,28 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
             Some(condition.to_string()),
         )
         .unwrap()
-        .with_iterate(iterate.clone())
-        .unwrap()
-        .with_column_types(source_column_types.clone(), derived_column_types.clone())
     };
+    let rollback_ops = vec![
+        rollback_op(
+            "from",
+            SetAction::Subtract,
+            "$from != 0x0000000000000000000000000000000000000000",
+        ),
+        rollback_op("to", SetAction::Add, "$to != 0x0000000000000000000000000000000000000000"),
+    ];
+    let derived_table = "test_schema.custody_balances".to_string();
+    let mut rollback_plan = DerivedTableRollbackPlan::default();
+    for operation_index in 0..rollback_ops.len() {
+        rollback_plan
+            .try_add_operation(
+                derived_table.clone(),
+                operation_index,
+                iterate.clone(),
+                source_column_types.clone(),
+                derived_column_types.clone(),
+            )
+            .unwrap();
+    }
     let task = ReorgTask {
         network: network.to_string(),
         fork_point: block2,
@@ -2784,29 +2787,61 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
         )
         .unwrap()],
         derived_tables: vec![DerivedTableInfo {
-            full_table_name: "test_schema.custody_balances".to_string(),
+            full_table_name: derived_table,
             cross_chain: false,
-            rollback_ops: vec![
-                rollback_op(
-                    "from",
-                    SetAction::Subtract,
-                    "$from != 0x0000000000000000000000000000000000000000",
-                ),
-                rollback_op(
-                    "to",
-                    SetAction::Add,
-                    "$to != 0x0000000000000000000000000000000000000000",
-                ),
-            ],
+            rollback_ops,
             journal_columns: vec![],
         }],
         canonical_blocks: vec![],
     };
 
     let rindexer_pg = env.rindexer_pg().await;
+    pg.batch_execute(
+        "UPDATE test_schema.erc1155_transfer_batch
+         SET values = ARRAY['7']::VARCHAR(78)[]",
+    )
+    .await
+    .unwrap();
+    let mut failed_window = BlockChainWindow::try_new(256).unwrap();
+    let error = match task
+        .execute_with_rollback_plan(
+            &mut failed_window,
+            Some(&rindexer_pg),
+            Some(&ch),
+            None,
+            &rollback_plan,
+        )
+        .await
+    {
+        Ok(_) => panic!("unequal iterate arrays must abort before rollback"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("unequal lengths"),
+        "unexpected unequal-iterate error: {error:#}"
+    );
+    let raw_rows: i64 = pg
+        .query_one("SELECT count(*) FROM test_schema.erc1155_transfer_batch", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(raw_rows, 1, "failed preflight must not delete stale event rows");
+    pg.batch_execute(
+        "UPDATE test_schema.erc1155_transfer_batch
+         SET values = ARRAY['7', '11']::VARCHAR(78)[]",
+    )
+    .await
+    .unwrap();
+
     let mut task_window = BlockChainWindow::try_new(256).unwrap();
     let result = task
-        .execute(&mut task_window, Some(&rindexer_pg), Some(&ch), None)
+        .execute_with_rollback_plan(
+            &mut task_window,
+            Some(&rindexer_pg),
+            Some(&ch),
+            None,
+            &rollback_plan,
+        )
         .await
         .expect("TransferBatch reorg rollback failed");
 
@@ -3156,9 +3191,6 @@ async fn test_reorg_reversal_decrement() {
                     action: SetAction::Decrement,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -3383,9 +3415,6 @@ async fn test_reorg_mixed_reversible_and_journal() {
                     action: SetAction::Add,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![DerivedColumnJournal {
                 derived_column: "max_trade".to_string(),
@@ -3503,9 +3532,6 @@ async fn test_reorg_reversal_uninvolved_row_unchanged() {
                     action: SetAction::Add,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -3652,9 +3678,6 @@ async fn test_reorg_clickhouse_add_reversal() {
                     action: SetAction::Add,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -3795,9 +3818,6 @@ async fn test_reorg_reversal_reserved_word_column_clickhouse() {
                     action: SetAction::Add,
                 }],
                 condition: None,
-                iterate: vec![],
-                source_column_types: HashMap::new(),
-                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -3966,9 +3986,6 @@ async fn test_reorg_two_events_same_table_reversible() {
                         action: SetAction::Add,
                     }],
                     condition: None,
-                    iterate: vec![],
-                    source_column_types: HashMap::new(),
-                    derived_column_types: HashMap::new(),
                 },
                 DerivedTableRollbackOp {
                     event_table: "test_schema.ping_pong_pong".to_string(),
@@ -3979,9 +3996,6 @@ async fn test_reorg_two_events_same_table_reversible() {
                         action: SetAction::Subtract,
                     }],
                     condition: None,
-                    iterate: vec![],
-                    source_column_types: HashMap::new(),
-                    derived_column_types: HashMap::new(),
                 },
             ],
             journal_columns: vec![],

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -5,7 +5,10 @@
 //! `cargo test`:
 //!   cargo nextest run -q -p rindexer --test e2e_reorg
 
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use alloy::primitives::{Address, B256};
 use reqwest::Client as HttpClient;
@@ -18,7 +21,7 @@ use rindexer::indexer::reorg::{
     },
     window::{BlockChainWindow, ParentValidation},
 };
-use rindexer::manifest::contract::{IterateBinding, SetAction};
+use rindexer::manifest::contract::{ColumnType, IterateBinding, SetAction};
 use rindexer::ClickhouseClient;
 use rindexer::PostgresClient;
 use rust_decimal::Decimal;
@@ -2130,6 +2133,8 @@ async fn test_reorg_reversal_add() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2243,6 +2248,8 @@ async fn test_reorg_reversal_reserved_word_column() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2338,6 +2345,8 @@ async fn test_reorg_reversal_subtract() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2434,6 +2443,8 @@ async fn test_reorg_reversal_increment() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2529,6 +2540,8 @@ async fn test_reorg_reversal_with_condition() {
                 // Only events where id > 7 were accumulated
                 condition: Some("id::NUMERIC > 7".to_string()),
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -2582,8 +2595,8 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
              operator CHAR(42) NOT NULL,
              \"from\" CHAR(42) NOT NULL,
              \"to\" CHAR(42) NOT NULL,
-             ids NUMERIC[] NOT NULL,
-             values NUMERIC[] NOT NULL,
+             ids VARCHAR(78)[] NOT NULL,
+             values VARCHAR(78)[] NOT NULL,
              tx_hash CHAR(66) NOT NULL,
              block_number NUMERIC NOT NULL,
              block_hash CHAR(66) NOT NULL,
@@ -2656,7 +2669,8 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
         "INSERT INTO test_schema.erc1155_transfer_batch
          (operator, \"from\", \"to\", ids, values, tx_hash, block_number,
           block_hash, network, tx_index, log_index)
-         VALUES ($1, $2, $3, ARRAY[101, 202]::NUMERIC[], ARRAY[7, 11]::NUMERIC[],
+         VALUES ($1, $2, $3, ARRAY['101', '202']::VARCHAR(78)[],
+                 ARRAY['7', '11']::VARCHAR(78)[],
                  $4, $5, $6, $7, 0, '0')",
         &[
             &sender.as_str(),
@@ -2725,6 +2739,17 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
         IterateBinding::parse("$ids as token_id").unwrap(),
         IterateBinding::parse("$values as amount").unwrap(),
     ];
+    let source_column_types = HashMap::from([
+        ("from".to_string(), ColumnType::Address),
+        ("to".to_string(), ColumnType::Address),
+        ("ids".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+        ("values".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+    ]);
+    let derived_column_types = HashMap::from([
+        ("user_address".to_string(), ColumnType::Address),
+        ("token_id".to_string(), ColumnType::Uint256),
+        ("balance".to_string(), ColumnType::Uint256),
+    ]);
     let rollback_op = |user_field: &str, action: SetAction, condition: &str| {
         DerivedTableRollbackOp::try_new(
             "test_schema.erc1155_transfer_batch".to_string(),
@@ -2743,6 +2768,7 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
         .unwrap()
         .with_iterate(iterate.clone())
         .unwrap()
+        .with_column_types(source_column_types.clone(), derived_column_types.clone())
     };
     let task = ReorgTask {
         network: network.to_string(),
@@ -3131,6 +3157,8 @@ async fn test_reorg_reversal_decrement() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -3356,6 +3384,8 @@ async fn test_reorg_mixed_reversible_and_journal() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![DerivedColumnJournal {
                 derived_column: "max_trade".to_string(),
@@ -3474,6 +3504,8 @@ async fn test_reorg_reversal_uninvolved_row_unchanged() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -3621,6 +3653,8 @@ async fn test_reorg_clickhouse_add_reversal() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -3762,6 +3796,8 @@ async fn test_reorg_reversal_reserved_word_column_clickhouse() {
                 }],
                 condition: None,
                 iterate: vec![],
+                source_column_types: HashMap::new(),
+                derived_column_types: HashMap::new(),
             }],
             journal_columns: vec![],
         }],
@@ -3931,6 +3967,8 @@ async fn test_reorg_two_events_same_table_reversible() {
                     }],
                     condition: None,
                     iterate: vec![],
+                    source_column_types: HashMap::new(),
+                    derived_column_types: HashMap::new(),
                 },
                 DerivedTableRollbackOp {
                     event_table: "test_schema.ping_pong_pong".to_string(),
@@ -3942,6 +3980,8 @@ async fn test_reorg_two_events_same_table_reversible() {
                     }],
                     condition: None,
                     iterate: vec![],
+                    source_column_types: HashMap::new(),
+                    derived_column_types: HashMap::new(),
                 },
             ],
             journal_columns: vec![],

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -2795,6 +2795,11 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
         canonical_blocks: vec![],
     };
 
+    let legacy_snapshot = format!("rindexer_internal._rindexer_reorg_snap_{network}_{block2}_0_ch");
+    ch.execute(&format!("CREATE TABLE {legacy_snapshot} (value UInt8) ENGINE = Memory"))
+        .await
+        .unwrap();
+
     let rindexer_pg = env.rindexer_pg().await;
     pg.batch_execute(
         "UPDATE test_schema.erc1155_transfer_batch
@@ -2899,6 +2904,202 @@ async fn test_reorg_reversal_transfer_batch_iterate() {
         .unwrap()
         .get(0);
     assert_eq!(checkpoint, Decimal::from(block2 - 1));
+    let legacy_snapshot_exists: u64 = ch
+        .query_one(&format!(
+            "SELECT count() FROM system.tables WHERE database = 'rindexer_internal'
+             AND name = '_rindexer_reorg_snap_{network}_{block2}_0_ch'"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(legacy_snapshot_exists, 1, "a stale legacy snapshot must not be reused");
+    ch.execute(&format!("DROP TABLE {legacy_snapshot}")).await.unwrap();
+    let leaked_snapshots: u64 = ch
+        .query_one(
+            "SELECT count() FROM system.tables
+             WHERE database = 'rindexer_internal'
+               AND name LIKE '_rindexer_reorg_snap_%'",
+        )
+        .await
+        .unwrap();
+    assert_eq!(leaked_snapshots, 0, "ClickHouse reversal snapshots must be cleaned up");
+}
+
+#[tokio::test]
+async fn test_reorg_reversal_expands_postgres_jsonb_tuple_arrays() {
+    let env = TestEnv::new().await;
+    let pg = env.pg_client().await;
+    env.setup_base_tables(&pg).await;
+
+    pg.batch_execute(
+        "CREATE TABLE rindexer_internal.test_schema_account_batch (
+             network VARCHAR(50) NOT NULL PRIMARY KEY,
+             last_synced_block NUMERIC NOT NULL
+         );
+         CREATE TABLE test_schema.account_batch (
+             rindexer_id SERIAL PRIMARY KEY,
+             accounts JSONB NOT NULL,
+             values VARCHAR(78)[] NOT NULL,
+             tx_hash CHAR(66) NOT NULL,
+             block_number NUMERIC NOT NULL,
+             block_hash CHAR(66) NOT NULL,
+             network VARCHAR(50) NOT NULL
+         );
+         CREATE TABLE test_schema.account_balances (
+             network VARCHAR(50) NOT NULL,
+             owner CHAR(42) NOT NULL,
+             balance NUMERIC NOT NULL,
+             rindexer_block_number BIGINT NOT NULL,
+             PRIMARY KEY (network, owner)
+         );",
+    )
+    .await
+    .unwrap();
+
+    let network = "dev";
+    let block = 10u64;
+    let owner_a = "0x0000000000000000000000000000000000000001";
+    let owner_b = "0x0000000000000000000000000000000000000002";
+    let accounts = json!([
+        {"owner": owner_a, "tokenAmount": "7"},
+        {"owner": owner_b, "tokenAmount": "11"}
+    ]);
+    let zero_hash = "0x0000000000000000000000000000000000000000000000000000000000000000";
+    pg.execute(
+        "INSERT INTO test_schema.account_batch
+         (accounts, values, tx_hash, block_number, block_hash, network)
+         VALUES ($1, ARRAY['1']::VARCHAR(78)[], $2, $3, $2, $4)",
+        &[&accounts, &zero_hash, &Decimal::from(block), &network],
+    )
+    .await
+    .unwrap();
+    pg.execute(
+        "INSERT INTO rindexer_internal.test_schema_account_batch
+         (network, last_synced_block) VALUES ($1, $2)",
+        &[&network, &Decimal::from(block)],
+    )
+    .await
+    .unwrap();
+    for (owner, balance) in [(owner_a, 17u64), (owner_b, 31)] {
+        pg.execute(
+            "INSERT INTO test_schema.account_balances
+             (network, owner, balance, rindexer_block_number) VALUES ($1, $2, $3, $4)",
+            &[&network, &owner, &Decimal::from(balance), &(block as i64)],
+        )
+        .await
+        .unwrap();
+    }
+
+    let derived_table = "test_schema.account_balances".to_string();
+    let mut rollback_plan = DerivedTableRollbackPlan::default();
+    rollback_plan
+        .try_add_operation(
+            derived_table.clone(),
+            0,
+            vec![
+                IterateBinding::parse("$accounts as account").unwrap(),
+                IterateBinding::parse("$values as value").unwrap(),
+            ],
+            HashMap::from([
+                ("accounts.owner".to_string(), ColumnType::Address),
+                ("accounts.tokenAmount".to_string(), ColumnType::Uint256),
+                ("values".to_string(), ColumnType::Array(Box::new(ColumnType::Uint256))),
+            ]),
+            HashMap::from([
+                ("owner".to_string(), ColumnType::Address),
+                ("balance".to_string(), ColumnType::Uint256),
+            ]),
+        )
+        .unwrap();
+    let mut task = ReorgTask {
+        network: network.to_string(),
+        fork_point: block,
+        detection_point: block,
+        event_tables: vec![EventTableInfo::try_new(
+            "test_schema".to_string(),
+            "account_batch".to_string(),
+            "test_schema_account_batch".to_string(),
+            "test_indexer".to_string(),
+            "Accounts".to_string(),
+            "AccountBatch".to_string(),
+        )
+        .unwrap()],
+        derived_tables: vec![DerivedTableInfo {
+            full_table_name: derived_table,
+            cross_chain: false,
+            rollback_ops: vec![DerivedTableRollbackOp::try_new(
+                "test_schema.account_batch".to_string(),
+                vec![("owner".to_string(), "account.owner".to_string())],
+                vec![DerivedColumnRollback::try_new(
+                    "balance".to_string(),
+                    "account.tokenAmount".to_string(),
+                    SetAction::Add,
+                )
+                .unwrap()],
+                Some("$account.tokenAmount > 0".to_string()),
+            )
+            .unwrap()],
+            journal_columns: vec![],
+        }],
+        canonical_blocks: vec![],
+    };
+    let rindexer_pg = env.rindexer_pg().await;
+
+    let mut window = BlockChainWindow::try_new(16).unwrap();
+    let error = match task
+        .execute_with_rollback_plan(&mut window, Some(&rindexer_pg), None, None, &rollback_plan)
+        .await
+    {
+        Ok(_) => panic!("mixed iterate lengths must fail before deletion"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("unequal lengths"));
+    pg.batch_execute(
+        "UPDATE test_schema.account_batch
+         SET values = ARRAY['1', '2']::VARCHAR(78)[]",
+    )
+    .await
+    .unwrap();
+
+    task.derived_tables[0].rollback_ops[0].columns[0].derived_column =
+        "missing_balance".to_string();
+    let error = match task
+        .execute_with_rollback_plan(&mut window, Some(&rindexer_pg), None, None, &rollback_plan)
+        .await
+    {
+        Ok(_) => panic!("invalid reversal SQL must fail"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("Accumulative reversal"));
+    let raw_rows: i64 =
+        pg.query_one("SELECT count(*) FROM test_schema.account_batch", &[]).await.unwrap().get(0);
+    assert_eq!(raw_rows, 1, "failed reversal must roll back raw deletion");
+    let checkpoint: Decimal = pg
+        .query_one(
+            "SELECT last_synced_block
+             FROM rindexer_internal.test_schema_account_batch WHERE network = $1",
+            &[&network],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(checkpoint, Decimal::from(block));
+    task.derived_tables[0].rollback_ops[0].columns[0].derived_column = "balance".to_string();
+
+    task.execute_with_rollback_plan(&mut window, Some(&rindexer_pg), None, None, &rollback_plan)
+        .await
+        .expect("JSONB tuple-array rollback failed");
+
+    let balances = pg
+        .query("SELECT trim(owner), balance FROM test_schema.account_balances ORDER BY owner", &[])
+        .await
+        .unwrap();
+    assert_eq!(balances[0].get::<_, String>(0), owner_a);
+    assert_eq!(balances[0].get::<_, Decimal>(1), Decimal::from(10u64));
+    assert_eq!(balances[1].get::<_, String>(0), owner_b);
+    assert_eq!(balances[1].get::<_, Decimal>(1), Decimal::from(20u64));
+    let raw_rows: i64 =
+        pg.query_one("SELECT count(*) FROM test_schema.account_batch", &[]).await.unwrap().get(0);
+    assert_eq!(raw_rows, 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/core/tests/e2e_reorg.rs
+++ b/core/tests/e2e_reorg.rs
@@ -18,7 +18,7 @@ use rindexer::indexer::reorg::{
     },
     window::{BlockChainWindow, ParentValidation},
 };
-use rindexer::manifest::contract::SetAction;
+use rindexer::manifest::contract::{IterateBinding, SetAction};
 use rindexer::ClickhouseClient;
 use rindexer::PostgresClient;
 use rust_decimal::Decimal;
@@ -2129,6 +2129,7 @@ async fn test_reorg_reversal_add() {
                     action: SetAction::Add,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -2241,6 +2242,7 @@ async fn test_reorg_reversal_reserved_word_column() {
                     action: SetAction::Add,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -2335,6 +2337,7 @@ async fn test_reorg_reversal_subtract() {
                     action: SetAction::Subtract,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -2430,6 +2433,7 @@ async fn test_reorg_reversal_increment() {
                     action: SetAction::Increment,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -2524,6 +2528,7 @@ async fn test_reorg_reversal_with_condition() {
                 }],
                 // Only events where id > 7 were accumulated
                 condition: Some("id::NUMERIC > 7".to_string()),
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -2552,6 +2557,287 @@ async fn test_reorg_reversal_with_condition() {
         rust_decimal::Decimal::from(10u64),
         "balance should be 30 - 20 = 10 (only id>7 reversed)"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Regression: ERC-1155 TransferBatch rollbacks must expand `ids` and `values`
+// pairwise and compile manifest `$from` / `$to` conditions against raw events.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_reorg_reversal_transfer_batch_iterate() {
+    let env = TestEnv::new().await;
+    let pg = env.pg_client().await;
+    env.setup_base_tables(&pg).await;
+    let ch = env.rindexer_ch().await;
+    env.setup_ch_tables(&ch).await;
+
+    pg.batch_execute(
+        "CREATE TABLE rindexer_internal.test_schema_transfer_batch (
+             network VARCHAR(50) NOT NULL PRIMARY KEY,
+             last_synced_block NUMERIC NOT NULL
+         );
+         CREATE TABLE test_schema.erc1155_transfer_batch (
+             rindexer_id SERIAL PRIMARY KEY,
+             operator CHAR(42) NOT NULL,
+             \"from\" CHAR(42) NOT NULL,
+             \"to\" CHAR(42) NOT NULL,
+             ids NUMERIC[] NOT NULL,
+             values NUMERIC[] NOT NULL,
+             tx_hash CHAR(66) NOT NULL,
+             block_number NUMERIC NOT NULL,
+             block_hash CHAR(66) NOT NULL,
+             network VARCHAR(50) NOT NULL,
+             tx_index NUMERIC NOT NULL,
+             log_index VARCHAR(78) NOT NULL
+         );
+         CREATE TABLE test_schema.custody_balances (
+             network VARCHAR(50) NOT NULL,
+             user_address CHAR(42) NOT NULL,
+             token_id NUMERIC NOT NULL,
+             balance NUMERIC NOT NULL,
+             rindexer_block_number BIGINT NOT NULL,
+             PRIMARY KEY (network, user_address, token_id)
+         );",
+    )
+    .await
+    .unwrap();
+    ch.execute(
+        "CREATE TABLE rindexer_internal.test_schema_transfer_batch (
+             network String,
+             last_synced_block UInt64
+         ) ENGINE = ReplacingMergeTree ORDER BY network",
+    )
+    .await
+    .unwrap();
+    ch.execute(
+        "CREATE TABLE test_schema.erc1155_transfer_batch (
+             operator FixedString(42),
+             `from` FixedString(42),
+             `to` FixedString(42),
+             ids Array(UInt256),
+             values Array(UInt256),
+             tx_hash FixedString(66),
+             block_number UInt64,
+             block_hash FixedString(66),
+             network String,
+             tx_index UInt64,
+             log_index UInt64
+         ) ENGINE = ReplacingMergeTree
+         ORDER BY (network, block_number, tx_hash, log_index)",
+    )
+    .await
+    .unwrap();
+    ch.execute(
+        "CREATE TABLE test_schema.custody_balances (
+             network String,
+             user_address FixedString(42),
+             token_id UInt256,
+             balance UInt256,
+             rindexer_block_number UInt64
+         ) ENGINE = ReplacingMergeTree
+         ORDER BY (network, user_address, token_id)",
+    )
+    .await
+    .unwrap();
+
+    let (contract, _) = deploy_ping_pong(&env.http, &env.rpc_url, env.deployer).await;
+    let block1 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 1).await;
+    let block2 = send_ping(&env.http, &env.rpc_url, env.deployer, contract, 2).await;
+
+    let network = "dev";
+    let accounts = get_accounts(&env.http, &env.rpc_url).await;
+    let sender = format!("{:#x}", accounts[0]);
+    let recipient = format!("{:#x}", accounts[1]);
+    let zero_tx = "0x0000000000000000000000000000000000000000000000000000000000000000";
+    let (block_hash, _) = get_block_by_number(&env.http, &env.rpc_url, block2).await;
+    let block_hash = format!("{:#x}", block_hash);
+    pg.execute(
+        "INSERT INTO test_schema.erc1155_transfer_batch
+         (operator, \"from\", \"to\", ids, values, tx_hash, block_number,
+          block_hash, network, tx_index, log_index)
+         VALUES ($1, $2, $3, ARRAY[101, 202]::NUMERIC[], ARRAY[7, 11]::NUMERIC[],
+                 $4, $5, $6, $7, 0, '0')",
+        &[
+            &sender.as_str(),
+            &sender.as_str(),
+            &recipient.as_str(),
+            &zero_tx,
+            &Decimal::from(block2),
+            &block_hash.as_str(),
+            &network,
+        ],
+    )
+    .await
+    .unwrap();
+    ch.execute(&format!(
+        "INSERT INTO test_schema.erc1155_transfer_batch
+         (operator, `from`, `to`, ids, values, tx_hash, block_number, block_hash,
+          network, tx_index, log_index)
+         VALUES ('{sender}', '{sender}', '{recipient}', [101, 202], [7, 11],
+                 '{zero_tx}', {block2}, '{block_hash}', '{network}', 0, 0)"
+    ))
+    .await
+    .unwrap();
+
+    env.insert_block_hashes(&pg, network, block1, block2).await;
+    env.insert_ch_block_hashes(&ch, network, block1, block2).await;
+    pg.execute(
+        "INSERT INTO rindexer_internal.test_schema_transfer_batch
+         (network, last_synced_block) VALUES ($1, $2)",
+        &[&network, &Decimal::from(block2)],
+    )
+    .await
+    .unwrap();
+    ch.execute(&format!(
+        "INSERT INTO rindexer_internal.test_schema_transfer_batch
+         (network, last_synced_block) VALUES ('{network}', {block2})"
+    ))
+    .await
+    .unwrap();
+
+    for (user, token_id, balance) in [
+        (sender.as_str(), 101u64, 13u64),
+        (sender.as_str(), 202, 19),
+        (recipient.as_str(), 101, 8),
+        (recipient.as_str(), 202, 13),
+    ] {
+        pg.execute(
+            "INSERT INTO test_schema.custody_balances
+             (network, user_address, token_id, balance, rindexer_block_number)
+             VALUES ($1, $2, $3, $4, $5)",
+            &[&network, &user, &Decimal::from(token_id), &Decimal::from(balance), &(block2 as i64)],
+        )
+        .await
+        .unwrap();
+        ch.execute(&format!(
+            "INSERT INTO test_schema.custody_balances
+             (network, user_address, token_id, balance, rindexer_block_number)
+             VALUES ('{network}', '{user}', {token_id}, {balance}, {block2})"
+        ))
+        .await
+        .unwrap();
+    }
+
+    trigger_reorg(&env.http, &env.rpc_url, 1).await;
+
+    let iterate = vec![
+        IterateBinding::parse("$ids as token_id").unwrap(),
+        IterateBinding::parse("$values as amount").unwrap(),
+    ];
+    let rollback_op = |user_field: &str, action: SetAction, condition: &str| {
+        DerivedTableRollbackOp::try_new(
+            "test_schema.erc1155_transfer_batch".to_string(),
+            vec![
+                ("user_address".to_string(), user_field.to_string()),
+                ("token_id".to_string(), "token_id".to_string()),
+            ],
+            vec![DerivedColumnRollback::try_new(
+                "balance".to_string(),
+                "amount".to_string(),
+                action,
+            )
+            .unwrap()],
+            Some(condition.to_string()),
+        )
+        .unwrap()
+        .with_iterate(iterate.clone())
+        .unwrap()
+    };
+    let task = ReorgTask {
+        network: network.to_string(),
+        fork_point: block2,
+        detection_point: block2,
+        event_tables: vec![EventTableInfo::try_new(
+            "test_schema".to_string(),
+            "erc1155_transfer_batch".to_string(),
+            "test_schema_transfer_batch".to_string(),
+            "test_indexer".to_string(),
+            "Erc1155".to_string(),
+            "TransferBatch".to_string(),
+        )
+        .unwrap()],
+        derived_tables: vec![DerivedTableInfo {
+            full_table_name: "test_schema.custody_balances".to_string(),
+            cross_chain: false,
+            rollback_ops: vec![
+                rollback_op(
+                    "from",
+                    SetAction::Subtract,
+                    "$from != 0x0000000000000000000000000000000000000000",
+                ),
+                rollback_op(
+                    "to",
+                    SetAction::Add,
+                    "$to != 0x0000000000000000000000000000000000000000",
+                ),
+            ],
+            journal_columns: vec![],
+        }],
+        canonical_blocks: vec![],
+    };
+
+    let rindexer_pg = env.rindexer_pg().await;
+    let mut task_window = BlockChainWindow::try_new(256).unwrap();
+    let result = task
+        .execute(&mut task_window, Some(&rindexer_pg), Some(&ch), None)
+        .await
+        .expect("TransferBatch reorg rollback failed");
+
+    assert_eq!(result.events_deleted, 1);
+    let balances = pg
+        .query(
+            "SELECT trim(user_address), token_id, balance
+             FROM test_schema.custody_balances
+             ORDER BY user_address, token_id",
+            &[],
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| (row.get::<_, String>(0), row.get::<_, Decimal>(1), row.get::<_, Decimal>(2)))
+        .collect::<Vec<_>>();
+    for (user, token_id, expected) in [
+        (sender.as_str(), 101u64, 20u64),
+        (sender.as_str(), 202, 30),
+        (recipient.as_str(), 101, 1),
+        (recipient.as_str(), 202, 2),
+    ] {
+        assert!(balances.contains(&(
+            user.to_string(),
+            Decimal::from(token_id),
+            Decimal::from(expected),
+        )));
+        let ch_balance: u64 = ch
+            .query_one(&format!(
+                "SELECT toUInt64(balance) FROM test_schema.custody_balances FINAL
+                 WHERE network = '{network}' AND user_address = '{user}'
+                   AND token_id = {token_id}"
+            ))
+            .await
+            .unwrap();
+        assert_eq!(ch_balance, expected);
+    }
+
+    let remaining_events: i64 = pg
+        .query_one("SELECT count(*) FROM test_schema.erc1155_transfer_batch", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(remaining_events, 0, "orphaned raw events should be deleted");
+    let remaining_ch_events: u64 =
+        ch.query_one("SELECT count() FROM test_schema.erc1155_transfer_batch FINAL").await.unwrap();
+    assert_eq!(remaining_ch_events, 0, "ClickHouse orphaned raw events should be deleted");
+    let checkpoint: Decimal = pg
+        .query_one(
+            "SELECT last_synced_block
+             FROM rindexer_internal.test_schema_transfer_batch WHERE network = $1",
+            &[&network],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(checkpoint, Decimal::from(block2 - 1));
 }
 
 // ---------------------------------------------------------------------------
@@ -2844,6 +3130,7 @@ async fn test_reorg_reversal_decrement() {
                     action: SetAction::Decrement,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -3068,6 +3355,7 @@ async fn test_reorg_mixed_reversible_and_journal() {
                     action: SetAction::Add,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![DerivedColumnJournal {
                 derived_column: "max_trade".to_string(),
@@ -3185,6 +3473,7 @@ async fn test_reorg_reversal_uninvolved_row_unchanged() {
                     action: SetAction::Add,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -3331,6 +3620,7 @@ async fn test_reorg_clickhouse_add_reversal() {
                     action: SetAction::Add,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -3471,6 +3761,7 @@ async fn test_reorg_reversal_reserved_word_column_clickhouse() {
                     action: SetAction::Add,
                 }],
                 condition: None,
+                iterate: vec![],
             }],
             journal_columns: vec![],
         }],
@@ -3639,6 +3930,7 @@ async fn test_reorg_two_events_same_table_reversible() {
                         action: SetAction::Add,
                     }],
                     condition: None,
+                    iterate: vec![],
                 },
                 DerivedTableRollbackOp {
                     event_table: "test_schema.ping_pong_pong".to_string(),
@@ -3649,6 +3941,7 @@ async fn test_reorg_two_events_same_table_reversible() {
                         action: SetAction::Subtract,
                     }],
                     condition: None,
+                    iterate: vec![],
                 },
             ],
             journal_columns: vec![],

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -5,6 +5,7 @@
 
 ### Bug fixes
 -------------------------------------------------
+- fix: reorg recovery now reverses custom-table operations that use `iterate`, including paired ERC-1155 `TransferBatch` arrays and event-field conditions.
 - fix: empty network RPC values now fail startup with a clear network/env-var message instead of the low-level "relative URL without a base" provider error, and generated YAML omits unset `reth` config, unset `timestamps`, and empty `config` objects.
 - fix: no-code stream-only projects now create `.rindexer/<stream>/.../last-synced-blocks` checkpoint directories on write, preventing RabbitMQ/SNS/webhook/etc. runs without storage from panicking with `Failed to canonicalize path` ([#449](https://github.com/joshstevens19/rindexer/issues/449)).
 - fix: live indexing now respects the network `max_block_range` setting after historical sync, preventing oversized `eth_getLogs` requests when catching up to the chain tip.

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -5,7 +5,7 @@
 
 ### Bug fixes
 -------------------------------------------------
-- fix: reorg recovery now reverses custom-table operations that use `iterate`, including paired ERC-1155 `TransferBatch` arrays, typed PostgreSQL values, and nested or indexed event-field references; unequal iterate arrays abort before stale events are deleted.
+- fix: reorg recovery now reverses custom-table operations that use `iterate`, including native and PostgreSQL JSONB tuple arrays, typed nested/indexed fields, and paired ERC-1155 `TransferBatch` values; PostgreSQL rollback is atomic, unequal arrays fail before deletion, and ClickHouse snapshots are attempt-scoped and cleaned up.
 
 - Fix live event indexing stalling when a temporary RPC retry ceiling matches the last synced block.
 

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -5,7 +5,7 @@
 
 ### Bug fixes
 -------------------------------------------------
-- fix: reorg recovery now reverses custom-table operations that use `iterate`, including paired ERC-1155 `TransferBatch` arrays and event-field conditions.
+- fix: reorg recovery now reverses custom-table operations that use `iterate`, including paired ERC-1155 `TransferBatch` arrays, typed PostgreSQL values, and nested or indexed event-field references; unequal iterate arrays abort before stale events are deleted.
 
 - Fix live event indexing stalling when a temporary RPC retry ceiling matches the last synced block.
 

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -5,7 +5,7 @@
 
 ### Bug fixes
 -------------------------------------------------
-- fix: reorg recovery now reverses custom-table operations that use `iterate`, including native and PostgreSQL JSONB tuple arrays, typed nested/indexed fields, and paired ERC-1155 `TransferBatch` values; PostgreSQL rollback is atomic, unequal arrays fail before deletion, and ClickHouse snapshots are attempt-scoped and cleaned up.
+- fix: reorg recovery now reverses custom-table operations that use `iterate`, including native and PostgreSQL JSONB tuple arrays, typed nested/indexed fields, and paired ERC-1155 `TransferBatch` values; rollback quiesces event writers, PostgreSQL changes are atomic, unequal arrays fail before deletion, and interrupted ClickHouse reversals resume from retained attempt-scoped snapshots.
 
 - Fix live event indexing stalling when a temporary RPC retry ceiling matches the last synced block.
 


### PR DESCRIPTION
## Summary

- retain custom-table `iterate` bindings in derived rollback plans
- expand paired arrays and compile manifest event conditions when snapshotting orphaned deltas
- serialize ClickHouse rollback join keys so composite/`UInt256` custom-table keys work

## Why

Rollback snapshots treated iterate aliases as physical event-table columns and interpolated conditions such as `$from` and `$to` as raw SQL. ERC-1155 `TransferBatch` rollback therefore failed before orphaned rows could be removed. ClickHouse `StorageJoin` also rejected custody-style composite/`UInt256` keys.

## Validation

- exact YAML-to-rollback-plan regression
- PostgreSQL + ClickHouse `TransferBatch` reorg integration covering paired `ids`/`values`, both add/subtract inverses, raw-row deletion, and checkpoint rewind
- default-feature workspace suite: 814 passed
- all-features workspace suite: 826 passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
