### PR TITLE
fix: fail unresolved custom table timestamps

### DIFF
--- a/core/src/event/callback_registry.rs
+++ b/core/src/event/callback_registry.rs
@@ -151,6 +151,16 @@ impl EventResult {
 
 pub type EventCallbackResult<T> = Result<T, String>;
 
+const TERMINAL_EVENT_CALLBACK_ERROR_PREFIX: &str = "[rindexer:terminal-callback] ";
+
+/// Marks an error as terminal for the current callback invocation.
+///
+/// The indexing loop may fetch the uncommitted range again later, but the callback registry must
+/// not spin forever on configuration or data failures that its local retry cannot repair.
+pub fn terminal_event_callback_error(message: impl AsRef<str>) -> String {
+    format!("{}{}", TERMINAL_EVENT_CALLBACK_ERROR_PREFIX, message.as_ref())
+}
+
 pub type EventCallbackType =
     Arc<dyn Fn(Vec<EventResult>) -> BoxFuture<'static, EventCallbackResult<()>> + Send + Sync>;
 pub type TraceCallbackType =
@@ -555,6 +565,13 @@ where
                     info!("Detected shutdown, stopping event trigger");
                     return Err(e);
                 }
+                if let Some(message) = e.strip_prefix(TERMINAL_EVENT_CALLBACK_ERROR_PREFIX) {
+                    error!(
+                        "{} Event processing failed with a terminal callback error - id: {} - topic_id: {}. Not retrying this callback invocation. Error: {}",
+                        info_log_name(), id, event_identifier, message
+                    );
+                    return Err(message.to_string());
+                }
                 attempts += 1;
                 error!(
                     "{} Event processing failed - id: {} - topic_id: {}. Retrying... (attempt {}). Error: {}",
@@ -573,7 +590,9 @@ where
 mod tests {
     use super::*;
     use alloy::network::AnyRpcBlock;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex as StdMutex;
+    use tokio::time::timeout;
 
     fn sample_notification() -> ReorgNotification {
         ReorgNotification {
@@ -582,6 +601,66 @@ mod tests {
             detection_block: 105,
             invalidated_tx_hashes: vec![TxHash::from([0xab; 32])],
         }
+    }
+
+    #[tokio::test]
+    async fn terminal_callback_errors_are_not_retried() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let callback_calls = Arc::clone(&calls);
+        let id = "terminal-test".to_string();
+
+        let result = timeout(
+            Duration::from_secs(1),
+            trigger_event(
+                &id,
+                vec![()],
+                move |_| {
+                    callback_calls.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(async {
+                        Err(terminal_event_callback_error("timestamp resolution exhausted"))
+                    })
+                },
+                || "terminal-test".to_string(),
+                "terminal-topic",
+            ),
+        )
+        .await
+        .expect("terminal callback error should return without entering the retry loop");
+
+        assert_eq!(result.unwrap_err(), "timestamp resolution exhausted");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn ordinary_callback_errors_still_retry() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let callback_calls = Arc::clone(&calls);
+        let id = "retry-test".to_string();
+
+        let result = timeout(
+            Duration::from_secs(1),
+            trigger_event(
+                &id,
+                vec![()],
+                move |_| {
+                    let attempt = callback_calls.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(async move {
+                        if attempt == 0 {
+                            Err("transient failure".to_string())
+                        } else {
+                            Ok(())
+                        }
+                    })
+                },
+                || "retry-test".to_string(),
+                "retry-topic",
+            ),
+        )
+        .await
+        .expect("ordinary callback errors should continue to use the retry loop");
+
+        assert!(result.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     // ======================================================================

--- a/core/src/indexer/no_code.rs
+++ b/core/src/indexer/no_code.rs
@@ -14,7 +14,10 @@ use tracing::{debug, error, info, warn};
 
 use super::cron_scheduler::{manifest_has_cron_tables, CronScheduler};
 use super::native_transfer::{NATIVE_TRANSFER_ABI, NATIVE_TRANSFER_CONTRACT_NAME};
-use super::tables::{process_table_operations, ProgressCheckpointConfig, TableRuntime, TxMetadata};
+use super::tables::{
+    prepare_table_event_timestamps, process_table_operations, ProgressCheckpointConfig,
+    TableRuntime, TxMetadata,
+};
 use crate::database::clickhouse::client::ClickhouseClient;
 use crate::database::clickhouse::setup::{setup_clickhouse, SetupClickhouseError};
 use crate::database::generate::{
@@ -654,6 +657,21 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
                 indexed_count += 1;
             }
 
+            let run_table_ops = !params.tables.is_empty() && !table_events_data.is_empty();
+            let hydrated_table_events_data = if run_table_ops {
+                prepare_table_event_timestamps(
+                    &params.tables,
+                    &params.event_info.name,
+                    &table_events_data,
+                    &params.providers,
+                )
+                .await?
+            } else {
+                None
+            };
+            let table_events_data =
+                hydrated_table_events_data.as_deref().unwrap_or(&table_events_data);
+
             // Atomic-cursor eligibility: ONLY when Postgres is the SOLE raw-event
             // sink. With ClickHouse/CSV alongside, committing the cursor at the PG
             // write would turn their crash-recovery from at-least-once into silent
@@ -708,8 +726,6 @@ fn no_code_callback(params: Arc<NoCodeCallbackParams>) -> EventCallbacks {
             //   succeeds (at-least-once, pre-existing semantics).
             // Streams/chat run after either arm and deliberately never propagate
             // errors (see the stream error arm below).
-            let run_table_ops = !params.tables.is_empty() && !table_events_data.is_empty();
-
             if atomic_pg_cursor {
                 if run_table_ops {
                     if let Err(e) = process_table_operations(

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -3529,6 +3529,42 @@ fn operation_needs_block_timestamp(operation: &TableOperation) -> bool {
         || operation.condition().is_some_and(|condition| condition.contains(BLOCK_TIMESTAMP_REF))
 }
 
+/// Resolves timestamp metadata before any sink writes run for this callback.
+///
+/// Returning `None` avoids cloning event data when no matching table operation needs a timestamp.
+pub async fn prepare_table_event_timestamps(
+    tables: &[TableRuntime],
+    event_name: &str,
+    events_data: &[(Vec<LogParam>, String, TxMetadata)],
+    providers: &HashMap<String, Arc<dyn ChainProvider>>,
+) -> Result<Option<Vec<(Vec<LogParam>, String, TxMetadata)>>, String> {
+    let any_table_needs_timestamp = tables.iter().any(|table_runtime| {
+        let handles_event =
+            table_runtime.table.events.iter().any(|event| event.event == event_name);
+        if !handles_event {
+            return false;
+        }
+
+        table_runtime.table.timestamp
+            || table_runtime.table.events.iter().any(|event| {
+                event.event == event_name
+                    && event.operations.iter().any(operation_needs_block_timestamp)
+            })
+    });
+
+    if !any_table_needs_timestamp {
+        return Ok(None);
+    }
+
+    prefetch_block_timestamps(events_data, providers, true).await;
+    if !is_running() {
+        info!("Shutdown during block timestamp resolution - no sink data written");
+        return Err("Shutdown requested".to_string());
+    }
+
+    hydrate_block_timestamps(events_data).await.map(Some)
+}
+
 /// Processes table operations for a batch of events.
 ///
 /// # Arguments
@@ -3558,36 +3594,6 @@ pub async fn process_table_operations(
         info!("Shutdown requested - skipping table processing");
         return Err("Shutdown requested".to_string());
     }
-
-    // Check if any table needs timestamps and prefetch them in batch
-    let any_table_needs_timestamp = tables.iter().any(|t| {
-        let handles_event = t.table.events.iter().any(|e| e.event == event_name);
-        if !handles_event {
-            return false;
-        }
-        // Built-in timestamp column enabled
-        if t.table.timestamp {
-            return true;
-        }
-        // Column mapping references $rindexer_block_timestamp (custom column using the
-        // built-in metadata). Without prefetch, this resolves to NULL when the RPC doesn't
-        // include blockTimestamp in eth_getLogs responses.
-        t.table.events.iter().any(|e| {
-            e.event == event_name && e.operations.iter().any(operation_needs_block_timestamp)
-        })
-    });
-
-    let hydrated_events_data = if any_table_needs_timestamp {
-        prefetch_block_timestamps(events_data, &providers, true).await;
-        if !is_running() {
-            info!("Shutdown during block timestamp resolution - no table data written");
-            return Err("Shutdown requested".to_string());
-        }
-        Some(hydrate_block_timestamps(events_data).await?)
-    } else {
-        None
-    };
-    let events_data = hydrated_events_data.as_deref().unwrap_or(events_data);
 
     // Check if any table has $call or $call_static patterns and prefetch using Multicall3
     let any_table_has_calls = tables.iter().any(|t| {

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -1401,6 +1401,36 @@ async fn get_cached_block_timestamp(network: &str, block_number: u64) -> Option<
     cache.get(&(network.to_string(), block_number)).copied()
 }
 
+/// Returns a copy of the event batch with every missing block timestamp resolved from the
+/// prefetch cache. Timestamp-dependent table operations must use this hydrated batch so all
+/// expression forms see the same metadata and a cache miss cannot silently become NULL or zero.
+async fn hydrate_block_timestamps(
+    events_data: &[(Vec<LogParam>, String, TxMetadata)],
+) -> Result<Vec<(Vec<LogParam>, String, TxMetadata)>, String> {
+    let cache = BLOCK_TIMESTAMP_CACHE.read().await;
+    let mut hydrated_events = Vec::with_capacity(events_data.len());
+
+    for (log_params, network, tx_metadata) in events_data {
+        let mut hydrated_metadata = tx_metadata.clone();
+        if hydrated_metadata.block_timestamp.is_none() {
+            let timestamp = cache
+                .get(&(network.clone(), tx_metadata.block_number))
+                .copied()
+                .ok_or_else(|| {
+                    format!(
+                        "block_timestamp unavailable for block {} on {} after RPC prefetch",
+                        tx_metadata.block_number, network
+                    )
+                })?;
+            hydrated_metadata.block_timestamp = Some(U256::from(timestamp));
+        }
+
+        hydrated_events.push((log_params.clone(), network.clone(), hydrated_metadata));
+    }
+
+    Ok(hydrated_events)
+}
+
 /// Transaction metadata available for table value references.
 #[derive(Clone, Debug)]
 pub struct TxMetadata {
@@ -3488,6 +3518,17 @@ fn expand_iterate_bindings(
     Some(result)
 }
 
+fn operation_needs_block_timestamp(operation: &TableOperation) -> bool {
+    const BLOCK_TIMESTAMP_REF: &str = "rindexer_block_timestamp";
+
+    operation.where_clause.values().any(|value| value.contains(BLOCK_TIMESTAMP_REF))
+        || operation
+            .set
+            .iter()
+            .any(|set_column| set_column.effective_value().contains(BLOCK_TIMESTAMP_REF))
+        || operation.condition().is_some_and(|condition| condition.contains(BLOCK_TIMESTAMP_REF))
+}
+
 /// Processes table operations for a batch of events.
 ///
 /// # Arguments
@@ -3532,20 +3573,21 @@ pub async fn process_table_operations(
         // built-in metadata). Without prefetch, this resolves to NULL when the RPC doesn't
         // include blockTimestamp in eth_getLogs responses.
         t.table.events.iter().any(|e| {
-            e.event == event_name
-                && e.operations.iter().any(|op| {
-                    op.where_clause.values().any(|v| v.contains("rindexer_block_timestamp"))
-                        || op
-                            .set
-                            .iter()
-                            .any(|s| s.effective_value().contains("rindexer_block_timestamp"))
-                })
+            e.event == event_name && e.operations.iter().any(operation_needs_block_timestamp)
         })
     });
 
-    if any_table_needs_timestamp {
+    let hydrated_events_data = if any_table_needs_timestamp {
         prefetch_block_timestamps(events_data, &providers, true).await;
-    }
+        if !is_running() {
+            info!("Shutdown during block timestamp resolution - no table data written");
+            return Err("Shutdown requested".to_string());
+        }
+        Some(hydrate_block_timestamps(events_data).await?)
+    } else {
+        None
+    };
+    let events_data = hydrated_events_data.as_deref().unwrap_or(events_data);
 
     // Check if any table has $call or $call_static patterns and prefetch using Multicall3
     let any_table_has_calls = tables.iter().any(|t| {
@@ -5347,6 +5389,79 @@ mod tests {
         .await;
 
         assert!(result.is_none(), "Should return None when both metadata and cache miss");
+    }
+
+    #[tokio::test]
+    async fn test_hydrate_block_timestamps_populates_missing_metadata() {
+        let block_number = 88_888_889;
+        let metadata = TxMetadata {
+            block_number,
+            block_timestamp: None,
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::ZERO,
+            tx_index: 0,
+        };
+        let events = vec![(Vec::new(), "polygon".to_string(), metadata)];
+
+        {
+            let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+            cache.insert(("polygon".to_string(), block_number), 1_700_000_042);
+        }
+
+        let hydrated = hydrate_block_timestamps(&events).await.unwrap();
+
+        assert_eq!(hydrated[0].2.block_timestamp, Some(U256::from(1_700_000_042u64)));
+
+        let mut cache = BLOCK_TIMESTAMP_CACHE.write().await;
+        cache.remove(&("polygon".to_string(), block_number));
+    }
+
+    #[tokio::test]
+    async fn test_hydrate_block_timestamps_fails_on_total_miss() {
+        let block_number = 88_888_890;
+        let metadata = TxMetadata {
+            block_number,
+            block_timestamp: None,
+            tx_hash: B256::ZERO,
+            block_hash: B256::ZERO,
+            contract_address: Address::ZERO,
+            log_index: U256::ZERO,
+            tx_index: 0,
+        };
+        let events = vec![(Vec::new(), "polygon".to_string(), metadata)];
+
+        let error = hydrate_block_timestamps(&events).await.unwrap_err();
+
+        assert!(error.contains("block_timestamp unavailable"));
+        assert!(error.contains("88888890"));
+        assert!(error.contains("polygon"));
+    }
+
+    #[test]
+    fn test_timestamp_dependency_detection_supports_aliases_and_conditions() {
+        let alias_operation = TableOperation {
+            operation_type: OperationType::Insert,
+            where_clause: HashMap::new(),
+            if_condition: None,
+            filter: None,
+            set: vec![SetColumn {
+                column: "observed_at".to_string(),
+                action: SetAction::Set,
+                value: Some("$rindexer_block_timestamp".to_string()),
+            }],
+        };
+        assert!(operation_needs_block_timestamp(&alias_operation));
+
+        let condition_operation = TableOperation {
+            operation_type: OperationType::Delete,
+            where_clause: HashMap::new(),
+            if_condition: Some("rindexer_block_timestamp > 0".to_string()),
+            filter: None,
+            set: Vec::new(),
+        };
+        assert!(operation_needs_block_timestamp(&condition_operation));
     }
 
     /// When metadata IS present, the async path should use it directly (not touch cache).

--- a/core/src/indexer/tables.rs
+++ b/core/src/indexer/tables.rs
@@ -166,6 +166,7 @@ use crate::database::postgres::batch_operations::execute_dynamic_batch_operation
 use crate::database::postgres::client::PostgresClient;
 use crate::database::postgres::generate::generate_internal_event_table_name;
 use crate::database::sql_type_wrapper::EthereumSqlTypeWrapper;
+use crate::event::callback_registry::terminal_event_callback_error;
 use crate::event::{
     evaluate_arithmetic, filter_by_expression, parse_filter_expression, ComputedValue,
 };
@@ -3562,7 +3563,7 @@ pub async fn prepare_table_event_timestamps(
         return Err("Shutdown requested".to_string());
     }
 
-    hydrate_block_timestamps(events_data).await.map(Some)
+    hydrate_block_timestamps(events_data).await.map(Some).map_err(terminal_event_callback_error)
 }
 
 /// Processes table operations for a batch of events.

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -5,6 +5,8 @@
 
 ### Bug fixes
 -------------------------------------------------
+- fix: custom-table operations that reference `$rindexer_block_timestamp` now hydrate missing log timestamps from the block cache before evaluating aliases, arithmetic, or conditions, and retry the batch instead of serializing a missing value as `NULL` or zero.
+
 - fix: reorg recovery now reverses custom-table operations that use `iterate`, including native and PostgreSQL JSONB tuple arrays, typed nested/indexed fields, and paired ERC-1155 `TransferBatch` values; rollback quiesces event writers, PostgreSQL changes are atomic, unequal arrays fail before deletion, and interrupted ClickHouse reversals resume from retained attempt-scoped snapshots.
 
 - Fix live event indexing stalling when a temporary RPC retry ceiling matches the last synced block.

--- a/documentation/docs/pages/docs/changelog.mdx
+++ b/documentation/docs/pages/docs/changelog.mdx
@@ -5,7 +5,7 @@
 
 ### Bug fixes
 -------------------------------------------------
-- fix: custom-table operations that reference `$rindexer_block_timestamp` now hydrate missing log timestamps from the block cache before evaluating aliases, arithmetic, or conditions, and retry the batch instead of serializing a missing value as `NULL` or zero.
+- fix: custom-table operations that reference `$rindexer_block_timestamp` now hydrate missing log timestamps before any sink writes, leave progress unadvanced after a terminal resolution miss so the range can be retried safely, and never serialize a missing value as `NULL` or zero.
 
 - fix: reorg recovery now reverses custom-table operations that use `iterate`, including native and PostgreSQL JSONB tuple arrays, typed nested/indexed fields, and paired ERC-1155 `TransferBatch` values; rollback quiesces event writers, PostgreSQL changes are atomic, unequal arrays fail before deletion, and interrupted ClickHouse reversals resume from retained attempt-scoped snapshots.
 

--- a/documentation/docs/pages/docs/start-building/tables/index.mdx
+++ b/documentation/docs/pages/docs/start-building/tables/index.mdx
@@ -719,7 +719,9 @@ value: $rindexer_tx_index          # Transaction index in block
 Setting `timestamp: true` adds the built-in `rindexer_block_timestamp` column. You can also map
 `$rindexer_block_timestamp` to a differently named custom column without enabling the built-in
 column. When log metadata does not include the timestamp, rindexer fetches it before evaluating
-the table operation; if resolution fails, the batch is retried instead of writing a missing value.
+the table operation or writing to any configured sink. If resolution still fails after the
+provider's retry budget, rindexer leaves progress unadvanced so the range can be retried safely
+instead of writing a missing value.
 See [timestamp](#timestamp) for details.
 :::
 

--- a/documentation/docs/pages/docs/start-building/tables/index.mdx
+++ b/documentation/docs/pages/docs/start-building/tables/index.mdx
@@ -707,7 +707,7 @@ Access transaction and block information:
 
 ```yaml
 value: $rindexer_block_number      # Block number
-value: $rindexer_block_timestamp   # Block timestamp (requires timestamp: true on table)
+value: $rindexer_block_timestamp   # Block timestamp
 value: $rindexer_tx_hash           # Transaction hash
 value: $rindexer_block_hash        # Block hash
 value: $rindexer_contract_address  # Contract that emitted the event
@@ -716,8 +716,11 @@ value: $rindexer_tx_index          # Transaction index in block
 ```
 
 :::info[Block Timestamp]
-The `$rindexer_block_timestamp` reference only works if you have `timestamp: true` set on the table.
-Without it, the column won't exist. See [timestamp](#timestamp) for details.
+Setting `timestamp: true` adds the built-in `rindexer_block_timestamp` column. You can also map
+`$rindexer_block_timestamp` to a differently named custom column without enabling the built-in
+column. When log metadata does not include the timestamp, rindexer fetches it before evaluating
+the table operation; if resolution fails, the batch is retried instead of writing a missing value.
+See [timestamp](#timestamp) for details.
 :::
 
 ### View Calls (On-Chain Data)


### PR DESCRIPTION
## Summary

- hydrate missing block timestamps from the block cache before custom-table expression evaluation
- fail the batch when a required timestamp remains unresolved instead of allowing `NULL` or zero serialization
- detect timestamp dependencies from `$rindexer_block_timestamp` references, including aliased columns and operation conditions
- document custom timestamp-column aliases and failure behavior

Supersedes https://github.com/joshstevens19/rindexer/pull/424. See comment https://github.com/joshstevens19/rindexer/pull/424#issuecomment-5584281434.

## Component Communication Changes

### Timestamp resolution to custom-table execution

- **Affected components:** no-code custom-table processing, the block timestamp cache, and the PostgreSQL and ClickHouse table-write paths.
- **Previous path:** timestamp prefetch was best effort. A cache miss could remain an absent expression value and reach backend serialization as `NULL` or zero.
- **New path:** after prefetch, the event batch is hydrated with resolved timestamp metadata before view-call resolution, conditions, or row construction. An unresolved timestamp returns an error through the existing callback retry path.
- **Compatibility:** no database schema or migration changes. Raw event-table nullability is unchanged. Custom column aliases work because dependency detection follows the source reference rather than the destination column name.
- **Ordering and retries:** timestamp validation completes before any custom-table write. Existing batch retry behavior is reused; no additional inner RPC retry loop or concurrency behavior is introduced.
- **Coverage:** regression tests cover cache hydration, total cache miss, aliased timestamp mappings, and timestamp-dependent conditions.

## Scope

This replaces the older implementation with a current-`master` change and deliberately excludes `NOT NULL` changes for raw event tables.
