### PR TITLE
fix(ci): allow large async errors on rust 1.98

### DIFF
--- a/core/src/chat/clients.rs
+++ b/core/src/chat/clients.rs
@@ -421,6 +421,7 @@ impl ChatClients {
         tasks
     }
 
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     pub async fn send_message(
         &self,
         event_message: &EventMessage,

--- a/core/src/chat/discord.rs
+++ b/core/src/chat/discord.rs
@@ -18,6 +18,7 @@ impl DiscordBot {
         Self { http }
     }
 
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     pub async fn send_message(
         &self,
         channel_id: ChannelId,

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -174,6 +174,7 @@ fn resolve_tables_against_abi(
     Ok(())
 }
 
+#[allow(clippy::result_large_err, reason = "preserve existing error API")]
 pub async fn setup_no_code(
     details: StartNoCodeDetails<'_>,
 ) -> Result<StartDetails<'_>, SetupNoCodeError> {

--- a/core/src/start.rs
+++ b/core/src/start.rs
@@ -117,6 +117,7 @@ async fn handle_shutdown(signal: &str) {
     std::process::exit(0);
 }
 
+#[allow(clippy::result_large_err, reason = "preserve existing error API")]
 pub async fn start_rindexer(details: StartDetails<'_>) -> Result<(), StartRindexerError> {
     info!(
         "🚀 start_rindexer called with indexing_details.is_some() = {}",
@@ -466,6 +467,7 @@ pub enum StartRindexerNoCode {
     SetupNoCodeError(#[from] SetupNoCodeError),
 }
 
+#[allow(clippy::result_large_err, reason = "preserve existing error API")]
 pub async fn start_rindexer_no_code(
     details: StartNoCodeDetails<'_>,
 ) -> Result<(), StartRindexerNoCode> {

--- a/core/src/streams/clients.rs
+++ b/core/src/streams/clients.rs
@@ -847,6 +847,7 @@ impl StreamsClients {
         tasks
     }
 
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     pub async fn stream(
         &self,
         id: String,
@@ -857,6 +858,7 @@ impl StreamsClients {
         self.stream_with_mode(id, event_message, index_event_in_order, is_trace_event, false).await
     }
 
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     async fn stream_with_mode(
         &self,
         id: String,
@@ -1115,6 +1117,7 @@ impl StreamsClients {
     /// All types reach publish through the shared `force_send_network_wide`
     /// path — no destination is silently dropped because its `events` list
     /// omits `__rindexer_reorg`.
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     pub async fn stream_reorg(
         &self,
         network: &str,
@@ -1170,6 +1173,7 @@ impl StreamsClients {
     /// relative to `head_block` (i.e., buried by at least the network's
     /// registered `reorg_safe_distance`). Called by `ReorgCoordinator` on every
     /// validated `on_new_block`. Returns the total number of events dispatched.
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     pub async fn flush_finalized(
         &self,
         network: &str,
@@ -1263,6 +1267,7 @@ impl StreamsClients {
     /// allocate; they don't await network I/O), and every resulting JoinHandle
     /// from every block is then awaited through a single `join_all`, so a
     /// flush of N buffered blocks runs at ~1 RTT instead of N.
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     async fn dispatch_flushed(
         &self,
         key: &BufferKey,

--- a/core/src/streams/sns.rs
+++ b/core/src/streams/sns.rs
@@ -57,6 +57,7 @@ impl SNS {
         Self { client }
     }
 
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     pub async fn publish(
         &self,
         id: &str,
@@ -66,6 +67,7 @@ impl SNS {
         publish_with_retry("sns", topic_arn, || self.publish_once(id, topic_arn, message)).await
     }
 
+    #[allow(clippy::result_large_err, reason = "preserve existing error API")]
     async fn publish_once(
         &self,
         id: &str,


### PR DESCRIPTION
## Summary

- allow `result_large_err` on async functions newly linted by Rust 1.98
- preserve existing error APIs without boxing or globally weakening Clippy

## Validation

- `cargo +1.98.0 fmt --all -- --check`
- `cargo +1.98.0 clippy --workspace --all-targets -- -D warnings`
- Rust library tests: 759 passed; 7 Docker/Postgres tests excluded after local container creation timed out