### PR TITLE
fix: arithmetic upserts in no-code tables losing debits on row creation

### DIFF
--- a/core/src/database/batch_operations.rs
+++ b/core/src/database/batch_operations.rs
@@ -82,6 +82,14 @@ impl BatchOperationSqlType {
         }
     }
 
+    /// Whether this is an array type. Array columns can't go through
+    /// `(array_agg(col))[1]` in GROUP BY aggregation (array_agg over arrays
+    /// adds a dimension, so `[1]` yields NULL); they use MAX instead.
+    pub fn is_array(&self) -> bool {
+        matches!(self, BatchOperationSqlType::TextArray)
+            || matches!(self, BatchOperationSqlType::Custom(t) if t.contains("[]"))
+    }
+
     /// Returns the PostgreSQL type for binary COPY operations.
     pub fn to_pg_type(self) -> PgType {
         match self {
@@ -169,6 +177,10 @@ pub struct DynamicColumnDefinition {
     pub sql_type: BatchOperationSqlType,
     pub behavior: BatchOperationColumnBehavior,
     pub action: BatchOperationAction,
+    /// Starting value when an arithmetic upsert (Add/Subtract) creates the row,
+    /// so a first-touch `subtract` yields `default - value` instead of `+value`.
+    /// Must be a validated numeric literal — it is embedded directly in SQL.
+    pub insert_default: Option<String>,
 }
 
 impl DynamicColumnDefinition {
@@ -179,6 +191,11 @@ impl DynamicColumnDefinition {
         behavior: BatchOperationColumnBehavior,
         action: BatchOperationAction,
     ) -> Self {
-        Self { name, table_column: None, value, sql_type, behavior, action }
+        Self { name, table_column: None, value, sql_type, behavior, action, insert_default: None }
+    }
+
+    pub fn with_insert_default(mut self, insert_default: Option<String>) -> Self {
+        self.insert_default = insert_default;
+        self
     }
 }

--- a/core/src/database/clickhouse/generate.rs
+++ b/core/src/database/clickhouse/generate.rs
@@ -64,10 +64,11 @@ pub fn generate_tables_for_indexer_clickhouse(
             sql.push_str(format!("CREATE DATABASE IF NOT EXISTS {};", schema_name).as_str());
             info!("Creating database if not exists: {}", schema_name);
 
-            // Only create raw event tables for events in include_events (not for table-only events)
+            // Create raw event tables for every event whose raw events the
+            // runtime stores (include_events plus table-driving events)
             let raw_events: Vec<_> = event_names
                 .iter()
-                .filter(|e| contract.is_event_in_include_events(&e.name))
+                .filter(|e| contract.stores_raw_events(&e.name))
                 .cloned()
                 .collect();
 

--- a/core/src/database/generate.rs
+++ b/core/src/database/generate.rs
@@ -373,12 +373,10 @@ pub fn generate_tables_for_indexer_sql(
             sql.push_str(format!("CREATE SCHEMA IF NOT EXISTS {schema_name};").as_str());
             info!("Creating schema if not exists: {}", schema_name);
 
-            // Only create raw event tables for events in include_events (not for table-only events)
-            let raw_events: Vec<_> = events
-                .iter()
-                .filter(|e| contract.is_event_in_include_events(&e.name))
-                .cloned()
-                .collect();
+            // Create raw event tables for every event whose raw events the
+            // runtime stores (include_events plus table-driving events)
+            let raw_events: Vec<_> =
+                events.iter().filter(|e| contract.stores_raw_events(&e.name)).cloned().collect();
 
             if !raw_events.is_empty() {
                 let event_matching_name_on_other = find_clashing_event_names(
@@ -617,4 +615,76 @@ pub fn drop_tables_for_indexer_sql(project_path: &Path, indexer: &Indexer) -> Co
     }
 
     Code::new(sql)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::Indexer;
+    use crate::manifest::native_transfer::NativeTransfers;
+
+    /// Raw event tables must be created for events that drive custom tables
+    /// even without include_events — the runtime stores raw events for them
+    /// (reorg source of truth), so skipping the DDL breaks every bulk insert.
+    #[test]
+    fn raw_event_tables_created_for_table_only_events() {
+        let dir = std::env::temp_dir().join(format!("rindexer-ddl-test-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("abis")).unwrap();
+        std::fs::write(
+            dir.join("abis/ERC20.abi.json"),
+            r#"[{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},
+                {"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"spender","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Approval","type":"event"}]"#,
+        )
+        .unwrap();
+
+        let contract: Contract = serde_yaml::from_str(
+            r#"
+name: USDC
+details:
+  - network: ethereum
+    address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    start_block: "1"
+abi: ./abis/ERC20.abi.json
+tables:
+  - name: balances
+    columns:
+      - name: holder
+        type: address
+      - name: balance
+        type: uint256
+        default: "0"
+    events:
+      - event: Transfer
+        operations:
+          - type: upsert
+            where:
+              holder: $to
+            set:
+              - column: balance
+                action: add
+                value: $value
+"#,
+        )
+        .unwrap();
+
+        let indexer = Indexer {
+            name: "ddltest".to_string(),
+            contracts: vec![contract],
+            native_transfers: NativeTransfers::default(),
+        };
+
+        let sql = generate_tables_for_indexer_sql(&dir, &indexer, false).unwrap();
+        let sql = sql.to_string();
+
+        assert!(
+            sql.contains("ddltest_usdc.transfer"),
+            "raw event table for the table-driving event must be created: {sql}"
+        );
+        assert!(
+            !sql.contains("ddltest_usdc.approval"),
+            "events neither included nor used by tables must not get raw tables: {sql}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/core/src/database/postgres/batch_operations/dynamic.rs
+++ b/core/src/database/postgres/batch_operations/dynamic.rs
@@ -3,11 +3,12 @@
 use tokio_postgres::types::ToSql;
 
 use super::query_builder::{
-    build_cte_header, build_delete_body, build_sequence_condition, build_set_clause,
-    build_to_process_cte, build_to_process_cte_aggregated, build_update_body, build_upsert_body,
-    build_upsert_set_clause, build_upsert_set_clause_latest_by_sequence, build_where_clause,
-    build_where_condition, format_table_name, ColumnAggregate, ColumnInfo, SetClauseType,
-    UpsertClauseType,
+    build_arithmetic_insert_expr, build_cte_header, build_delete_body, build_sequence_condition,
+    build_set_clause, build_to_process_cte, build_to_process_cte_aggregated, build_update_body,
+    build_upsert_body, build_upsert_set_clause, build_upsert_set_clause_arithmetic,
+    build_upsert_set_clause_latest_by_sequence, build_where_clause, build_where_condition,
+    format_table_name, rewrite_custom_where_for_arithmetic, ColumnAggregate, ColumnInfo,
+    SetClauseType, UpsertClauseType,
 };
 use crate::database::batch_operations::{
     BatchOperationAction, BatchOperationColumnBehavior, BatchOperationType, DynamicColumnDefinition,
@@ -177,6 +178,10 @@ async fn execute_batch(
                     ColumnAggregate::Max
                 } else if min_columns.contains(&name) {
                     ColumnAggregate::Min
+                } else if col.sql_type.is_array() {
+                    // array_agg over arrays adds a dimension ([1] yields NULL);
+                    // max(anyarray) is a valid deterministic pick
+                    ColumnAggregate::Max
                 } else if set_columns.contains(&name) {
                     ColumnAggregate::LastBySeq
                 } else {
@@ -275,6 +280,14 @@ async fn execute_batch(
             };
 
             let mut update_clauses: Vec<String> = Vec::new();
+            // INSERT-branch SELECT expression overrides for arithmetic columns:
+            // a row created by add/subtract must start from the column default
+            // (default ± delta), not the raw delta.
+            let mut insert_exprs: Vec<(&str, String)> = Vec::new();
+            // Overriding the INSERT branch changes what EXCLUDED.<col> carries,
+            // so EXCLUDED references to arithmetic columns inside the pushed-down
+            // condition must be rewritten back to the raw delta.
+            let mut rewritten_where = custom_where.map(str::to_string);
             let arithmetic_without_sequence_guard = has_arithmetic && sequence_col.is_some();
 
             for col in &set_columns {
@@ -303,23 +316,34 @@ async fn execute_batch(
                 }
             }
 
-            for col in &add_columns {
-                if !where_columns.contains(col) && !distinct_cols.contains(col) {
-                    update_clauses.push(build_upsert_set_clause(
-                        col,
-                        &formatted_table_name,
-                        UpsertClauseType::Add,
-                    ));
-                }
-            }
-
-            for col in &subtract_columns {
-                if !where_columns.contains(col) && !distinct_cols.contains(col) {
-                    update_clauses.push(build_upsert_set_clause(
-                        col,
-                        &formatted_table_name,
-                        UpsertClauseType::Subtract,
-                    ));
+            for (cols, clause_type) in [
+                (&add_columns, UpsertClauseType::Add),
+                (&subtract_columns, UpsertClauseType::Subtract),
+            ] {
+                for col in cols {
+                    if !where_columns.contains(col) && !distinct_cols.contains(col) {
+                        let insert_default = columns
+                            .iter()
+                            .find(|c| c.name == *col)
+                            .and_then(|c| c.insert_default.as_deref());
+                        update_clauses.push(build_upsert_set_clause_arithmetic(
+                            col,
+                            &formatted_table_name,
+                            insert_default,
+                        ));
+                        insert_exprs.push((
+                            col,
+                            build_arithmetic_insert_expr(col, clause_type, insert_default),
+                        ));
+                        if let Some(w) = rewritten_where.as_mut() {
+                            *w = rewrite_custom_where_for_arithmetic(
+                                w,
+                                col,
+                                clause_type,
+                                insert_default,
+                            );
+                        }
+                    }
                 }
             }
 
@@ -349,7 +373,8 @@ async fn execute_batch(
                 &conflict_columns,
                 update_clauses,
                 if arithmetic_without_sequence_guard { None } else { sequence_col },
-                custom_where,
+                rewritten_where.as_deref(),
+                &insert_exprs,
             ));
 
             let params: Vec<&(dyn ToSql + Sync)> =

--- a/core/src/database/postgres/batch_operations/macros.rs
+++ b/core/src/database/postgres/batch_operations/macros.rs
@@ -1,5 +1,10 @@
 /// Creates a batch operation function for PostgreSQL database.
 ///
+/// Upserts with arithmetic actions (Add/Subtract/Max/Min) do not carry the
+/// sequence-id guard — it would silently drop deltas from lower-sequence
+/// events — so re-delivering the same rows re-applies them. Callers must not
+/// retry a batch whose statement already committed.
+///
 /// # Example
 ///
 /// ```ignore
@@ -65,10 +70,13 @@ macro_rules! create_batch_postgres_operation {
                 BatchOperationAction, BatchOperationColumnBehavior, BatchOperationType,
             };
             use $crate::database::postgres::batch_operations::{
-                build_cte_header, build_delete_body, build_insert_body, build_sequence_condition,
-                build_set_clause, build_to_process_cte, build_update_body, build_upsert_body,
-                build_upsert_set_clause, build_where_clause, build_where_condition,
-                format_table_name, ColumnInfo, SetClauseType, UpsertClauseType,
+                build_arithmetic_insert_expr, build_cte_header, build_delete_body,
+                build_insert_body, build_sequence_condition, build_set_clause,
+                build_to_process_cte, build_to_process_cte_aggregated, build_update_body,
+                build_upsert_body, build_upsert_set_clause, build_upsert_set_clause_arithmetic,
+                build_upsert_set_clause_latest_by_sequence, build_where_clause,
+                build_where_condition, format_table_name, ColumnAggregate, ColumnInfo,
+                SetClauseType, UpsertClauseType,
             };
 
             async fn execute_batch(
@@ -121,6 +129,22 @@ macro_rules! create_batch_postgres_operation {
                     })
                     .collect();
 
+                let max_columns: Vec<&str> = columns
+                    .iter()
+                    .filter_map(|col| match col.action {
+                        BatchOperationAction::Max => Some(col.name),
+                        _ => None,
+                    })
+                    .collect();
+
+                let min_columns: Vec<&str> = columns
+                    .iter()
+                    .filter_map(|col| match col.action {
+                        BatchOperationAction::Min => Some(col.name),
+                        _ => None,
+                    })
+                    .collect();
+
                 let where_columns: Vec<&str> = columns
                     .iter()
                     .filter_map(|col| match col.action {
@@ -155,8 +179,50 @@ macro_rules! create_batch_postgres_operation {
                 query.push_str(&placeholders.join(", "));
                 query.push_str(")");
 
-                // Add to_process CTE
-                query.push_str(&build_to_process_cte(&distinct_cols, sequence_col));
+                // Add to_process CTE.
+                // When arithmetic columns exist (add/subtract/max/min), use GROUP BY
+                // with aggregations instead of DISTINCT ON so duplicate keys within a
+                // batch accumulate rather than dropping all but one row (same fix as
+                // the dynamic path, GitHub #383). Plain Insert operations keep every
+                // row — aggregation would silently collapse duplicates.
+                let has_arithmetic = !add_columns.is_empty()
+                    || !subtract_columns.is_empty()
+                    || !max_columns.is_empty()
+                    || !min_columns.is_empty();
+                let is_plain_insert = matches!($op_type, BatchOperationType::Insert);
+
+                if has_arithmetic && !is_plain_insert && !distinct_cols.is_empty() {
+                    let agg_columns: Vec<(&str, ColumnAggregate)> = columns
+                        .iter()
+                        .map(|col| {
+                            let name = col.name;
+                            let agg =
+                                if distinct_cols.contains(&name) || where_columns.contains(&name) {
+                                    ColumnAggregate::GroupKey
+                                } else if sequence_col == Some(name) {
+                                    ColumnAggregate::Max
+                                } else if add_columns.contains(&name)
+                                    || subtract_columns.contains(&name)
+                                {
+                                    ColumnAggregate::Sum
+                                } else if max_columns.contains(&name) {
+                                    ColumnAggregate::Max
+                                } else if min_columns.contains(&name) {
+                                    ColumnAggregate::Min
+                                } else if col.sql_type.is_array() {
+                                    // array_agg over arrays adds a dimension ([1]
+                                    // yields NULL); max(anyarray) is a valid pick
+                                    ColumnAggregate::Max
+                                } else {
+                                    ColumnAggregate::LastBySeq
+                                };
+                            (name, agg)
+                        })
+                        .collect();
+                    query.push_str(&build_to_process_cte_aggregated(&agg_columns, sequence_col));
+                } else {
+                    query.push_str(&build_to_process_cte(&distinct_cols, sequence_col));
+                }
 
                 let formatted_table_name = format_table_name($table_name);
 
@@ -192,6 +258,24 @@ macro_rules! create_batch_postgres_operation {
                                 .push(build_set_clause(&col_info, SetClauseType::Subtract));
                         }
 
+                        for col_name in &max_columns {
+                            let column_def = columns.iter().find(|c| c.name == *col_name).unwrap();
+                            let col_info = ColumnInfo {
+                                name: col_name,
+                                table_column: column_def.table_column,
+                            };
+                            all_set_clauses.push(build_set_clause(&col_info, SetClauseType::Max));
+                        }
+
+                        for col_name in &min_columns {
+                            let column_def = columns.iter().find(|c| c.name == *col_name).unwrap();
+                            let col_info = ColumnInfo {
+                                name: col_name,
+                                table_column: column_def.table_column,
+                            };
+                            all_set_clauses.push(build_set_clause(&col_info, SetClauseType::Min));
+                        }
+
                         query.push_str(&build_update_body(&formatted_table_name, all_set_clauses));
                     }
                     BatchOperationType::Delete => {
@@ -219,33 +303,93 @@ macro_rules! create_batch_postgres_operation {
                         };
 
                         let mut update_clauses: Vec<String> = Vec::new();
+                        // INSERT-branch SELECT expression overrides for arithmetic
+                        // columns: a row created by add/subtract must start from 0,
+                        // not the raw delta (a first-touch subtract must go negative).
+                        let mut insert_exprs: Vec<(&str, String)> = Vec::new();
+                        // The sequence guard (EXCLUDED.seq > table.seq) would silently
+                        // drop arithmetic deltas from lower-sequence events, so it is
+                        // disabled when arithmetic columns exist; set columns then keep
+                        // the latest value via a per-column CASE on the sequence.
+                        let arithmetic_without_sequence_guard =
+                            has_arithmetic && sequence_col.is_some();
 
                         for col in &set_columns {
                             if !where_columns.contains(col) && !distinct_cols.contains(col) {
-                                update_clauses.push(build_upsert_set_clause(
-                                    col,
-                                    &formatted_table_name,
-                                    UpsertClauseType::Set,
-                                ));
+                                if arithmetic_without_sequence_guard {
+                                    if Some(*col) == sequence_col {
+                                        update_clauses.push(build_upsert_set_clause(
+                                            col,
+                                            &formatted_table_name,
+                                            UpsertClauseType::Max,
+                                        ));
+                                    } else {
+                                        update_clauses.push(
+                                            build_upsert_set_clause_latest_by_sequence(
+                                                col,
+                                                &formatted_table_name,
+                                                sequence_col.expect("sequence column exists"),
+                                            ),
+                                        );
+                                    }
+                                } else {
+                                    update_clauses.push(build_upsert_set_clause(
+                                        col,
+                                        &formatted_table_name,
+                                        UpsertClauseType::Set,
+                                    ));
+                                }
                             }
                         }
 
                         for col in &add_columns {
                             if !where_columns.contains(col) && !distinct_cols.contains(col) {
-                                update_clauses.push(build_upsert_set_clause(
+                                update_clauses.push(build_upsert_set_clause_arithmetic(
                                     col,
                                     &formatted_table_name,
-                                    UpsertClauseType::Add,
+                                    None,
+                                ));
+                                insert_exprs.push((
+                                    col,
+                                    build_arithmetic_insert_expr(col, UpsertClauseType::Add, None),
                                 ));
                             }
                         }
 
                         for col in &subtract_columns {
                             if !where_columns.contains(col) && !distinct_cols.contains(col) {
+                                update_clauses.push(build_upsert_set_clause_arithmetic(
+                                    col,
+                                    &formatted_table_name,
+                                    None,
+                                ));
+                                insert_exprs.push((
+                                    col,
+                                    build_arithmetic_insert_expr(
+                                        col,
+                                        UpsertClauseType::Subtract,
+                                        None,
+                                    ),
+                                ));
+                            }
+                        }
+
+                        for col in &max_columns {
+                            if !where_columns.contains(col) && !distinct_cols.contains(col) {
                                 update_clauses.push(build_upsert_set_clause(
                                     col,
                                     &formatted_table_name,
-                                    UpsertClauseType::Subtract,
+                                    UpsertClauseType::Max,
+                                ));
+                            }
+                        }
+
+                        for col in &min_columns {
+                            if !where_columns.contains(col) && !distinct_cols.contains(col) {
+                                update_clauses.push(build_upsert_set_clause(
+                                    col,
+                                    &formatted_table_name,
+                                    UpsertClauseType::Min,
                                 ));
                             }
                         }
@@ -255,8 +399,9 @@ macro_rules! create_batch_postgres_operation {
                             &column_names,
                             &conflict_columns,
                             update_clauses,
-                            sequence_col,
+                            if arithmetic_without_sequence_guard { None } else { sequence_col },
                             None, // custom_where - not used in macro-generated operations
+                            &insert_exprs,
                         ));
 
                         let params: Vec<&(dyn ToSql + Sync)> =

--- a/core/src/database/postgres/batch_operations/mod.rs
+++ b/core/src/database/postgres/batch_operations/mod.rs
@@ -7,15 +7,19 @@
 mod dynamic;
 mod macros;
 mod query_builder;
+#[cfg(test)]
+mod tests;
 
 pub use dynamic::execute_dynamic_batch_operation;
 
 // Re-exported for use by the create_batch_postgres_operation! macro
 #[allow(unused_imports)]
 pub use query_builder::{
-    build_cte_header, build_delete_body, build_insert_body, build_sequence_condition,
-    build_set_clause, build_to_process_cte, build_to_process_cte_aggregated, build_update_body,
-    build_upsert_body, build_upsert_set_clause, build_upsert_set_clause_latest_by_sequence,
+    build_arithmetic_insert_expr, build_cte_header, build_delete_body, build_insert_body,
+    build_sequence_condition, build_set_clause, build_to_process_cte,
+    build_to_process_cte_aggregated, build_update_body, build_upsert_body, build_upsert_set_clause,
+    build_upsert_set_clause_arithmetic, build_upsert_set_clause_latest_by_sequence,
     build_where_clause, build_where_condition, format_table_name, quote_identifier,
-    ColumnAggregate, ColumnInfo, SetClauseType, UpsertClauseType,
+    rewrite_custom_where_for_arithmetic, ColumnAggregate, ColumnInfo, SetClauseType,
+    UpsertClauseType,
 };

--- a/core/src/database/postgres/batch_operations/query_builder.rs
+++ b/core/src/database/postgres/batch_operations/query_builder.rs
@@ -130,8 +130,9 @@ pub fn build_to_process_cte_aggregated(
                     if let Some(ref seq) = quoted_seq {
                         format!("(array_agg({} ORDER BY {} DESC))[1] AS {}", qname, seq, qname)
                     } else {
-                        // No sequence column — fall back to MAX as a deterministic pick
-                        format!("MAX({}) AS {}", qname, qname)
+                        // No sequence column — take an arbitrary value. array_agg is
+                        // type-agnostic; MAX would fail for BOOLEAN/BYTEA columns.
+                        format!("(array_agg({}))[1] AS {}", qname, qname)
                     }
                 }
             }
@@ -204,6 +205,11 @@ pub fn build_delete_body(formatted_table_name: &str) -> String {
 /// * `update_clauses` - SET clauses for the update
 /// * `sequence_col` - Optional sequence column for ordering (adds WHERE EXCLUDED.seq > table.seq)
 /// * `custom_where` - Optional custom WHERE condition (e.g., for @table references)
+/// * `insert_exprs` - Per-column SQL expression overrides for the INSERT branch's
+///   SELECT list (e.g., `(0 - tp."balance")` so a `subtract` that creates the row
+///   starts from the column default instead of inserting the raw value). Note that
+///   `EXCLUDED.<col>` in update clauses and WHERE conditions then refers to the
+///   overridden expression's value, not the raw batch value.
 pub fn build_upsert_body(
     formatted_table_name: &str,
     all_columns: &[&str],
@@ -211,13 +217,20 @@ pub fn build_upsert_body(
     update_clauses: Vec<String>,
     sequence_col: Option<&str>,
     custom_where: Option<&str>,
+    insert_exprs: &[(&str, String)],
 ) -> String {
     let formatted_columns =
         all_columns.iter().map(|col| quote_identifier(col)).collect::<Vec<_>>().join(", ");
 
     let tp_columns = all_columns
         .iter()
-        .map(|col| format!("tp.{}", quote_identifier(col)))
+        .map(|col| {
+            insert_exprs
+                .iter()
+                .find(|(name, _)| name == col)
+                .map(|(_, expr)| expr.clone())
+                .unwrap_or_else(|| format!("tp.{}", quote_identifier(col)))
+        })
         .collect::<Vec<_>>()
         .join(", ");
 
@@ -329,6 +342,92 @@ pub fn build_upsert_set_clause(
     }
 }
 
+/// Builds the SELECT expression for the INSERT branch of an arithmetic
+/// (add/subtract) upsert column.
+///
+/// A row created by an arithmetic upsert must start from the column default,
+/// not the raw batch value — otherwise a first-touch `subtract` inserts
+/// `+value` instead of `default - value` (lost debits in running balances).
+///
+/// `insert_default` must be a validated numeric literal (see
+/// `DynamicColumnDefinition::insert_default`); when absent, 0 is used, which
+/// matches the `COALESCE(table.col, 0)` semantics of the update branch.
+pub fn build_arithmetic_insert_expr(
+    col: &str,
+    clause_type: UpsertClauseType,
+    insert_default: Option<&str>,
+) -> String {
+    let tp_col = format!("tp.{}", quote_identifier(col));
+    let default = insert_default.unwrap_or("0");
+
+    match clause_type {
+        UpsertClauseType::Add => format!("({} + {})", default, tp_col),
+        UpsertClauseType::Subtract => format!("({} - {})", default, tp_col),
+        // Set/Max/Min don't rewrite the insert value
+        _ => tp_col,
+    }
+}
+
+/// Builds the ON CONFLICT SET clause for an arithmetic (add/subtract) upsert
+/// column whose INSERT branch was built with `build_arithmetic_insert_expr`.
+///
+/// `EXCLUDED.col` carries `default ± delta` (the value the INSERT branch would
+/// have written), so the update branch recovers the delta by removing the
+/// default again:
+///   col = COALESCE(table.col, 0) + EXCLUDED.col - default
+///
+/// This same clause serves both add and subtract — the sign already lives in
+/// the EXCLUDED value.
+pub fn build_upsert_set_clause_arithmetic(
+    col: &str,
+    formatted_table_name: &str,
+    insert_default: Option<&str>,
+) -> String {
+    let column_name = quote_identifier(col);
+    match insert_default {
+        Some(default) => format!(
+            "{} = COALESCE({}.{}, 0) + EXCLUDED.{} - {}",
+            column_name, formatted_table_name, column_name, column_name, default
+        ),
+        None => format!(
+            "{} = COALESCE({}.{}, 0) + EXCLUDED.{}",
+            column_name, formatted_table_name, column_name, column_name
+        ),
+    }
+}
+
+/// Rewrites `EXCLUDED."<col>"` references in a custom WHERE condition so they
+/// keep meaning the raw batch delta for an arithmetic upsert column.
+///
+/// SQL-pushed YAML conditions render event variables as `EXCLUDED."<col>"`
+/// (see `Expression::to_sql_condition`). Once the INSERT branch is overridden
+/// with `build_arithmetic_insert_expr`, `EXCLUDED.<col>` carries
+/// `default ± delta` — sign-inverted for subtract — so conditions like
+/// `"$value <= @balance"` would silently invert. This recovers the delta:
+/// - subtract: `(default - EXCLUDED."col")`
+/// - add: `(EXCLUDED."col" - default)` (no-op when there is no default)
+pub fn rewrite_custom_where_for_arithmetic(
+    custom_where: &str,
+    col: &str,
+    clause_type: UpsertClauseType,
+    insert_default: Option<&str>,
+) -> String {
+    // Always-quoted form produced by Expression::to_sql_condition
+    let excluded_ref = format!("EXCLUDED.\"{}\"", col);
+    let replacement = match clause_type {
+        UpsertClauseType::Subtract => {
+            format!("({} - {})", insert_default.unwrap_or("0"), excluded_ref)
+        }
+        UpsertClauseType::Add => match insert_default {
+            Some(default) => format!("({} - {})", excluded_ref, default),
+            // No default: EXCLUDED already carries the raw delta
+            None => return custom_where.to_string(),
+        },
+        _ => return custom_where.to_string(),
+    };
+    custom_where.replace(&excluded_ref, &replacement)
+}
+
 /// Builds an upsert SET clause that keeps the latest value by sequence while
 /// allowing arithmetic columns in the same upsert to accumulate regardless of
 /// processing order.
@@ -353,6 +452,7 @@ pub fn build_upsert_set_clause_latest_by_sequence(
 }
 
 /// Type of upsert SET clause to generate.
+#[derive(Clone, Copy)]
 pub enum UpsertClauseType {
     Set,
     Add,
@@ -388,5 +488,148 @@ pub fn build_where_clause(conditions: &[String]) -> String {
         String::new()
     } else {
         format!("\nWHERE {}", conditions.join("\n  AND "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arithmetic_insert_expr_negates_subtract() {
+        assert_eq!(
+            build_arithmetic_insert_expr("balance", UpsertClauseType::Subtract, None),
+            "(0 - tp.balance)"
+        );
+        assert_eq!(
+            build_arithmetic_insert_expr("balance", UpsertClauseType::Subtract, Some("100")),
+            "(100 - tp.balance)"
+        );
+    }
+
+    #[test]
+    fn arithmetic_insert_expr_offsets_add_by_default() {
+        assert_eq!(
+            build_arithmetic_insert_expr("balance", UpsertClauseType::Add, None),
+            "(0 + tp.balance)"
+        );
+        assert_eq!(
+            build_arithmetic_insert_expr("balance", UpsertClauseType::Add, Some("100")),
+            "(100 + tp.balance)"
+        );
+    }
+
+    #[test]
+    fn arithmetic_insert_expr_leaves_set_max_min_untouched() {
+        for clause_type in [UpsertClauseType::Set, UpsertClauseType::Max, UpsertClauseType::Min] {
+            assert_eq!(
+                build_arithmetic_insert_expr("balance", clause_type, Some("100")),
+                "tp.balance"
+            );
+        }
+    }
+
+    #[test]
+    fn arithmetic_upsert_set_clause_recovers_delta_from_excluded() {
+        assert_eq!(
+            build_upsert_set_clause_arithmetic("balance", "t", None),
+            "balance = COALESCE(t.balance, 0) + EXCLUDED.balance"
+        );
+        assert_eq!(
+            build_upsert_set_clause_arithmetic("balance", "t", Some("100")),
+            "balance = COALESCE(t.balance, 0) + EXCLUDED.balance - 100"
+        );
+    }
+
+    #[test]
+    fn upsert_body_applies_insert_expr_overrides() {
+        let insert_exprs = vec![(
+            "balance",
+            build_arithmetic_insert_expr("balance", UpsertClauseType::Subtract, None),
+        )];
+        let body = build_upsert_body(
+            "t",
+            &["network", "holder", "balance"],
+            &["network", "holder"],
+            vec!["balance = COALESCE(t.balance, 0) + EXCLUDED.balance".to_string()],
+            None,
+            None,
+            &insert_exprs,
+        );
+
+        assert!(
+            body.contains("SELECT tp.network, tp.holder, (0 - tp.balance)"),
+            "insert branch must start subtract rows from the default: {body}"
+        );
+        assert!(
+            !body.contains("WHERE EXCLUDED."),
+            "arithmetic upserts must not carry the sequence guard: {body}"
+        );
+    }
+
+    #[test]
+    fn custom_where_rewrite_recovers_raw_delta() {
+        let guard = "EXCLUDED.\"balance\" <= t.\"balance\"";
+
+        assert_eq!(
+            rewrite_custom_where_for_arithmetic(guard, "balance", UpsertClauseType::Subtract, None),
+            "(0 - EXCLUDED.\"balance\") <= t.\"balance\""
+        );
+        assert_eq!(
+            rewrite_custom_where_for_arithmetic(
+                guard,
+                "balance",
+                UpsertClauseType::Subtract,
+                Some("100")
+            ),
+            "(100 - EXCLUDED.\"balance\") <= t.\"balance\""
+        );
+        assert_eq!(
+            rewrite_custom_where_for_arithmetic(
+                guard,
+                "balance",
+                UpsertClauseType::Add,
+                Some("100")
+            ),
+            "(EXCLUDED.\"balance\" - 100) <= t.\"balance\""
+        );
+        // Add with no default: EXCLUDED already carries the raw delta
+        assert_eq!(
+            rewrite_custom_where_for_arithmetic(guard, "balance", UpsertClauseType::Add, None),
+            guard
+        );
+        // Other columns' EXCLUDED references are untouched
+        assert_eq!(
+            rewrite_custom_where_for_arithmetic(guard, "amount", UpsertClauseType::Subtract, None),
+            guard
+        );
+    }
+
+    #[test]
+    fn aggregated_cte_without_sequence_uses_array_agg_for_set_columns() {
+        let cte = build_to_process_cte_aggregated(
+            &[("holder", ColumnAggregate::GroupKey), ("flag", ColumnAggregate::LastBySeq)],
+            None,
+        );
+        assert!(
+            cte.contains("(array_agg(flag))[1] AS flag"),
+            "must not use MAX() which fails for BOOLEAN/BYTEA: {cte}"
+        );
+    }
+
+    #[test]
+    fn upsert_body_without_overrides_keeps_sequence_guard() {
+        let body = build_upsert_body(
+            "t",
+            &["holder", "name", "seq"],
+            &["holder"],
+            vec!["name = EXCLUDED.name".to_string()],
+            Some("seq"),
+            None,
+            &[],
+        );
+
+        assert!(body.contains("SELECT tp.holder, tp.name, tp.seq"), "{body}");
+        assert!(body.contains("WHERE EXCLUDED.seq > COALESCE(t.seq, 0)"), "{body}");
     }
 }

--- a/core/src/database/postgres/batch_operations/tests.rs
+++ b/core/src/database/postgres/batch_operations/tests.rs
@@ -1,0 +1,621 @@
+//! Real-Postgres integration tests for batch upsert semantics, mirroring the
+//! ERC20 running-balances shape from the no-code `tables:` feature (one upsert
+//! operation crediting `$to` with `add`, one debiting `$from` with `subtract`).
+//!
+//! The key invariants under test:
+//! - A row *created* by an arithmetic upsert starts from the column default
+//!   (`default - value` for subtract), not the raw value. A sender-only
+//!   address must end up negative.
+//! - Duplicate keys within one statement accumulate (GROUP BY SUM) instead of
+//!   dropping all but one row.
+//! - Arithmetic deltas apply regardless of event sequence order (no sequence
+//!   guard), while plain `set` upserts still honor the sequence guard.
+//! - The `create_batch_postgres_operation!` macro path (custom Rust indexing)
+//!   has the same semantics as the dynamic no-code path.
+//!
+//! Requires Docker:
+//!   cargo test -p rindexer --lib database::postgres::batch_operations
+
+use std::collections::HashMap;
+
+use alloy::primitives::U256;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use tokio_postgres::types::ToSql;
+
+use super::execute_dynamic_batch_operation;
+use crate::database::batch_operations::{
+    column, BatchOperationAction, BatchOperationColumnBehavior, BatchOperationSqlType,
+    BatchOperationType, DynamicColumnDefinition,
+};
+use crate::database::postgres::client::PostgresClient;
+use crate::{rindexer_error, EthereumSqlTypeWrapper};
+
+const NETWORK: &str = "ethereum";
+const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+
+/// Builds one row for the balances table exactly as
+/// `execute_postgres_operation` in `indexer/tables.rs` would for a
+/// credit (`Add`) or debit (`Subtract`) operation.
+fn balance_row(
+    holder: &str,
+    value: u64,
+    seq: u128,
+    action: BatchOperationAction,
+    insert_default: Option<&str>,
+) -> Vec<DynamicColumnDefinition> {
+    vec![
+        DynamicColumnDefinition::new(
+            "network".to_string(),
+            EthereumSqlTypeWrapper::String(NETWORK.to_string()),
+            BatchOperationSqlType::Varchar,
+            BatchOperationColumnBehavior::Distinct,
+            BatchOperationAction::Where,
+        ),
+        DynamicColumnDefinition::new(
+            "holder".to_string(),
+            EthereumSqlTypeWrapper::String(holder.to_string()),
+            BatchOperationSqlType::Text,
+            BatchOperationColumnBehavior::Distinct,
+            BatchOperationAction::Where,
+        ),
+        DynamicColumnDefinition::new(
+            "balance".to_string(),
+            EthereumSqlTypeWrapper::U256Numeric(U256::from(value)),
+            BatchOperationSqlType::Numeric,
+            BatchOperationColumnBehavior::Normal,
+            action,
+        )
+        .with_insert_default(insert_default.map(str::to_string)),
+        DynamicColumnDefinition::new(
+            "rindexer_sequence_id".to_string(),
+            EthereumSqlTypeWrapper::U128(seq),
+            BatchOperationSqlType::Numeric,
+            BatchOperationColumnBehavior::Sequence,
+            BatchOperationAction::Set,
+        ),
+    ]
+}
+
+/// Applies one batch of transfers the way `process_table_operations` does:
+/// first all credits as one upsert statement, then all debits as another.
+async fn apply_transfer_batch(
+    db: &PostgresClient,
+    table: &str,
+    transfers: &[(&str, &str, u64, u128)], // (from, to, value, sequence)
+) {
+    let credits: Vec<Vec<DynamicColumnDefinition>> = transfers
+        .iter()
+        .filter(|(_, to, _, _)| *to != ZERO_ADDRESS)
+        .map(|(_, to, value, seq)| {
+            balance_row(to, *value, *seq, BatchOperationAction::Add, Some("0"))
+        })
+        .collect();
+    if !credits.is_empty() {
+        execute_dynamic_batch_operation(
+            db,
+            table,
+            BatchOperationType::Upsert,
+            credits,
+            "test-credit",
+            None,
+        )
+        .await
+        .expect("credit upsert failed");
+    }
+
+    let debits: Vec<Vec<DynamicColumnDefinition>> = transfers
+        .iter()
+        .filter(|(from, _, _, _)| *from != ZERO_ADDRESS)
+        .map(|(from, _, value, seq)| {
+            balance_row(from, *value, *seq, BatchOperationAction::Subtract, Some("0"))
+        })
+        .collect();
+    if !debits.is_empty() {
+        execute_dynamic_batch_operation(
+            db,
+            table,
+            BatchOperationType::Upsert,
+            debits,
+            "test-debit",
+            None,
+        )
+        .await
+        .expect("debit upsert failed");
+    }
+}
+
+async fn fetch_balances(db: &PostgresClient, table: &str) -> HashMap<String, i128> {
+    db.query(&format!("SELECT holder, balance::TEXT AS balance FROM {table}"), &[])
+        .await
+        .expect("failed to query balances")
+        .into_iter()
+        .map(|row| {
+            let holder: String = row.get("holder");
+            let balance: String = row.get("balance");
+            (holder, balance.parse::<i128>().expect("balance should be an integer"))
+        })
+        .collect()
+}
+
+async fn start_postgres() -> (testcontainers::ContainerAsync<Postgres>, PostgresClient) {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let container = Postgres::default().start().await.expect("failed to start postgres");
+    let port = container.get_host_port_ipv4(5432).await.expect("failed to get postgres port");
+
+    let _guard = crate::database::postgres::client::TEST_DATABASE_URL_LOCK.lock().await;
+    std::env::set_var(
+        "DATABASE_URL",
+        format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres?sslmode=disable"),
+    );
+    let client = PostgresClient::new().await.expect("failed to create postgres client");
+    (container, client)
+}
+
+/// The envio open-indexer-benchmark `erc20-account-balances` shape: running
+/// balances from Transfer events, including sender-only addresses that must
+/// end up negative.
+#[tokio::test]
+async fn arithmetic_upsert_running_balances_match_in_memory_fold() {
+    let (_container, db) = start_postgres().await;
+
+    db.batch_execute(
+        "CREATE TABLE balances (
+            network VARCHAR(50) NOT NULL,
+            holder TEXT NOT NULL,
+            balance NUMERIC NOT NULL DEFAULT 0,
+            rindexer_sequence_id NUMERIC,
+            PRIMARY KEY (network, holder)
+        )",
+    )
+    .await
+    .expect("failed to create balances table");
+
+    // (from, to, value, sequence) — batches mirror how block ranges chunk
+    // events. Covers: sender-only (a), duplicate sender in one batch (c),
+    // self-transfer (d), debit-then-credit across batches (e), mint (zero
+    // address from), receiver-then-sender (b).
+    let batches: Vec<Vec<(&str, &str, u64, u128)>> = vec![
+        vec![
+            ("0xa", "0xb", 10, 1),
+            ("0xc", "0xb", 3, 2),
+            ("0xc", "0xb", 4, 3),
+            ("0xd", "0xd", 5, 4),
+            ("0xe", "0xf", 8, 5),
+        ],
+        vec![(ZERO_ADDRESS, "0xg", 100, 6), ("0xg", "0xe", 3, 7), ("0xb", "0xa", 2, 8)],
+        vec![("0xe", "0xa", 1, 9), ("0xf", "0xc", 2, 10)],
+    ];
+
+    let mut expected: HashMap<String, i128> = HashMap::new();
+    for batch in &batches {
+        for (from, to, value, _) in batch {
+            if *to != ZERO_ADDRESS {
+                *expected.entry(to.to_string()).or_default() += *value as i128;
+            }
+            if *from != ZERO_ADDRESS {
+                *expected.entry(from.to_string()).or_default() -= *value as i128;
+            }
+        }
+    }
+
+    for batch in &batches {
+        apply_transfer_batch(&db, "balances", batch).await;
+    }
+
+    let actual = fetch_balances(&db, "balances").await;
+
+    // Every touched address must have a row — no account may be absent.
+    assert_eq!(actual.len(), expected.len(), "account count mismatch: {actual:?}");
+    for (holder, expected_balance) in &expected {
+        assert_eq!(
+            actual.get(holder),
+            Some(expected_balance),
+            "balance mismatch for {holder}: {actual:?}"
+        );
+    }
+
+    // The specific regression: a sender-only address must be negative.
+    assert_eq!(actual.get("0xd"), Some(&0), "self-transfer must net to zero");
+    assert!(actual.get("0xc").is_some_and(|b| *b < 0), "sender-first address must go negative");
+}
+
+/// A row created by an arithmetic upsert starts from the column default.
+#[tokio::test]
+async fn arithmetic_upsert_honors_nonzero_column_default() {
+    let (_container, db) = start_postgres().await;
+
+    db.batch_execute(
+        "CREATE TABLE scores (
+            network VARCHAR(50) NOT NULL,
+            holder TEXT NOT NULL,
+            balance NUMERIC NOT NULL DEFAULT 100,
+            rindexer_sequence_id NUMERIC,
+            PRIMARY KEY (network, holder)
+        )",
+    )
+    .await
+    .expect("failed to create scores table");
+
+    let upsert = |holder: &str, value: u64, seq: u128, action: BatchOperationAction| {
+        vec![balance_row(holder, value, seq, action, Some("100"))]
+    };
+
+    // New row via subtract: 100 - 30 = 70
+    execute_dynamic_batch_operation(
+        &db,
+        "scores",
+        BatchOperationType::Upsert,
+        upsert("0xx", 30, 1, BatchOperationAction::Subtract),
+        "test",
+        None,
+    )
+    .await
+    .unwrap();
+    // Existing row via add: 70 + 10 = 80
+    execute_dynamic_batch_operation(
+        &db,
+        "scores",
+        BatchOperationType::Upsert,
+        upsert("0xx", 10, 2, BatchOperationAction::Add),
+        "test",
+        None,
+    )
+    .await
+    .unwrap();
+    // New row via add: 100 + 5 = 105
+    execute_dynamic_batch_operation(
+        &db,
+        "scores",
+        BatchOperationType::Upsert,
+        upsert("0xy", 5, 3, BatchOperationAction::Add),
+        "test",
+        None,
+    )
+    .await
+    .unwrap();
+
+    let actual = fetch_balances(&db, "scores").await;
+    assert_eq!(actual.get("0xx"), Some(&80));
+    assert_eq!(actual.get("0xy"), Some(&105));
+}
+
+/// Plain `set` upserts (no arithmetic) must still honor the sequence guard:
+/// an event with a lower sequence than the stored row is ignored.
+#[tokio::test]
+async fn set_upsert_still_honors_sequence_guard() {
+    let (_container, db) = start_postgres().await;
+
+    db.batch_execute(
+        "CREATE TABLE latest_names (
+            network VARCHAR(50) NOT NULL,
+            holder TEXT NOT NULL,
+            name TEXT,
+            rindexer_sequence_id NUMERIC,
+            PRIMARY KEY (network, holder)
+        )",
+    )
+    .await
+    .expect("failed to create latest_names table");
+
+    let set_row = |name: &str, seq: u128| {
+        vec![vec![
+            DynamicColumnDefinition::new(
+                "network".to_string(),
+                EthereumSqlTypeWrapper::String(NETWORK.to_string()),
+                BatchOperationSqlType::Varchar,
+                BatchOperationColumnBehavior::Distinct,
+                BatchOperationAction::Where,
+            ),
+            DynamicColumnDefinition::new(
+                "holder".to_string(),
+                EthereumSqlTypeWrapper::String("0xh".to_string()),
+                BatchOperationSqlType::Text,
+                BatchOperationColumnBehavior::Distinct,
+                BatchOperationAction::Where,
+            ),
+            DynamicColumnDefinition::new(
+                "name".to_string(),
+                EthereumSqlTypeWrapper::String(name.to_string()),
+                BatchOperationSqlType::Text,
+                BatchOperationColumnBehavior::Normal,
+                BatchOperationAction::Set,
+            ),
+            DynamicColumnDefinition::new(
+                "rindexer_sequence_id".to_string(),
+                EthereumSqlTypeWrapper::U128(seq),
+                BatchOperationSqlType::Numeric,
+                BatchOperationColumnBehavior::Sequence,
+                BatchOperationAction::Set,
+            ),
+        ]]
+    };
+
+    // The stale write (seq 5) is applied LAST so the assertion can only pass
+    // if the sequence guard blocks it — last-write-wins would leave "b".
+    for (name, seq) in [("a", 10), ("c", 20), ("b", 5)] {
+        execute_dynamic_batch_operation(
+            &db,
+            "latest_names",
+            BatchOperationType::Upsert,
+            set_row(name, seq),
+            "test",
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let row =
+        db.query_one("SELECT name FROM latest_names WHERE holder = '0xh'", &[]).await.unwrap();
+    let name: String = row.get("name");
+    assert_eq!(name, "c", "stale seq 5 applied last must be ignored; seq 20 must win");
+}
+
+/// A pushed-down `if:` condition ("$balance <= @balance" style) references the
+/// arithmetic column via EXCLUDED — the rewrite must keep it meaning the raw
+/// delta even though the INSERT branch now carries `default - delta`.
+#[tokio::test]
+async fn custom_where_on_subtract_column_keeps_raw_delta_semantics() {
+    let (_container, db) = start_postgres().await;
+
+    db.batch_execute(
+        "CREATE TABLE guarded_balances (
+            network VARCHAR(50) NOT NULL,
+            holder TEXT NOT NULL,
+            balance NUMERIC NOT NULL DEFAULT 0,
+            rindexer_sequence_id NUMERIC,
+            PRIMARY KEY (network, holder)
+        )",
+    )
+    .await
+    .expect("failed to create guarded_balances table");
+
+    // Exactly what Expression::to_sql_condition produces for
+    // `if: "$balance <= @balance"` — only debit when funds are sufficient.
+    let guard = "EXCLUDED.\"balance\" <= guarded_balances.\"balance\"";
+
+    // Seed the account with 50.
+    execute_dynamic_batch_operation(
+        &db,
+        "guarded_balances",
+        BatchOperationType::Upsert,
+        vec![balance_row("0xg1", 50, 1, BatchOperationAction::Add, Some("0"))],
+        "test",
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Sufficient funds: 30 <= 50, debit applies: 50 - 30 = 20
+    execute_dynamic_batch_operation(
+        &db,
+        "guarded_balances",
+        BatchOperationType::Upsert,
+        vec![balance_row("0xg1", 30, 2, BatchOperationAction::Subtract, Some("0"))],
+        "test",
+        Some(guard),
+    )
+    .await
+    .unwrap();
+
+    // Insufficient funds: 100 <= 20 is false, debit must be skipped
+    execute_dynamic_batch_operation(
+        &db,
+        "guarded_balances",
+        BatchOperationType::Upsert,
+        vec![balance_row("0xg1", 100, 3, BatchOperationAction::Subtract, Some("0"))],
+        "test",
+        Some(guard),
+    )
+    .await
+    .unwrap();
+
+    let actual = fetch_balances(&db, "guarded_balances").await;
+    assert_eq!(
+        actual.get("0xg1"),
+        Some(&20),
+        "guard must compare the raw delta, not the negated insert value"
+    );
+
+    // Same guard with a NON-ZERO default: the rewrite must recover the delta
+    // using the column's default (25), not 0. A wrong default source would
+    // evaluate the second debit's guard as (0 - (25-30)) = 5 <= 20 and apply it.
+    db.batch_execute(
+        "CREATE TABLE guarded_scores (
+            network VARCHAR(50) NOT NULL,
+            holder TEXT NOT NULL,
+            balance NUMERIC NOT NULL DEFAULT 25,
+            rindexer_sequence_id NUMERIC,
+            PRIMARY KEY (network, holder)
+        )",
+    )
+    .await
+    .expect("failed to create guarded_scores table");
+    let score_guard = "EXCLUDED.\"balance\" <= guarded_scores.\"balance\"";
+
+    // First touch via unguarded subtract: 25 - 5 = 20
+    execute_dynamic_batch_operation(
+        &db,
+        "guarded_scores",
+        BatchOperationType::Upsert,
+        vec![balance_row("0xg2", 5, 1, BatchOperationAction::Subtract, Some("25"))],
+        "test",
+        None,
+    )
+    .await
+    .unwrap();
+    // Guarded debit of 30: raw delta 30 <= 20 is false, must be skipped
+    execute_dynamic_batch_operation(
+        &db,
+        "guarded_scores",
+        BatchOperationType::Upsert,
+        vec![balance_row("0xg2", 30, 2, BatchOperationAction::Subtract, Some("25"))],
+        "test",
+        Some(score_guard),
+    )
+    .await
+    .unwrap();
+
+    let actual = fetch_balances(&db, "guarded_scores").await;
+    assert_eq!(
+        actual.get("0xg2"),
+        Some(&20),
+        "guard rewrite must use the column default (25) to recover the delta"
+    );
+}
+
+/// Max upserts: new rows take the event value, existing rows keep the greater.
+#[tokio::test]
+async fn max_upsert_keeps_greater_value() {
+    let (_container, db) = start_postgres().await;
+
+    db.batch_execute(
+        "CREATE TABLE high_water (
+            network VARCHAR(50) NOT NULL,
+            holder TEXT NOT NULL,
+            balance NUMERIC NOT NULL DEFAULT 0,
+            rindexer_sequence_id NUMERIC,
+            PRIMARY KEY (network, holder)
+        )",
+    )
+    .await
+    .expect("failed to create high_water table");
+
+    // The smaller value is applied LAST so the assertion can only pass with
+    // Max semantics — last-write-wins (Set) would leave 5.
+    for (value, seq) in [(10u64, 1u128), (20, 2), (5, 3)] {
+        execute_dynamic_batch_operation(
+            &db,
+            "high_water",
+            BatchOperationType::Upsert,
+            vec![balance_row("0xw", value, seq, BatchOperationAction::Max, None)],
+            "test",
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let actual = fetch_balances(&db, "high_water").await;
+    assert_eq!(actual.get("0xw"), Some(&20), "smaller value applied last must not win");
+}
+
+/// The `create_batch_postgres_operation!` macro (custom Rust indexing) must
+/// have the same arithmetic semantics as the dynamic no-code path: rows
+/// created by subtract go negative, duplicate keys in a batch accumulate,
+/// and lower-sequence deltas still apply.
+#[tokio::test]
+async fn macro_batch_upsert_matches_dynamic_semantics() {
+    struct BalanceDelta {
+        holder: &'static str,
+        amount: U256,
+        seq: u128,
+        last_block: u64,
+    }
+
+    crate::create_batch_postgres_operation!(
+        macro_debit,
+        BalanceDelta,
+        "macro_balances",
+        BatchOperationType::Upsert,
+        |delta: &BalanceDelta| {
+            vec![
+                column(
+                    "holder",
+                    EthereumSqlTypeWrapper::String(delta.holder.to_string()),
+                    BatchOperationSqlType::Text,
+                    BatchOperationColumnBehavior::Distinct,
+                    BatchOperationAction::Where,
+                ),
+                column(
+                    "balance",
+                    EthereumSqlTypeWrapper::U256Numeric(delta.amount),
+                    BatchOperationSqlType::Numeric,
+                    BatchOperationColumnBehavior::Normal,
+                    BatchOperationAction::Subtract,
+                ),
+                column(
+                    "peak_debit",
+                    EthereumSqlTypeWrapper::U256Numeric(delta.amount),
+                    BatchOperationSqlType::Numeric,
+                    BatchOperationColumnBehavior::Normal,
+                    BatchOperationAction::Max,
+                ),
+                column(
+                    "last_block",
+                    EthereumSqlTypeWrapper::U64BigInt(delta.last_block),
+                    BatchOperationSqlType::Bigint,
+                    BatchOperationColumnBehavior::Normal,
+                    BatchOperationAction::Set,
+                ),
+                column(
+                    "rindexer_sequence_id",
+                    EthereumSqlTypeWrapper::U128(delta.seq),
+                    BatchOperationSqlType::Numeric,
+                    BatchOperationColumnBehavior::Sequence,
+                    BatchOperationAction::Set,
+                ),
+            ]
+        },
+        "test-macro-debit"
+    );
+
+    let (_container, db) = start_postgres().await;
+
+    db.batch_execute(
+        "CREATE TABLE macro_balances (
+            holder TEXT PRIMARY KEY,
+            balance NUMERIC NOT NULL DEFAULT 0,
+            peak_debit NUMERIC,
+            last_block BIGINT,
+            rindexer_sequence_id NUMERIC
+        )",
+    )
+    .await
+    .expect("failed to create macro_balances table");
+
+    // Duplicate key within one call must accumulate: -10 - 3 = -13.
+    // The set column must keep the value from the highest sequence (600);
+    // the max column must keep the greatest debit (10).
+    macro_debit(
+        &db,
+        &[
+            BalanceDelta { holder: "0xm1", amount: U256::from(10u64), seq: 5, last_block: 500 },
+            BalanceDelta { holder: "0xm1", amount: U256::from(3u64), seq: 6, last_block: 600 },
+            BalanceDelta { holder: "0xm2", amount: U256::from(7u64), seq: 7, last_block: 700 },
+        ],
+    )
+    .await
+    .expect("macro debit failed");
+
+    // Lower sequence than the stored row: the arithmetic delta must still
+    // apply (-13 - 2 = -15) but the stale set column must NOT overwrite, and
+    // the smaller debit (2, applied last) must not shrink the max column.
+    macro_debit(
+        &db,
+        &[BalanceDelta { holder: "0xm1", amount: U256::from(2u64), seq: 1, last_block: 100 }],
+    )
+    .await
+    .expect("macro debit failed");
+
+    let actual = fetch_balances(&db, "macro_balances").await;
+    assert_eq!(actual.get("0xm1"), Some(&-15));
+    assert_eq!(actual.get("0xm2"), Some(&-7));
+
+    let row = db
+        .query_one(
+            "SELECT last_block, peak_debit::TEXT AS peak, rindexer_sequence_id::TEXT AS seq
+             FROM macro_balances WHERE holder = '0xm1'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let last_block: i64 = row.get("last_block");
+    let peak: String = row.get("peak");
+    let seq: String = row.get("seq");
+    assert_eq!(last_block, 600, "set column must keep the latest-by-sequence value");
+    assert_eq!(peak, "10", "max column must keep the greatest value, not the last");
+    assert_eq!(seq, "6", "sequence column must keep the max sequence");
+}

--- a/core/src/database/postgres/client.rs
+++ b/core/src/database/postgres/client.rs
@@ -29,6 +29,13 @@ pub fn connection_string() -> Result<String, env::VarError> {
     Ok(connection)
 }
 
+/// DATABASE_URL is process-global while tests run in parallel, so tests that
+/// point it at a per-test container must hold this lock from `set_var` until
+/// the client has connected.
+#[cfg(test)]
+pub(crate) static TEST_DATABASE_URL_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 #[derive(thiserror::Error, Debug)]
 pub enum PostgresConnectionError {
     #[error("The database connection string is wrong please check your environment: {0}")]

--- a/core/src/database/postgres/migrations.rs
+++ b/core/src/database/postgres/migrations.rs
@@ -92,10 +92,10 @@ pub async fn execute_migrations_for_indexer_sql(
             let events = ABIItem::extract_event_names_and_signatures_from_abi(abi_items)?;
             let schema_name = generate_indexer_contract_schema_name(&indexer.name, &contract_name);
 
-            // Only run migrations on raw event tables (events in include_events)
-            // Skip events that are only used for custom tables
+            // Run migrations on every raw event table that exists — the same
+            // predicate DDL creation uses (include_events plus table events)
             let raw_events: Vec<_> =
-                events.iter().filter(|e| contract.is_event_in_include_events(&e.name)).collect();
+                events.iter().filter(|e| contract.stores_raw_events(&e.name)).collect();
 
             for event_info in raw_events {
                 let table_name = format!("{}.{}", schema_name, camel_to_snake(&event_info.name));

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -105,6 +105,12 @@ pub fn resolve_table_column_types(
         // Resolve column types in custom tables
         if let Some(tables) = &mut contract.tables {
             resolve_tables_against_abi(tables, &event_abi_types)?;
+            for table in tables.iter() {
+                super::tables::warn_on_unusable_arithmetic_defaults(
+                    table,
+                    &format!("{}.{}", contract.name, table.name),
+                );
+            }
         }
     }
 
@@ -116,6 +122,12 @@ pub fn resolve_table_column_types(
                 .map_err(|e| SetupNoCodeError::ProcessIndexersError(e.into()))?;
             let event_abi_types = build_event_abi_types(abi_items)?;
             resolve_tables_against_abi(tables, &event_abi_types)?;
+            for table in tables.iter() {
+                super::tables::warn_on_unusable_arithmetic_defaults(
+                    table,
+                    &format!("native_transfers.{}", table.name),
+                );
+            }
         }
     }
 
@@ -1049,11 +1061,10 @@ async fn process_contract(
             })
             .unwrap_or_default();
 
-        // Determine if this event should store raw events
-        // Store raw events if: (a) event is in include_events, OR (b) tables are defined
-        // (tables need raw events as source of truth for reorg recomputation)
-        let has_tables = !contract_tables.is_empty();
-        let store_raw_events = contract.is_event_in_include_events(&event_name) || has_tables;
+        // Store raw events when this event's raw event table exists — same
+        // predicate the DDL and migrations use (include_events plus events
+        // that drive custom tables, the reorg recomputation source of truth)
+        let store_raw_events = contract.stores_raw_events(&event_name);
 
         let tables_arc = Arc::new(contract_tables);
         let streams_arc = Arc::new(streams_client);

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -146,7 +146,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use alloy::dyn_abi::{DynSolType, DynSolValue};
-use alloy::primitives::{Address, Bytes, B256, U256, U64};
+use alloy::primitives::{Address, Bytes, B256, I256, U256, U64};
 use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
 use serde_json::{json, Value};
@@ -1435,6 +1435,41 @@ impl TableRuntime {
             full_table_name,
             indexer_name: indexer_name.to_string(),
             contract_name: contract_name.to_string(),
+        }
+    }
+}
+
+/// Warns when a column used by an add/subtract upsert has a `default` that
+/// can't be canonicalized to a numeric literal (e.g. `1e18`). Postgres may
+/// accept such a default in DDL, but rows created by the arithmetic upsert
+/// would start from 0 instead — surfacing the divergence beats silently
+/// computing wrong balances. Called once per table during manifest column
+/// resolution; requires column types to be resolved first.
+pub(crate) fn warn_on_unusable_arithmetic_defaults(table: &Table, table_label: &str) {
+    for operation in table.all_operations() {
+        // Only upserts create rows via the arithmetic insert path
+        if operation.operation_type != OperationType::Upsert {
+            continue;
+        }
+        for set_col in &operation.set {
+            if !matches!(
+                set_col.action,
+                SetAction::Add | SetAction::Subtract | SetAction::Increment | SetAction::Decrement
+            ) {
+                continue;
+            }
+            let Some(column) = table.columns.iter().find(|c| c.name == set_col.column) else {
+                continue;
+            };
+            let Some(default) = column.default.as_deref() else { continue };
+            if arithmetic_insert_default(default, column.resolved_type()).is_none() {
+                warn!(
+                    "{}: column '{}' has default '{}' which is not a plain numeric literal; \
+                     rows created by the '{:?}' operation will start from 0 instead of the \
+                     default. Use a plain decimal value (e.g. \"1000000000000000000\").",
+                    table_label, column.name, default, set_col.action
+                );
+            }
         }
     }
 }
@@ -3867,6 +3902,30 @@ fn column_type_to_batch_sql_type(column_type: &ColumnType) -> BatchOperationSqlT
     }
 }
 
+/// Canonicalizes a column's YAML `default` into a numeric SQL literal usable as
+/// the starting value of an arithmetic upsert (a row created by `subtract` must
+/// begin at `default - value`, not `+value`). Returns None for non-numeric
+/// types or unparseable values (callers fall back to 0), so no raw YAML string
+/// ever reaches the SQL text.
+fn arithmetic_insert_default(default: &str, column_type: &ColumnType) -> Option<String> {
+    let default = default.trim();
+    match column_type {
+        ColumnType::Uint8 | ColumnType::Uint16 | ColumnType::Uint32 | ColumnType::Uint64 => {
+            default.parse::<u64>().ok().map(|v| v.to_string())
+        }
+        ColumnType::Int8 | ColumnType::Int16 | ColumnType::Int32 | ColumnType::Int64 => {
+            default.parse::<i64>().ok().map(|v| v.to_string())
+        }
+        ColumnType::Uint128 | ColumnType::Uint256 => {
+            default.parse::<U256>().ok().map(|v| v.to_string())
+        }
+        ColumnType::Int128 | ColumnType::Int256 => {
+            default.parse::<I256>().ok().map(|v| v.to_string())
+        }
+        _ => None,
+    }
+}
+
 /// Maps SetAction to BatchOperationAction.
 fn set_action_to_batch_action(action: &SetAction) -> BatchOperationAction {
     match action {
@@ -3966,13 +4025,27 @@ async fn execute_postgres_operation(
                 BatchOperationAction::Nothing
             };
 
-            columns.push(DynamicColumnDefinition::new(
-                column.name.clone(),
-                value,
-                column_type_to_batch_sql_type(column_type),
-                behavior,
-                action,
-            ));
+            // Arithmetic upserts start new rows from the column default
+            let insert_default =
+                if matches!(action, BatchOperationAction::Add | BatchOperationAction::Subtract) {
+                    column
+                        .default
+                        .as_deref()
+                        .and_then(|d| arithmetic_insert_default(d, column_type))
+                } else {
+                    None
+                };
+
+            columns.push(
+                DynamicColumnDefinition::new(
+                    column.name.clone(),
+                    value,
+                    column_type_to_batch_sql_type(column_type),
+                    behavior,
+                    action,
+                )
+                .with_insert_default(insert_default),
+            );
         }
 
         // Auto-injected metadata columns
@@ -5747,5 +5820,131 @@ mod tests {
             &meta,
         );
         assert_eq!(result, Some("blk=42,log=3".to_string()));
+    }
+
+    #[test]
+    fn arithmetic_insert_default_canonicalizes_numeric_literals() {
+        // Accepted: plain decimals (trimmed), hex via alloy FromStr, signed values
+        assert_eq!(arithmetic_insert_default("0", &ColumnType::Uint256), Some("0".to_string()));
+        assert_eq!(arithmetic_insert_default(" 50 ", &ColumnType::Uint256), Some("50".to_string()));
+        assert_eq!(arithmetic_insert_default("0x10", &ColumnType::Uint256), Some("16".to_string()));
+        assert_eq!(
+            arithmetic_insert_default("1_000", &ColumnType::Uint256),
+            Some("1000".to_string())
+        );
+        assert_eq!(arithmetic_insert_default("-5", &ColumnType::Int64), Some("-5".to_string()));
+        assert_eq!(arithmetic_insert_default("-5", &ColumnType::Int256), Some("-5".to_string()));
+        assert_eq!(arithmetic_insert_default("255", &ColumnType::Uint8), Some("255".to_string()));
+
+        // Rejected (callers fall back to 0 and TableRuntime::new warns):
+        // negatives on unsigned types, scientific notation, non-numeric types
+        assert_eq!(arithmetic_insert_default("-5", &ColumnType::Uint64), None);
+        assert_eq!(arithmetic_insert_default("1e18", &ColumnType::Uint256), None);
+        assert_eq!(arithmetic_insert_default("abc", &ColumnType::Uint256), None);
+        assert_eq!(arithmetic_insert_default("0", &ColumnType::String), None);
+        assert_eq!(arithmetic_insert_default("true", &ColumnType::Bool), None);
+    }
+
+    /// End-to-end check of the YAML-declared upsert path against a real
+    /// Postgres: a `subtract` operation that creates the row must start from
+    /// the column default (`default - value`), and later deltas accumulate.
+    ///
+    /// Requires Docker.
+    #[tokio::test]
+    async fn yaml_subtract_upsert_creates_rows_from_column_default() {
+        use testcontainers::runners::AsyncRunner;
+        use testcontainers_modules::postgres::Postgres;
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let table: Table = serde_yaml::from_str(
+            r#"
+name: balances
+columns:
+  - name: holder
+    type: string
+  - name: balance
+    type: uint256
+    default: "50"
+events:
+  - event: Transfer
+    operations:
+      - type: upsert
+        where:
+          holder: $from
+        set:
+          - column: balance
+            action: subtract
+            value: $value
+"#,
+        )
+        .expect("table yaml should parse");
+        let operation = &table.events[0].operations[0];
+
+        let container = Postgres::default().start().await.expect("failed to start postgres");
+        let port = container.get_host_port_ipv4(5432).await.expect("failed to get postgres port");
+        let postgres = {
+            let _guard = crate::database::postgres::client::TEST_DATABASE_URL_LOCK.lock().await;
+            std::env::set_var(
+                "DATABASE_URL",
+                format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres?sslmode=disable"),
+            );
+            PostgresClient::new().await.expect("failed to create postgres client")
+        };
+
+        postgres
+            .batch_execute(
+                "CREATE TABLE yaml_balances (
+                    network VARCHAR(50) NOT NULL,
+                    holder TEXT NOT NULL,
+                    balance NUMERIC NOT NULL DEFAULT 50,
+                    rindexer_sequence_id NUMERIC,
+                    PRIMARY KEY (network, holder)
+                )",
+            )
+            .await
+            .expect("failed to create yaml_balances table");
+
+        let row = |value: u64, seq: u128| TableRowData {
+            columns: HashMap::from([
+                ("holder".to_string(), EthereumSqlTypeWrapper::String("0xsender".to_string())),
+                ("balance".to_string(), EthereumSqlTypeWrapper::U256Numeric(U256::from(value))),
+                (
+                    injected_columns::RINDEXER_SEQUENCE_ID.to_string(),
+                    EthereumSqlTypeWrapper::U128(seq),
+                ),
+            ]),
+            network: "ethereum".to_string(),
+        };
+
+        // First touch is a debit: row must be created at 50 - 30 = 20
+        execute_postgres_operation(
+            &postgres,
+            "yaml_balances",
+            &table,
+            operation,
+            &[row(30, 1)],
+            None,
+        )
+        .await
+        .expect("first debit failed");
+        // Second debit accumulates: 20 - 25 = -5
+        execute_postgres_operation(
+            &postgres,
+            "yaml_balances",
+            &table,
+            operation,
+            &[row(25, 2)],
+            None,
+        )
+        .await
+        .expect("second debit failed");
+
+        let stored = postgres
+            .query_one("SELECT balance::TEXT AS balance FROM yaml_balances", &[])
+            .await
+            .expect("failed to query yaml_balances");
+        let balance: String = stored.get("balance");
+        assert_eq!(balance, "-5", "debits must apply against the column default");
     }
 }

--- a/core/src/manifest/contract.rs
+++ b/core/src/manifest/contract.rs
@@ -1473,6 +1473,18 @@ impl Contract {
             None => false, // No include_events means no raw event storage
         }
     }
+
+    /// Whether raw events for this event are stored, and therefore whether its
+    /// raw event table exists: either the event is in `include_events`, or it
+    /// drives a custom table (raw events are the source of truth for reorg
+    /// recomputation). DDL creation, migrations, and the runtime bulk insert
+    /// must all agree on this predicate.
+    pub fn stores_raw_events(&self, event_name: &str) -> bool {
+        self.is_event_in_include_events(event_name)
+            || self.tables.as_ref().is_some_and(|tables| {
+                tables.iter().any(|t| t.events.iter().any(|e| e.event == event_name))
+            })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

The [envio open-indexer-benchmark `erc20-account-balances` case](https://github.com/enviodev/open-indexer-benchmark/blob/main/cases/erc20-account-balances/README.md#rindexer) reported that rindexer's no-code tables could not compute running balances: debits were intermittently lost (465 of 1,747 accounts absent, 672 with wrong balances), and reordering the YAML operations only changed *which* addresses broke.

**Root cause:** arithmetic (`add`/`subtract`) upserts compile to one `INSERT ... ON CONFLICT DO UPDATE`, but the arithmetic only existed on the conflict branch:

```sql
INSERT INTO balances (...) SELECT tp.network, tp.holder, tp.balance ...   -- raw +value
ON CONFLICT (network, holder)
DO UPDATE SET balance = COALESCE(balances.balance, 0) - EXCLUDED.balance
```

A row *created* by a `subtract` — any address whose first touch inside the indexed window is a debit — got `+value` instead of `default − value`. Which addresses hit that depends on batch boundaries and operation order, hence "intermittent". The bug ships in **every release since the tables feature landed (v0.30.0 → v0.41.0)** and affects the flagship docs example (`tables_erc20_balances`) plus `tables_erc1155_balances`, `tables_dex_pool`, and any subtract-bearing table indexed from mid-history. Add-only and set-only tables were unaffected, and indexing from a token's deployment block masks it (everyone receives before sending) — which is why it survived so long.

## Fix

- The INSERT branch now selects `(default ± delta)`; the conflict branch recovers the delta via `col = COALESCE(t.col, 0) + EXCLUDED.col - default`. One clause serves add and subtract — the sign lives in the inserted value.
- `EXCLUDED."col"` references to arithmetic columns inside SQL-pushed `if:` conditions (e.g. `"$value <= @balance"`) are rewritten back to the raw delta, since `EXCLUDED` now carries `default ± delta` — without this, subtract guards would silently invert.
- YAML column defaults are canonicalized through strict numeric parsing (`u64`/`i64`/`U256`/`I256`) before touching SQL text; unparseable defaults (e.g. `"1e18"`, which Postgres DDL accepts but would diverge) fall back to 0 with a startup warning.

### Custom Rust indexing (`create_batch_postgres_operation!`) brought to parity

The macro had the same sign bug **plus** two bugs #389 only fixed for the no-code path: `DISTINCT ON` silently dropped duplicate-key deltas within a batch, and the sequence guard silently dropped arithmetic updates from lower-sequence events. The macro now uses the same GROUP BY aggregation (gated off for plain `Insert` ops), guard-disable for arithmetic, latest-by-sequence set columns, and gains `max`/`min` support. Array-typed set columns aggregate via `MAX` (`array_agg(...)[1]` yields NULL for arrays; `MAX(bool/bytea)` doesn't exist, so scalars use `array_agg`). Note: `rindexer::database` is private, so the exported macro currently can't compile in external crates anyway (E0603) — worth a follow-up decision.

### Bonus fix: table-only projects couldn't index at all since v0.37.0

Found while validating end-to-end: since #375, the runtime stores raw events for table-driving events (they're the reorg recomputation source of truth), but the DDL only created raw event tables for `include_events` — so a no-code project with `tables:` and no `include_events` COPYs into a missing relation and retries forever. Nothing indexes; the docs' flagship example is unrunnable on current master. DDL (Postgres + ClickHouse), migrations, and the runtime now share a single `Contract::stores_raw_events()` predicate.

## Verification

- **Mutation check:** reverting just the SQL fix makes the new integration test fail with the benchmark's exact corruption signature (sender-first account `+9` instead of `−5`).
- **Real end-to-end run:** `rindexer start indexer` over mainnet USDC blocks 24250761–24250860 (6,675 Transfer events) compared against balances folded independently from raw `eth_getLogs`: **4,057 accounts — 0 missing, 0 extra, 0 wrong**, including all 1,373 negative-balance accounts (the class this bug corrupted).
- **New tests** (testcontainers, run per-process under nextest like the existing docker tests): benchmark-shape running-balances fold, non-zero column defaults, sequence-guard regression (stale write applied last), guarded-condition semantics with zero and non-zero defaults, max upserts (smaller value applied last), macro parity (duplicate-key accumulation, lower-sequence deltas, latest-by-sequence set columns, max columns), pure-SQL unit tests for every new builder, and a DDL test for table-only raw event tables.
- Full suite: 806/806 passing, `cargo clippy --workspace --all-targets -- -D warnings` clean, fmt clean.

## Known pre-existing issues (out of scope, worth separate issues)

1. Shutdown mid-batch can checkpoint a block for which only some operations ran — the remaining operations are skipped on restart.
2. A mid-operations error triggers infinite callback retry, re-applying already-committed arithmetic statements (arithmetic upserts are at-least-once by design now; documented on the macro).
3. ClickHouse custom tables never accumulate `add`/`subtract` (plain INSERT into `ReplacingMergeTree` keeps only the last event's value) — needs a separate design.
4. The exported macro is unusable from external crates due to `mod database;` being private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)